### PR TITLE
cbuild: report fetch exceptions

### DIFF
--- a/cbuild/hooks/do_fetch/00_distfiles.py
+++ b/cbuild/hooks/do_fetch/00_distfiles.py
@@ -85,8 +85,8 @@ def invoke(pkg):
             try:
                 fname = request.urlretrieve(url, str(dfile))[0]
                 fname = os.path.basename(fname)
-            except:
-                pass
+            except Exception as e:
+                pkg.log_warn(f"error fetching '{fname}': {e}")
         if not dfile.is_file():
             pkg.error(f"failed to fetch '{fname}'")
         if not verify_cksum(fname, dfile, ck, pkg):


### PR DESCRIPTION
I ran into an issue during bootstrapping where some packages hosted on savannah were failing to download. I made this change to help see why they were failing. Here's an example of the output with this small change made (the new part is the warning on line 2):

```
=> acl-2.3.1-r1: fetching distfile 'acl-2.3.1.tar.gz'...
=> WARNING: acl-2.3.1-r1: error fetching 'acl-2.3.1.tar.gz': HTTP Error 403: Forbidden
=> acl-2.3.1-r1: failed to fetch 'acl-2.3.1.tar.gz'
=> A failure has occured!
Traceback (most recent call last):
[snip]
cbuild.core.template.PackageError
```

I eventually solved the issue by changing the `nongnu` entry in `sites.py` to use one of the alternate URL suggested in the footer of the downloads page on Savannah ([for example](http://download.savannah.nongnu.org/releases/acl/)) and the downloads worked:

> Downloads will redirect to your nearest mirror site.
> Files on mirrors may be subject to a replication delay of up to 24 hours.
> In case of problems to avoid the mirror use http://download-mirror.savannah.gnu.org/releases/ or http://download-mirror.savannah.nongnu.org/releases/ 