### PR TITLE
[RFC] cbuild: fix bootstrap profile

### DIFF
--- a/cbuild/build_profiles/bootstrap.ini
+++ b/cbuild/build_profiles/bootstrap.ini
@@ -1,0 +1,4 @@
+[profile]
+cflags    = -O2 -pipe -rtlib=compiler-rt
+cxxflags  = ${cflags} -stdlib=libc++ -unwindlib=libunwind
+ldflags   = -fuse-ld=lld

--- a/cbuild/core/template.py
+++ b/cbuild/core/template.py
@@ -555,6 +555,7 @@ class Template(Package):
             self.triplet = None
             cpu.init_target(cpu.host_wordsize(), cpu.host_endian())
 
+            psct = cp["profile"]
             bp = dict(psct)
 
         self.build_profile = bp


### PR DESCRIPTION
since 6b2a1825af66b89947c5ca7baf2c17b5afe9a98f, bootstrap is broken: 
```
$ ./bootstrap.sh
void-x86_64-musl-ROOTFS-20210218.tar.xz: OK
>> Updating base system...
[...]

=> cbuild: bootstrapping stage 0
=> A failure has occured!
Traceback (most recent call last):
  File "/cports/cbuild.py", line 358, in <module>
    ({
  File "/cports/cbuild.py", line 230, in bootstrap
    rp = template.read_pkg(
  File "/cports/cbuild/core/template.py", line 985, in read_pkg
    ret.setup_profile(bootstrapping)
  File "/cports/cbuild/core/template.py", line 549, in setup_profile
    with open(paths.cbuild() / "build_profiles/bootstrap.ini") as cf:
FileNotFoundError: [Errno 2] No such file or directory: '/cports/cbuild/build_profiles/bootstrap.ini'
```

Once `cbuild/build_profiles/bootstrap.ini` added, need to fix  `cbuild/core/template.py` :
```
$ ./bootstrap.sh
void-x86_64-musl-ROOTFS-20210218.tar.xz: OK
>> Updating base system...
[...]

=> cbuild: bootstrapping stage 0
=> A failure has occured!
Traceback (most recent call last):
  File "/cports/cbuild.py", line 358, in <module>
    ({
  File "/cports/cbuild.py", line 230, in bootstrap
    rp = template.read_pkg(
  File "/cports/cbuild/core/template.py", line 984, in read_pkg
    ret.setup_profile(bootstrapping)
  File "/cports/cbuild/core/template.py", line 558, in setup_profile
    bp = dict(psct)
UnboundLocalError: local variable 'psct' referenced before assignment
```
=> I'm not fully confident on implication on patched `cbuild/core/template.py` in this PR : could you have a look ?


