### PR TITLE
bootstrap.sh: need llvm (provides llvm-ar)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -113,7 +113,7 @@ xbps-install -Syu || exit 1
 echo ">> Installing cbuild dependencies..."
 xbps-install -y python3 pax-utils apk-tools openssl git bubblewrap || exit 1
 echo ">> Installing build tools..."
-xbps-install -y base-devel clang lld libcxx-devel llvm-libunwind-devel \
+xbps-install -y base-devel clang lld llvm libcxx-devel llvm-libunwind-devel \
                 cmake meson pkgconf bmake ninja byacc flex perl m4 || exit 1
 
 cd /cports


### PR DESCRIPTION
following PR #10, fix this:

```
$ ./bootstrap.sh
[...]
=> cbuild: bootstrapping stage 0
[...]

=> musl-1.2.2-r0: building [gnu_configure] (dependency of base-chroot) for x86_64...
   [runtime] kernel-libc-headers>=0: found (5.10.4-r0)
   [runtime] musl=1.2.2-r0: subpackage (ignored)
=> musl-1.2.2-r0: running init_patch hook: 00_env_pkg_config...
=> musl-1.2.2-r0: running init_patch hook: 00_env_hardening...
=> musl-1.2.2-r0: running init_patch hook: 00_env_bootstrap...
=> musl-1.2.2-r0: running do_build...

[...]

rm -f lib/libm.a
rm -f lib/librt.a
rm -f lib/libpthread.a
llvm-ar rc lib/libm.a
make: llvm-ar: No such file or directory
make: *** [Makefile:172: lib/libm.a] Error 127
make: *** Waiting for unfinished jobs....
llvm-ar rc lib/librt.a
make: llvm-ar: No such file or directory
make: *** [Makefile:172: lib/librt.a] Error 127
llvm-ar rc lib/libpthread.a
make: llvm-ar: No such file or directory
make: *** [Makefile:172: lib/libpthread.a] Error 127
=> A failure has occured!
Traceback (most recent call last):
  File "/cports/cbuild.py", line 358, in <module>
    ({
  File "/cports/cbuild.py", line 236, in bootstrap
    build.build(tgt, rp, {}, opt_signkey)
  File "/cports/cbuild/core/build.py", line 16, in build
    autodep = dependencies.install(pkg, pkg.origin.pkgname, "pkg", depmap, signkey)
  File "/cports/cbuild/core/dependencies.py", line 250, in install
    build.build(step, template.read_pkg(
  File "/cports/cbuild/core/build.py", line 31, in build
    buildm.invoke(pkg, step)
  File "/cports/cbuild/step/build.py", line 12, in invoke
    pkg.run_step("build", optional = True)
  File "/cports/cbuild/core/template.py", line 660, in run_step
    if not run_pkg_func(self, "do_" + stepn) and not optional:
  File "/cports/cbuild/core/template.py", line 155, in run_pkg_func
    func(pkg)
  File "/cports/cbuild/build_style/gnu_configure.py", line 8, in do_build
    self.make.build()
  File "/cports/cbuild/util/make.py", line 75, in build
    return self.invoke(
  File "/cports/cbuild/util/make.py", line 68, in invoke
    return self.template.do(
  File "/cports/cbuild/core/template.py", line 644, in do
    return chroot.enter(
  File "/cports/cbuild/core/chroot.py", line 362, in enter
    return subprocess.run(
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['make', '-j3']' returned non-zero exit status 2.
```