### PR TITLE
cbuild distfile: fix discard of _SITE

### DIFF
--- a/cbuild/hooks/do_fetch/00_distfiles.py
+++ b/cbuild/hooks/do_fetch/00_distfiles.py
@@ -52,7 +52,7 @@ def interp_url(pkg, url):
     import re
 
     def matchf(m):
-        mw = m.group(1).rstrip("_SITE").lower()
+        mw = m.group(1).removesuffix("_SITE").lower()
         if not mw in sites:
             pkg.error(f"malformed distfile URL '{url}'")
         return sites[mw]


### PR DESCRIPTION
rstrip remove characters, we need to remote a string.
fix "PYPI_SITE" => "pyp"