### PR TITLE
cbuild: StampCheck object has no attribute cwd

### DIFF
--- a/cbuild/core/template.py
+++ b/cbuild/core/template.py
@@ -47,7 +47,7 @@ class StampCheck:
         return isinstance(excv, StampException)
 
     def check(self):
-        if (self.cwd / f".stamp_{self.name}_done").exists():
+        if (self.pkg.cwd / f".stamp_{self.name}_done").exists():
             raise StampException()
 
 @contextlib.contextmanager


### PR DESCRIPTION
fix this:
```
$ ./cbuild.py zap
$ ./cbuild.py binary-bootstrap
$ ./cbuild.py pkg clang-rt-crt-cross
[...]
=> clang-rt-crt-cross-12.0.0-r0: installing host dependencies: cmake, gmake, python, llvm-devel, clang-tools-extra
=> clang-rt-crt-cross-12.0.0-r0: installing target dependencies: zlib-devel, libffi-devel
=> clang-rt-crt-cross-12.0.0-r0: running do_fetch hook: 00_distfiles...
=> clang-rt-crt-cross-12.0.0-r0: running do_extract hook: 00_distfiles...
=> clang-rt-crt-cross-12.0.0-r0: running init_patch hook: 00_env_pkg_config...
=> clang-rt-crt-cross-12.0.0-r0: running do_patch hook: 00_patches...
=> clang-rt-crt-cross-12.0.0-r0: patching: crt-enable-ppc.patch
=> clang-rt-crt-cross-12.0.0-r0: patching: riscv64.patch
=> clang-rt-crt-cross-12.0.0-r0: running post_patch...
=> clang-rt-crt-cross-12.0.0-r0: running pre_configure hook: 02_script_wrapper...
=> clang-rt-crt-cross-12.0.0-r0: running do_configure...
=> A failure has occured!
Traceback (most recent call last):
  File "/home/yopito/chimera/cports.git/./cbuild.py", line 390, in <module>
    ({
  File "/home/yopito/chimera/cports.git/./cbuild.py", line 381, in do_pkg
    build.build(tgt, rp, {}, opt_signkey)
  File "/home/yopito/chimera/cports.git/cbuild/core/build.py", line 30, in build
    autodep = dependencies.install(pkg, pkg.origin.pkgname, "pkg", depmap, signkey)
  File "/home/yopito/chimera/cports.git/cbuild/core/dependencies.py", line 411, in install
    build.build(step, template.read_pkg(
  File "/home/yopito/chimera/cports.git/cbuild/core/build.py", line 42, in build
    configure.invoke(pkg, step)
  File "/home/yopito/chimera/cports.git/cbuild/step/configure.py", line 15, in invoke
    pkg.run_step("configure", optional = True)
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 649, in run_step
    if not run_pkg_func(self, "do_" + stepn) and not optional:
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 159, in run_pkg_func
    func(pkg)
  File "/home/yopito/chimera/cports.git/srcpkgs/clang-rt-crt-cross/template.py", line 78, in do_configure
    s.check()
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 50, in check
    if (self.cwd / f".stamp_{self.name}_done").exists():
AttributeError: 'StampCheck' object has no attribute 'cwd'
```