### PR TITLE
cbuild: meson: fix compiler options in crossbuild option file

### DIFF
--- a/cbuild/util/meson.py
+++ b/cbuild/util/meson.py
@@ -38,11 +38,11 @@ llvm-config = '/usr/bin/llvm-config'
 needs_exe_wrapper = true
 
 [built-in options]
-c_args = {pkg.get_cflags()}
-c_link_args = {pkg.get_ldflags()}
+c_args = {list(map(lambda v: str(v), pkg.get_cflags()))}
+c_link_args = {list(map(lambda v: str(v), pkg.get_ldflags()))}
 
-cpp_args = {pkg.get_cxxflags()}
-cpp_link_args = {pkg.get_ldflags()}
+cpp_args = {list(map(lambda v: str(v), pkg.get_cxxflags()))}
+cpp_link_args = {list(map(lambda v: str(v), pkg.get_ldflags()))}
 
 [host_machine]
 system = 'linux'


### PR DESCRIPTION
fix the error below. not sure this the smartest way to fix it ...

```
$ ./cbuild.py zap
$ ./cbuild.py binary-bootstrap
$ ./cbuild.py -a aarch64 pkg zstd
```
```
....
=> zstd-1.5.0-r0: building [meson] for aarch64...
   [host] pkgconf: found (1.7.3-r0)
   [host] meson: found (0.58.1-r0)
   [target] zlib-devel: found (1.2.11-r0)
   [target] liblzma-devel: found (5.2.5-r0)
   [target] liblz4-devel: found (1.9.3-r0)
   [runtime] libzstd=1.5.0-r0: subpackage (ignored)
=> zstd-1.5.0-r0: installing host dependencies: pkgconf, meson
=> zstd-1.5.0-r0: installing target dependencies: zlib-devel, liblzma-devel, liblz4-devel
=> zstd-1.5.0-r0: running init_patch hook: 00_env_pkg_config...
=> zstd-1.5.0-r0: running pre_configure hook: 02_script_wrapper...
=> zstd-1.5.0-r0: running do_configure...

ERROR: Malformed value in machine file variable 'c_args'.
=> A failure has occured!
Traceback (most recent call last):
  File "/home/yopito/chimera/cports.git/./cbuild.py", line 390, in <module>
    ({
  File "/home/yopito/chimera/cports.git/./cbuild.py", line 381, in do_pkg
    build.build(tgt, rp, {}, opt_signkey)
  File "/home/yopito/chimera/cports.git/cbuild/core/build.py", line 42, in build
    configure.invoke(pkg, step)
  File "/home/yopito/chimera/cports.git/cbuild/step/configure.py", line 15, in invoke
    pkg.run_step("configure", optional = True)
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 649, in run_step
    if not run_pkg_func(self, "do_" + stepn) and not optional:
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 159, in run_pkg_func
    func(pkg)
  File "/home/yopito/chimera/cports.git/cbuild/build_style/meson.py", line 4, in do_configure
    meson.configure(self, self.meson_dir)
  File "/home/yopito/chimera/cports.git/cbuild/util/meson.py", line 68, in configure
    pkg.do(
  File "/home/yopito/chimera/cports.git/cbuild/core/template.py", line 630, in do
    return chroot.enter(
  File "/home/yopito/chimera/cports.git/cbuild/core/chroot.py", line 405, in enter
    return subprocess.run(
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['bwrap', '--ro-bind', PosixPath('/build/chimera/masterdir'), '/', '--bind', PosixPath('/build/chimera/masterdir/builddir'), '/builddir', '--bind', PosixPath('/build/chimera/masterdir/destdir'), '/destdir', '--ro-bind', PosixPath('/build/chimera/hostdir/sources'), '/sources', '--dev', '/dev', '--proc', '/proc', '--tmpfs', '/tmp', '--bind', PosixPath('/build/chimera/hostdir/ccache'), '/ccache', '--unshare-all', '--chdir', PosixPath('/builddir/zstd-1.5.0'), 'meson', '--prefix=/usr', '--libdir=/usr/lib', '--libexecdir=/usr/libexec', '--bindir=/usr/bin', '--sbindir=/usr/bin', '--includedir=/usr/include', '--datadir=/usr/share', '--mandir=/usr/share/man', '--infodir=/usr/share/info', '--sysconfdir=/etc', '--localstatedir=/var', '--sharedstatedir=/var/lib', '--buildtype=plain', '--auto-features=auto', '--wrap-mode=nodownload', '-Ddefault_library=both', '-Db_ndebug=true', '-Db_staticpic=true', '--cross-file=/builddir/zstd-1.5.0/build/cbuild.cross', '-Dzlib=enabled', '-Dlzma=enabled', '-Dlz4=enabled', '-Dbin_contrib=true', 'build/meson', 'build']' returned non-zero exit status 1.
```
edit: fix log display
