### PR TITLE
main/pkgconf: keep pkg.m4 in main package (not in -devel)

### DIFF
--- a/main/pkgconf/template.py
+++ b/main/pkgconf/template.py
@@ -26,4 +26,10 @@ def _lib(self):
 
 @subpackage("pkgconf-devel")
 def _devel(self):
-    return self.default_devel()
+    # pkg.m4 must remain in main package
+    return [
+        "usr/include",
+        "usr/lib/pkgconfig",
+        "usr/lib/*.a",
+        "usr/lib/*.so",
+    ]


### PR DESCRIPTION
usual way is that `usr/share/aclocal/pkg.m4` is provided by the "main" pkgconf package.

if not, GNU automake/autoconf will generate configure script with the following errors.

```
....
/builddir/tmux-3.2a/configure: 4957: PKG_PROG_PKG_CONFIG: not found
....
checking for working strtonum... no
checking for working reallocarray... yes
checking for working recallocarray... no
checking for library containing clock_gettime... none required
/builddir/tmux-3.2a/configure: 6015: Syntax error: newline unexpected (expecting ")")
=> A failure has occured!
```

