### PR TITLE
[RFC] main/dinit: crossbuild support, enhance checks.

### DIFF
--- a/main/dinit/files/mconfig
+++ b/main/dinit/files/mconfig
@@ -1,0 +1,23 @@
+
+# static mconfig file instead of generated one, in order
+# to use compiler settings from cbuild (passed via environment).
+# commented values comes from dinit generated mconfig for x86_64/musl
+
+#0.12# SBINDIR=/sbin
+SBINDIR=/usr/bin
+
+MANDIR=/usr/share/man
+SYSCONTROLSOCKET=/run/dinitctl
+
+BUILD_SHUTDOWN=yes
+
+#0.12# CXX=clang++
+#0.12# CXXOPTS=-D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11 -Os -Wall -flto -fno-rtti -fno-plt
+#0.12# LDFLAGS=-flto -Os
+
+CXX ?=clang++
+CXXOPTS=$(CXXFLAGS)
+LDFLAGS ?= -flto -Os
+
+# for unit testing
+SANITIZEOPTS=-fsanitize=address,undefined

--- a/main/dinit/patches/disable-build-options-generation.patch
+++ b/main/dinit/patches/disable-build-options-generation.patch
@@ -1,0 +1,27 @@
+disable mconfig file generation in order to control
+compiler flags from packaging.
+
+--- dinit-0.12.0.ORIG/build/Makefile
++++ dinit-0.12.0/build/Makefile
+@@ -5,6 +5,9 @@
+ 
+ # Look for a suitable build config file and use it.
+ ../mconfig:
++	:
++
++../mconfig.DISABLED:
+ 	@UNAME=`uname`;\
+ 	if [ -f "../configs/mconfig.$$UNAME.sh" ]; then \
+ 	    echo "Found auto-configuration script for OS: $$UNAME"; \
+--- dinit-0.12.0.ORIG/src/Makefile
++++ dinit-0.12.0/src/Makefile
+@@ -16,6 +16,9 @@
+ 
+ # Look for a suitable build config file and use it.
+ ../mconfig:
++	:
++
++../mconfig.DISABLED:
+ 	@UNAME=`uname`;\
+ 	if [ -f "../configs/mconfig.$$UNAME.sh" ]; then \
+ 	    echo "Found auto-configuration script for OS: $$UNAME"; \

--- a/main/dinit/patches/mconfig-gen-for-host.patch
+++ b/main/dinit/patches/mconfig-gen-for-host.patch
@@ -1,0 +1,12 @@
+--- a/build/tools/Makefile
++++ b/build/tools/Makefile
+@@ -1,6 +1,6 @@
+-HOSTCXX ?= $(CXX)
+-HOSTCXXFLAGS ?= $(CXXFLAGS)
+-HOSTLDFLAGS ?= $(LDFLAGS)
++HOSTCXX ?= $(BUILD_CXX)
++HOSTCXXFLAGS ?= $(BUILD_CXXFLAGS)
++HOSTLDFLAGS ?= $(BUILD_LDFLAGS)
+ 
+ mconfig-gen: mconfig-gen.cc
+ 	$(HOSTCXX) $(HOSTCXXOPTS) -o mconfig-gen mconfig-gen.cc $(HOSTLDFLAGS)

--- a/main/dinit/template.py
+++ b/main/dinit/template.py
@@ -1,19 +1,23 @@
+# XXX build: static binaries since init system ?
 pkgname = "dinit"
 pkgver = "0.12.0"
 pkgrel = 0
 build_style = "makefile"
 make_cmd = "gmake"
-make_install_args = ["SBINDIR=/usr/bin"]
 hostmakedepends = ["gmake", "bsdm4"]
 pkgdesc = "Service manager and init system"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "Apache-2.0"
-url = f"https://github.com/davmac314/{pkgname}"
-source = f"{url}/releases/download/v{pkgver}/{pkgname}-{pkgver}.tar.xz"
+url = "https://davmac.org/projects/dinit"
+source = f"https://github.com/davmac314/dinit/releases/download/v{pkgver}/dinit-{pkgver}.tar.xz"
 sha256 = "d5f9afe7005da7c08224dddcf2b63f37a6c4120b7493bed4669ef362cde1b544"
 tool_flags = {"CXXFLAGS": ["-fno-rtti"], "LDFLAGS": ["-fno-rtti"]}
 
-def init_configure(self):
-    eflags = ["CXXOPTS=" + self.get_cxxflags(shell = True)]
-    self.make_build_args += eflags
-    self.make_check_args += eflags
+def post_patch(self):
+    # static mconfig file instead of generated one
+    self.cp(self.files_path / "mconfig", self.cwd)
+
+def do_check(self):
+    self.make.invoke("check")
+    # integration tests
+    self.make.invoke("check-igr")


### PR DESCRIPTION
Details:
* I was able to crossbuild `dinit` from `x86_64` to all other architectures with this fix.
* building flags are the same than before for `x86_64`, package content is the same.
* not tested on runtime
* target arch package depends on `so:libunwind.so.1`, that is not the case for native one ?
* since init system, also build it statically ?