### PR TITLE
main/strace: fix crossbuild

### DIFF
--- a/main/strace/template.py
+++ b/main/strace/template.py
@@ -21,3 +21,8 @@ license = "LGPL-2.1-or-later"
 url = "https://strace.io"
 source = f"https://github.com/{pkgname}/{pkgname}/releases/download/v{pkgver}/{pkgname}-{pkgver}.tar.xz"
 sha256 = "901bee6db5e17debad4530dd9ffb4dc9a96c4a656edbe1c3141b7cb307b11e73"
+
+def pre_configure(self):
+    # linux headers location on crossbuild
+    if self.cross_build:
+        self.configure_env = {"CPPFLAGS" : f"-I{self.profile().sysroot}/usr/include"}


### PR DESCRIPTION
makes `strace` build finds linux headers of target