### PR TITLE
main/base-cross: move brokenlinks into the right subpkgs

### DIFF
--- a/main/base-cross/template.py
+++ b/main/base-cross/template.py
@@ -7,7 +7,7 @@ pkgdesc = "Base metapackage for cross-compiling"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "custom:meta"
 url = "https://chimera-linux.org"
-options = ["!cross", "brokenlinks"]
+options = ["!cross"]
 
 _targets = list(filter(
     lambda p: p != self.profile().arch,
@@ -52,6 +52,7 @@ def _gen_crossp(an, at):
             f"musl-cross-{an}",
             f"libcxx-cross-{an}",
         ]
+        self.options = ["brokenlinks"]
         return [f"usr/bin/{at}-*", f"usr/lib/ccache/bin/{at}-*"]
     depends.append(f"base-cross-{an}={pkgver}-r{pkgrel}")
 


### PR DESCRIPTION
fix this:
```
$ ./cbuild pkg main/base-cross
...
=> base-cross-riscv64-0.1-r0: running post_install hook: 000_handle_modes...
=> base-cross-riscv64-0.1-r0: running post_install hook: 001_hardlinks...
=> base-cross-riscv64-0.1-r0: detecting hardlinks
=> base-cross-riscv64-0.1-r0: running post_install hook: 002_uncompress_manpages...
=> base-cross-riscv64-0.1-r0: running post_install hook: 003_remove_misc...
=> base-cross-riscv64-0.1-r0: running post_install hook: 004_remove_libtool_archives...
=> base-cross-riscv64-0.1-r0: running post_install hook: 005_remove_perl_files...
=> base-cross-riscv64-0.1-r0: running post_install hook: 006_remove_python_bytecode...
=> base-cross-riscv64-0.1-r0: running post_install hook: 007_strip_debug...
=> base-cross-riscv64-0.1-r0: running post_install hook: 008_rename_python_bindings...
=> base-cross-riscv64-0.1-r0: running post_install hook: 009_remove_pkgconf_sysroot...
=> base-cross-riscv64-0.1-r0: running post_install hook: 099_check_suid...
=> base-cross-riscv64-0.1-r0: running post_install hook: 100_rewrite_python_shebang...
=> base-cross-riscv64-0.1-r0: running post_install hook: 199_remove_empty_dirs...
=> base-cross-riscv64-0.1-r0: running post_install hook: 200_split_autopkgs...
=> base-cross-riscv64-0.1-r0: running post_install hook: 999_lint_devel...
=> base-cross-0.1-r0: running post_install hook: 000_handle_modes...
=> base-cross-0.1-r0: running post_install hook: 001_hardlinks...
=> base-cross-0.1-r0: detecting hardlinks
=> base-cross-0.1-r0: running post_install hook: 002_uncompress_manpages...
=> base-cross-0.1-r0: running post_install hook: 003_remove_misc...
=> base-cross-0.1-r0: running post_install hook: 004_remove_libtool_archives...
=> base-cross-0.1-r0: running post_install hook: 005_remove_perl_files...
=> base-cross-0.1-r0: running post_install hook: 006_remove_python_bytecode...
=> base-cross-0.1-r0: running post_install hook: 007_strip_debug...
=> base-cross-0.1-r0: running post_install hook: 008_rename_python_bindings...
=> base-cross-0.1-r0: running post_install hook: 009_remove_pkgconf_sysroot...
=> base-cross-0.1-r0: running post_install hook: 099_check_suid...
=> base-cross-0.1-r0: running post_install hook: 100_rewrite_python_shebang...
=> base-cross-0.1-r0: running post_install hook: 199_remove_empty_dirs...
=> WARNING: base-cross-0.1-r0: removed empty directory: usr/bin
=> WARNING: base-cross-0.1-r0: removed empty directory: usr/lib/ccache/bin
=> WARNING: base-cross-0.1-r0: removed empty directory: usr/lib/ccache
=> WARNING: base-cross-0.1-r0: removed empty directory: usr/lib
=> WARNING: base-cross-0.1-r0: removed empty directory: usr
=> base-cross-0.1-r0: running post_install hook: 200_split_autopkgs...
=> base-cross-0.1-r0: running post_install hook: 999_lint_devel...
=> base-cross-aarch64-0.1-r0: running pre_pkg hook: 001_runtime_deps...
=> base-cross-aarch64-0.1-r0: ERROR:    symlink: usr/bin/c++ <-> UNKNOWN PACKAGE!
Traceback (most recent call last):
  File "/build/chimera/SCRATCH_cports.git/src/runner.py", line 924, in fire
    case "build" | "check" | "install" | "pkg": do_pkg(cmd)
  File "/build/chimera/SCRATCH_cports.git/src/runner.py", line 858, in do_pkg
    build.build(
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/core/build.py", line 107, in build
    prepkg.invoke(sp)
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/step/prepkg.py", line 11, in invoke
    template.call_pkg_hooks(pkg, "pre_pkg")
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/core/template.py", line 165, in call_pkg_hooks
    run_pkg_func(pkg, f[0], f"{stepn}_{f[1]}", f"{stepn} hook: {f[1]}")
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/core/template.py", line 160, in run_pkg_func
    func(pkg)
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/hooks/pre_pkg/001_runtime_deps.py", line 289, in invoke
    _scan_symlinks(pkg)
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/hooks/pre_pkg/001_runtime_deps.py", line 270, in _scan_symlinks
    pkg.error(f"   symlink: {sdest} <-> UNKNOWN PACKAGE!")
  File "/build/chimera/SCRATCH_cports.git/src/cbuild/core/template.py", line 183, in error
    raise errors.PackageException(msg, end, self)
cbuild.core.errors.PackageException:    symlink: usr/bin/c++ <-> UNKNOWN PACKAGE!
```