### PR TITLE
main/libpulse: default_progs() already handles usr/share/ content.

### DIFF
--- a/main/libpulse/template.py
+++ b/main/libpulse/template.py
@@ -32,7 +32,4 @@ def _devel(self):
 @subpackage("libpulse-progs")
 def _progs(self):
     self.pkgdesc = "PulseAudio utilities"
-    return self.default_progs(extra = [
-        "usr/share/bash-completion",
-        "usr/share/zsh",
-    ])
+    return self.default_progs()


### PR DESCRIPTION
side effect: new automatic subpackage `libpulse-progs-bashcomp`.
zsh completion stuff remain in libpulse-progs package.
