### PR TITLE
various fix on main packages

### DIFF
--- a/main/libaom/template.py
+++ b/main/libaom/template.py
@@ -12,7 +12,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-2-Clause"
 url = "https://aomedia.org"
 source = [f"https://aomedia.googlesource.com/aom/+archive/v{pkgver}.tar.gz"]
-sha256 = ["5d1919c6ccd8811f344a89150a89234404e8273734cb0bd91e48b045d3226439"]
+sha256 = ["3d618b65eb601c348a10ef375dc6a72fe4c94d702a0ca4be1b268ffcf9c46609"]
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=2097152"]}
 # requires a testdata download, tests take long
 options = ["!check"]

--- a/main/libvidstab/template.py
+++ b/main/libvidstab/template.py
@@ -2,6 +2,7 @@ pkgname = "libvidstab"
 pkgver = "1.1.0"
 pkgrel = 0
 build_style = "cmake"
+configure_args = []
 hostmakedepends = ["cmake", "ninja", "pkgconf"]
 makedepends = ["orc-devel", "libomp-devel"]
 pkgdesc = "Video stabilization library"

--- a/main/libvpx7/template.py
+++ b/main/libvpx7/template.py
@@ -35,6 +35,7 @@ match self.profile().arch:
         _tgt = "ppc64le-linux-gcc"
     case "x86_64":
         _tgt = "x86_64-linux-gcc"
+        tools = {"AS": "yasm"}
     case _:
         _tgt = "generic-gnu"
 


### PR DESCRIPTION
was able to build all packages on x86_64 with these patches.
runtime not tested yet.

some reworks on the followings ?
* `main/libxpv7` : don't know if have to extend to all target arch for yasm
* `main/libaom` : sha256 changed because it's not a formal release but generated on-fly ?