### PR TITLE
main/debianutils: update to 5.7

### DIFF
--- a/main/debianutils/template.py
+++ b/main/debianutils/template.py
@@ -1,13 +1,13 @@
 pkgname = "debianutils"
-pkgver = "5.5"
+pkgver = "5.7"
 pkgrel = 0
 build_style = "gnu_configure"
 pkgdesc = "Miscellaneous utilities from Debian"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://tracker.debian.org/pkg/debianutils"
-source = f"$(DEBIAN_SITE)/main/d/debianutils/debianutils_{pkgver}.orig.tar.xz"
-sha256 = "2b0fad5c00eb2b8461523b2950e6f06e6ddbb0ac3384c5a3377867d51098d102"
+source = f"$(DEBIAN_SITE)/main/d/debianutils/debianutils_{pkgver}.orig.tar.gz"
+sha256 = "27ec9e0e7e44dc8ab611aa576330471bacb07e4491ffecf0d3aa6909c92f9022"
 
 def post_install(self):
     # (add|remove)-shell conflicts with our system


### PR DESCRIPTION
The 5.5 tarball is no longer on the Debian server (so my bootstrap failed). Bootstrap succeeded after this update.

I tried to find a stable source of release tarballs but didn't find one. https://packages.debian.org/source/unstable/debianutils lists the same file as I've added in this PR (also there's no `xz` file now).

https://salsa.debian.org/debian/debianutils has tags that could be used to get a tarball from GitLab, but I understand this would not follow the "using proper release tarballs rather than arbitrary git or similar revisions" [guideline](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality-requirements).