### PR TITLE
main/polkit: fix positional argument for meson

### DIFF
--- a/main/polkit/patches/meson.patch
+++ b/main/polkit/patches/meson.patch
@@ -1,0 +1,40 @@
+positional argument are not allowed starting with meson 0.6.0
+see https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/99
+
+From b5415812524a73fe106d4611cee29bb17546042b Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Tue, 22 Mar 2022 12:40:25 +0000
+Subject: [PATCH] Don't pass positional parameters to i18n.merge_file
+
+---
+ actions/meson.build      | 1 -
+ src/examples/meson.build | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/actions/meson.build b/actions/meson.build
+index 2abaaf3..1e3f370 100644
+--- a/actions/meson.build
++++ b/actions/meson.build
+@@ -1,7 +1,6 @@
+ policy = 'org.freedesktop.policykit.policy'
+ 
+ i18n.merge_file(
+-  policy,
+   input: policy + '.in',
+   output: '@BASENAME@',
+   po_dir: po_dir,
+diff --git a/src/examples/meson.build b/src/examples/meson.build
+index c6305ab..8c18de5 100644
+--- a/src/examples/meson.build
++++ b/src/examples/meson.build
+@@ -1,7 +1,6 @@
+ policy = 'org.freedesktop.policykit.examples.pkexec.policy'
+ 
+ i18n.merge_file(
+-  policy,
+   input: policy + '.in',
+   output: '@BASENAME@',
+   po_dir: po_dir,
+-- 
+GitLab
+


### PR DESCRIPTION
initial output message:
```
=> polkit-0.120-r0: installing host dependencies: meson, pkgconf, gobject-introspection, gettext-tiny, glib-devel, perl, xsltproc, docbook-xsl-nons
=> polkit-0.120-r0: installing target dependencies: elogind-devel, duktape-devel, linux-pam-devel
=> polkit-0.120-r0: running do_fetch hook: 000_sources...
=> polkit-0.120-r0: running do_extract hook: 000_sources...
=> polkit-0.120-r0: running init_patch hook: 000_env_pkg_config...
=> polkit-0.120-r0: running do_patch hook: 000_patches...
=> polkit-0.120-r0: patching: a2bf5c9c83b6ae46cbd5c779d3055bff81ded683.patch
=> polkit-0.120-r0: patching: duktape.patch
=> polkit-0.120-r0: patching: innetgr.patch
=> polkit-0.120-r0: running pre_configure hook: 000_script_wrapper...
=> polkit-0.120-r0: running pre_configure hook: 001_prepare_users...
=> polkit-0.120-r0: running do_configure...
The Meson build system
Version: 0.61.3
Source dir: /builddir/polkit-0.120
Build dir: /builddir/polkit-0.120/build
Build type: native build
Project name: polkit
Project version: 0.120
C compiler for the host machine: clang (clang 13.0.0 "clang version 13.0.0")
C linker for the host machine: clang ld.lld 13.0.0
C++ compiler for the host machine: clang++ (clang 13.0.0 "clang version 13.0.0")
C++ linker for the host machine: clang++ ld.lld 13.0.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
Checking for function "clearenv" : YES 
Checking for function "fdatasync" : YES 
meson.build:123: WARNING: Consider using the built-in option for language standard version instead of using "-std=c99".
Found pkg-config: /usr/bin/pkg-config (1.8.0)
Run-time dependency gio-2.0 found: YES 2.70.1
Run-time dependency gio-unix-2.0 found: YES 2.70.1
Run-time dependency glib-2.0 found: YES 2.70.1
Run-time dependency gobject-2.0 found: YES 2.70.1
Run-time dependency expat found: YES 2.4.1
Has header "expat.h" with dependency expat: YES 
Checking for function "XML_ParserCreate" with dependency expat: YES 
Run-time dependency duktape found: YES 2.6.0
Library m found: YES
Run-time dependency threads found: YES
Checking for function "pthread_condattr_setclock" : YES 
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency dbus-1 found: NO (tried pkgconfig and cmake)
Has header "netgroup.h" : NO 
Checking if "setnetgrent return support" compiles: NO 
Run-time dependency libelogind found: YES 246.10
Checking for function "sd_uid_get_display" with dependency libelogind: YES 
Library pam found: YES
Checking for function "pam_start" with dependency -lpam: YES 
Message: how to call pam_strerror: unknown
Run-time dependency gobject-introspection-1.0 found: YES 1.70.0

actions/meson.build:3:5: ERROR: Function does not take positional arguments.

A full log can be found at /builddir/polkit-0.120/build/meson-logs/meson-log.txt
```