### PR TITLE
vairous update-check fix 

### DIFF
--- a/main/exiv2/update.py
+++ b/main/exiv2/update.py
@@ -1,1 +1,2 @@
+url = "https://github.com/Exiv2/exiv2/releases"
 pattern = "exiv2-([\d.]+)-Source.tar.gz"

--- a/main/iana-etc/update.py
+++ b/main/iana-etc/update.py
@@ -1,7 +1,6 @@
 url = "https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml"
-_pver = self.template.pkgver
-pkgver = f"{_pver[0:4]}-{_pver[4:6]}-{_pver[6:]}"
 pattern = "<updated>([-\d]+)(?=</updated>)"
 
 def fetch_versions(self, src):
-    return map(lambda v: v.replace("-", ""), self.fetch_versions(src))
+    # keep only global last updated date
+    return map(lambda v: v.replace("-", ""), self.fetch_versions(src)[:1])

--- a/main/icu/update.py
+++ b/main/icu/update.py
@@ -1,2 +1,2 @@
-url = "https://github.com/unicode-org/icu/releases"
+url = "https://github.com/unicode-org/icu/releases/latest"
 pattern = r"release-([\d\-]+)\.tar\.gz"

--- a/main/itstool/update.py
+++ b/main/itstool/update.py
@@ -1,0 +1,1 @@
+url = "https://itstool.org/download.html"

--- a/main/jbig2dec/update.py
+++ b/main/jbig2dec/update.py
@@ -1,1 +1,2 @@
-pattern = r"/refs/tags/R_(\d+_\d+_\d+)\.tar\.gz"
+url = "https://github.com/ArtifexSoftware/jbig2dec/tags"
+pattern = r'/ArtifexSoftware/jbig2dec/releases/tag/([\d.]+)">'

--- a/main/json-c/update.py
+++ b/main/json-c/update.py
@@ -1,0 +1,1 @@
+pattern = r">json-c-([\d.]+)</a>"

--- a/main/libaio/update.py
+++ b/main/libaio/update.py
@@ -1,0 +1,2 @@
+url = "https://pagure.io/libaio/releases"
+pattern = r" libaio-([\d.]+)</strong>"

--- a/main/xserver-xorg-protocol/update.py
+++ b/main/xserver-xorg-protocol/update.py
@@ -1,1 +1,1 @@
-ignore = ["*"]
+ignore = True


### PR DESCRIPTION
fix the following problems:

```
$ find main contrib -type f -name template.py | xargs dirname | sort | xargs -n 1 ./cbuild update-check
...
CAUTION: no version found for 'exiv2'
...
iana-etc=20220816 -> iana-etc=199207
iana-etc=20220816 -> iana-etc=200201
   ...
iana-etc=20220816 -> iana-etc=20220812
iana-etc=20220816 -> iana-etc=20220816
...
CAUTION: no version found for 'icu'
CAUTION: no version found for 'itstool'
CAUTION: no version found for 'jbig2dec'
CAUTION: no version found for 'json-c'
...
CAUTION: no version found for 'libaio'
...
CAUTION: no version found for 'xserver-xorg-protocol'
...
```
