### PR TITLE
contrib/tmux: new package (3.3a)

### DIFF
--- a/contrib/tmux/template.py
+++ b/contrib/tmux/template.py
@@ -1,0 +1,16 @@
+pkgname = "tmux"
+pkgver = "3.3a"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--prefix=/usr"]
+hostmakedepends = ["byacc", "pkgconf"]
+makedepends = ["libevent-devel", "ncurses-devel"]
+pkgdesc = "Terminal multiplexer"
+maintainer = "Justin Berthault <justin.berthault@zaclys.net>"
+license = "ISC"
+url = "https://tmux.github.io"
+source = f"https://github.com/tmux/tmux/releases/download/{pkgver}/tmux-{pkgver}.tar.gz"
+sha256 = "e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f"
+
+def post_install(self):
+    self.install_license("COPYING")


### PR DESCRIPTION
- Built and tested working on aarch64 (rpi400)