### PR TITLE
main: Fix symbolic link loops

### DIFF
--- a/main/libpulse/libpulse
+++ b/main/libpulse/libpulse
@@ -1,1 +1,0 @@
-libpulse

--- a/main/libsoup/libsoup
+++ b/main/libsoup/libsoup
@@ -1,1 +1,0 @@
-libsoup

--- a/main/lvm2/lvm2.post-upgrade
+++ b/main/lvm2/lvm2.post-upgrade
@@ -1,1 +1,1 @@
-lvm2.post-upgrade
+lvm2.post-install


### PR DESCRIPTION
Encountered while running some `grep -r` from Chimera on this repo:
```
grep: ./main/device-mapper/lvm2.post-upgrade: Symbolic link loop
grep: ./main/device-mapper-devel/lvm2.post-upgrade: Symbolic link loop
grep: ./main/libpulse-devel/libpulse: Symbolic link loop
grep: ./main/libpulse-progs/libpulse: Symbolic link loop
grep: ./main/libpulse/libpulse: Symbolic link loop
grep: ./main/libsoup-devel/libsoup: Symbolic link loop
grep: ./main/libsoup/libsoup: Symbolic link loop
grep: ./main/lvm2/lvm2.post-upgrade: Symbolic link loop
```