### PR TITLE
cbuild: fix cargo check method

### DIFF
--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -140,7 +140,7 @@ class Cargo:
     ):
         tmpl = self.template
         return self._invoke(
-            "test", "--release", tmpl.make_check_args + args,
+            "test", [ "--release" ] + tmpl.make_check_args + args,
             jobs, True, tmpl.make_check_env, env, wrksrc,
             tmpl.make_check_wrapper, wrapper
         )


### PR DESCRIPTION
I don't think the cargo check method is used in the current ports tree but I ran into this error when creating a Rust package:

```
TypeError: Cargo._invoke() takes 10 positional arguments but 11 were given
```

This PR fixes the call to `Cargo._invoke`.