### PR TITLE
chimerautils: fix sha256 sum for commit a8b03cd4e0d9

### DIFF
--- a/main/chimerautils/template.py
+++ b/main/chimerautils/template.py
@@ -16,7 +16,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-2-Clause"
 url = "https://github.com/chimera-linux/chimerautils"
 source = f"https://github.com/chimera-linux/{pkgname}/archive/{_commit}.tar.gz"
-sha256 = "300a9dc2e0f1bd3e664e25caff7ad8356cb603abd9d2a006f0ab9712ec266544"
+sha256 = "6688d5acdba49622da7f42d7ea3c1c1c8fabab5dadcd20186530fbe302d995f3"
 hardening = ["vis", "cfi"]
 # no test suite
 options = ["bootstrap", "!check"]


### PR DESCRIPTION
build from source fails on sha256 sum for chimera utils commit a8b03cd4e0d955f462da8c902e57884e17f2fe4f  downloaded 3 times  and got sha256 sum 6688d5acdba49622da7f42d7ea3c1c1c8fabab5dadcd20186530fbe302d995f3 three times. 

updating the template, builds fine.