### PR TITLE
cbuild: meson: explicitly call setup command

### DIFF
--- a/src/cbuild/util/meson.py
+++ b/src/cbuild/util/meson.py
@@ -83,6 +83,7 @@ def configure(
 
     pkg.do(
         "meson",
+        "setup",
         "--prefix=/usr",
         "--libdir=/usr/lib",
         "--libexecdir=/usr/libexec",


### PR DESCRIPTION
Fixes the following warning during meson configure stage (which has apparently been [emitted since meson `0.64.0`](https://wiki.archlinux.org/title/Meson_package_guidelines#Using_meson_binary_directly)):
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```