### PR TITLE
 contrib/reboot-mode: new package (1.0.0)

### DIFF
--- a/contrib/reboot-mode/template.py
+++ b/contrib/reboot-mode/template.py
@@ -1,0 +1,15 @@
+pkgname = "reboot-mode"
+pkgver = "1.0.0"
+pkgrel = 0
+build_style = "makefile"
+make_build_target = pkgname
+makedepends = ["linux-headers"]
+pkgdesc = "Reboot a mobile device to a specific mode"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-3.0-or-later"
+url = "https://gitlab.com/postmarketOS/reboot-mode"
+source = f"{url}/-/archive/{pkgver}.tar.gz"
+sha256 = "ed9f13dffe745a109970c12f48a7be3e1c1f7bdee35a0d242264df11f6a17a62"
+
+def do_install(self):
+    self.install_bin(pkgname)


### PR DESCRIPTION
Facilitates e.g. `reboot-mode bootloader` which utilizes [the `LINUX_REBOOT_CMD_RESTART2` UAPI](https://elixir.bootlin.com/linux/latest/ident/LINUX_REBOOT_CMD_RESTART2) for rebooting a (mobile) device to a specific mode, such as `bootloader` -> fastboot flashing mode on my Android phone.