### PR TITLE
contrib/htop: new package (3.2.2)

### DIFF
--- a/contrib/htop/template.py
+++ b/contrib/htop/template.py
@@ -1,0 +1,12 @@
+pkgname = "htop"
+pkgver = "3.2.2"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--enable-unicode", "--enable-sensors"]
+makedepends = ["ncurses-devel", "libsensors-devel"]
+pkgdesc = "Interactive process viewer"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-2.0-only"
+url = "https://htop.dev"
+source = f"https://github.com/htop-dev/htop/releases/download/{pkgver}/htop-{pkgver}.tar.xz"
+sha256 = "bac9e9ab7198256b8802d2e3b327a54804dc2a19b77a5f103645b11c12473dc8"


### PR DESCRIPTION
It's better than `top` :p
![image](https://user-images.githubusercontent.com/47358222/227954726-d3d242c7-1f92-479c-b96d-5a3681704ea5.png)

I considered instead packaging [`btop`](https://github.com/aristocratos/btop) but that had hundreds of various random compile errors which seemed specific to `libc++` so I didn't bother, who knows perhaps LLVM 16 will change the situation