### PR TITLE
Fix EFISTUB entry boot order

### DIFF
--- a/main/efibootmgr/files/99-efibootmgr-hook.sh
+++ b/main/efibootmgr/files/99-efibootmgr-hook.sh
@@ -119,14 +119,14 @@ add_entry() {
     fi
 }
 
-BOOTORDER=$(/usr/bin/efibootmgr | grep "BootOrder: " | cut -c 12-)
-
 # remove old chimera entries first
 del_chimeras
 
 for KVER in $(linux-version list | linux-version sort --reverse); do
     add_entry "$KVER"
 done
+
+BOOTORDER=$(/usr/bin/efibootmgr | grep "BootOrder: " | cut -c 12-)
 
 /usr/bin/efibootmgr -qo "$BOOTORDER"
 


### PR DESCRIPTION
BOOTORDER variable did not capture proper entries due to wrong sequential placement in the script, resulting in botched EFI boot menu entries, with BootOrder parameter not updated correctly. Placing it after all the entries have been processed fixes the issue. 