### PR TITLE
Working update-check for Debian Salsa URLs

### DIFF
--- a/main/console-setup/update.py
+++ b/main/console-setup/update.py
@@ -1,1 +1,0 @@
-url = "https://salsa.debian.org/installer-team/console-setup/-/tags"

--- a/main/cryptsetup-scripts/update.py
+++ b/main/cryptsetup-scripts/update.py
@@ -1,4 +1,3 @@
-url = "https://salsa.debian.org/cryptsetup-team/cryptsetup/-/tags"
 pattern = r"cryptsetup\ Debian\ release\ 2:([\d.-]+)"
 
 def fetch_versions(self, src):

--- a/main/initramfs-tools/update.py
+++ b/main/initramfs-tools/update.py
@@ -1,1 +1,0 @@
-url = "https://salsa.debian.org/kernel-team/initramfs-tools/-/tags"

--- a/src/cbuild/core/update_check.py
+++ b/src/cbuild/core/update_check.py
@@ -256,7 +256,8 @@ class UpdateCheck:
                     ([\d.]+)(?=\.tar\.gz") # match
                 """
                 rxg = 1
-            elif "//gitlab." in url:
+            elif "//gitlab." in url or \
+                 "salsa.debian.org" in url:
                 pn = "/".join(url.split("/")[0:5])
                 url = f"{pn}/tags"
                 rx = fr"""


### PR DESCRIPTION
Noticed this while packaging [`minicom`](https://salsa.debian.org/minicom-team/minicom) which I can also confirm this works for out of the box without need for `update.py` overrides :)