### PR TITLE
contrib/minicom: new package (2.8)

### DIFF
--- a/contrib/minicom/template.py
+++ b/contrib/minicom/template.py
@@ -1,0 +1,12 @@
+pkgname = "minicom"
+pkgver = "2.8"
+pkgrel = 0
+build_style = "gnu_configure"
+makedepends = ["ncurses-devel", "linux-headers"]
+pkgdesc = "Friendly menu driven serial communication program"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-2.0-or-later"
+url = "https://salsa.debian.org/minicom-team/minicom"
+source = f"{url}/-/archive/{pkgver}.tar.gz"
+sha256 = "91f41c0ec1e695d95eaa567be7616abb43e30e823022fe123f245a2b3f50680b"
+hardening = ["vis", "cfi"]


### PR DESCRIPTION
Seems to work for UART TX/RX with my FTDI FT232R USB adapter; `update-check` is broken but #163 addresses that.
![image](https://user-images.githubusercontent.com/47358222/231211631-69b5aef5-9898-42d5-9c22-8c48fb194cd2.png)