### PR TITLE
Android tools + dependencies

### DIFF
--- a/contrib/android-tools/template.py
+++ b/contrib/android-tools/template.py
@@ -1,0 +1,32 @@
+pkgname = "android-tools"
+pkgver = "34.0.4"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja", "perl", "go", "pkgconf", "protobuf"]
+makedepends = [
+    "brotli-devel",
+    "lz4-devel",
+    "pcre2-devel",
+    "libusb-devel",
+    "zstd-devel",
+    "protobuf-devel",
+    "linux-headers",
+    "gtest-devel",
+]
+depends = ["python", "android-udev-rules"]
+pkgdesc = "Android platform tools (e.g. adb and fastboot)"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "Apache-2.0 AND ISC AND GPL-2.0-only AND MIT"
+url = "https://github.com/nmeum/android-tools"
+source = f"{url}/releases/download/{pkgver}/android-tools-{pkgver}.tar.xz"
+sha256 = "7a22ff9cea81ff4f38f560687858e8f8fb733624412597e3cc1ab0262f8da3a1"
+hardening = ["vis", "cfi"]
+# no tests
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("vendor/boringssl/LICENSE", name="boringssl.LICENSE")
+    self.install_license(
+        "vendor/boringssl/third_party/fiat/LICENSE", name="fiat.LICENSE"
+    )

--- a/contrib/android-udev-rules/template.py
+++ b/contrib/android-udev-rules/template.py
@@ -1,0 +1,17 @@
+pkgname = "android-udev-rules"
+pkgver = "20230614"
+pkgrel = 0
+pkgdesc = (
+    "Android udev rules list aimed to be the most comprehensive on the net"
+)
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/M0Rf30/android-udev-rules"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "563b8f3194110b7173dfaad61e74da2842b28c4f2409dedce04d5572ef2f056f"
+options = ["!splitudev"]
+system_groups = ["adbusers"]
+
+
+def do_install(self):
+    self.install_file("51-android.rules", "usr/lib/udev/rules.d")


### PR DESCRIPTION
Brings in `adb`, `fastboot` and friends normally required for dealing with development and flashing of Android devices.