### PR TITLE
contrib/qt6-* : enable check and some minor fixes

### DIFF
--- a/contrib/qt6-qtbase/template.py
+++ b/contrib/qt6-qtbase/template.py
@@ -255,7 +255,7 @@ def _devel(self):
     return self.default_devel(
         extra=[
             "usr/lib/qt6/metatypes",
-            "usr/lib/qt6/mkspecs/modules",
+            "usr/lib/qt6/mkspecs",
             "usr/lib/qt6/modules",
             "usr/lib/*.prl",
         ]

--- a/contrib/qt6-qtbase/template.py
+++ b/contrib/qt6-qtbase/template.py
@@ -71,7 +71,7 @@ debug_level = 1  # defatten, especially with LTO
 # FIXME
 hardening = ["!int"]
 # TODO
-options = ["!check", "!cross"]
+options = ["!cross"]
 
 if self.profile().arch == "riscv64":
     tool_flags = {
@@ -93,8 +93,91 @@ def init_configure(self):
         self.configure_args += ["-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"]
 
 
+def do_check(self):
+    # OOB       : 56% tests passed, 237 tests failed out of 539
+    # +offscreen: 91% tests passed,  47 tests failed out of 539
+    excl_list = [
+        "tst_selftests",                # requires valgrind
+        "tst_qmake",                    # Could not find qmake spec 'linux-clang'.
+        "tst_moc",                      # tst_Moc::initTestCase() 'fi.exists()' returned FALSE. ()
+        "tst_rcc",                      # Could not start "/builddir/qt6-base-6.5.0/build/lib/qt6/libexec/rcc": chdir: No such file or directory
+        "tst_qstandardpaths",           # using / as runtime directory ? wrong permission then
+        "tst_qresourceengine",          # tst_QResourceEngine::lastModified() '!fi.lastModified().isValid()' returned FALSE.
+        "tst_qfilesystemwatcher",       # tst_QFileSystemWatcher::addPaths() Compared lists have different sizes.
+        "tst_qpluginloader",            # tst_QPluginLoader::loadDebugObj() 'QFile::exists(QFINDTESTDATA("elftest/debugobj.so"))' returned FALSE. ()
+        "tst_qlibrary",                 # tst_QLibrary::initTestCase() 'QDir::setCurrent(testdatadir)' returned FALSE. (Could not chdir to )
+        "tst_qtextstream",              # tst_QTextStream::initTestCase() '!m_rfc3261FilePath.isEmpty()' returned FALSE. ()
+        "test_build_simple_widget_app_qmake",  # fatal error: 'QApplication' file not found
+        "test_interface",               # requires Qt6WidgetsConfig.cmake (present in build/lib/cmake/Qt6Widgets/Qt6WidgetsConfig.cmake)
+        "test_add_big_resource",        # No data signature found
+        "mockplugins",                  # Unknown platform linux-clang
+        "test_import_plugins",          # not runned: dep of mockplugins
+        "test_add_resources_big_resources",    # No data signature found
+        "tst_qaddpreroutine",           # Unknown platform linux-clang
+        "test_static_resources",        # Unknown platform linux-clang
+        "test_generating_cpp_exports",  # Unknown platform linux-clang
+        "test_widgets_app_deployment",  # Subprocess aborted
+        "tst_qopenglwindow",            # execution failed with exit code Segmentation fault.
+        "tst_qimagereader",             # execution failed with exit code Segmentation fault.
+        "tst_qicoimageformat",          # execution failed with exit code Segmentation fault.
+        "tst_qimage",                   # execution failed with exit code Segmentation fault.
+        "tst_qpainter",                 # execution failed with exit code Segmentation fault.
+        "tst_qfont",                    # tst_QFont::defaultFamily(serif) 'QFontDatabase::hasFamily(familyForHint)' returned FALSE.
+        "tst_qfontdatabase",            # tst_QFontDatabase::systemFixedFont() 'fdbSaysFixed' returned FALSE.
+        "tst_qfontmetrics",             # tst_QFontMetrics::zeroWidthMetrics() Compared values are not the same
+        "tst_qglyphrun",                # tst_QGlyphRun::mixedScripts() Compared values are not the same
+        "tst_qrawfont",                 # tst_QRawFont::unsupportedWritingSystem(Default hinting preference) 'layoutFont.familyName() != QString::fromLatin1("QtBidiTestFont")' returned FALSE
+        "tst_qtextcursor",              # tst_QTextCursor::insertHtml(insert as text in new block at end of heading) Compared values are not the same
+        "tst_qtextdocumentlayout",      # tst_QTextDocumentLayout::imageAtRightAlignedTab() Compared doubles are not the same (fuzzy compare)
+        "tst_qtextmarkdownimporter",    # tst_QTextMarkdownImporter::lists(styled spans in list items) Compared values are not the same
+        "tst_qopenglconfig",            # tst_QOpenGlConfig::testGlConfiguration() 'context.create()' returned FALSE
+        "tst_qopengl",                  # tst_QOpenGL::sharedResourceCleanup(Using QWindow) 'ctx->create()' returned FALSE
+        "tst_qx11info",                 # tst_QX11Info::startupId() Compared values are not the same
+        "tst_qdnslookup",               # Resolver functions not found (voidlinux: Some glibc specific DNS Lookup)
+        "tst_qfiledialog",              # tst_QFiledialog::historyBack() Compared values are not the same
+        "tst_qgraphicsproxywidget",     # tst_QGraphicsProxyWidget::focusOutEvent(widget, focus to other widget) Widget should have focus but doesn't
+        "tst_qgraphicsview",            # execution failed with exit code Segmentation fault.
+        "tst_qapplication",             # tst_QApplication::libraryPaths() '!testDir.isEmpty()' returned FALSE. ()
+        "tst_qfontcombobox",            # tst_QFontComboBox::currentFontChanged() Compared values are not the same
+        "tst_qlineedit",                # tst_QLineEdit::setInputMask(keys blank=input) To eat blanks or not? Known issue. Task 43172
+        "tst_qmenubar",                 # tst_QLineEdit::returnPressed_maskvalidator(mask '999', intfix validator(0,999), input '12<cr>') QIntValidator has changed behaviour. Does not accept spaces.
+        "tst_qopenglwidget",            # execution failed with exit code Segmentation fault.
+        "tst_qcomplextext",             # tst_QComplexText::bidiCursorMovement(data46) 'newX <= x' returned FALSE
+    ]
+    self.do(
+        "ctest",
+        "-E",
+        "(" + "|".join(excl_list) + ")",
+        wrksrc=self.make_dir,
+        env={
+            "QT_QPA_PLATFORM": "offscreen",
+            "CTEST_OUTPUT_ON_FAILURE": "True",
+            "QMAKESPEC": f"{self.chroot_cwd}/mkspecs/linux-clang",
+        },
+    )
+
+
 def post_install(self):
+    # remove installed checks files (because of "-DQT_BUILD_TESTS=ON")
     self.rm(self.destdir / "usr/tests", recursive=True)
+    self.rm(self.destdir / "usr/lib/qt6/tests", recursive=True)
+    self.rm(self.destdir / "usr/lib/qt6/bin/tst_qhashseed_helper")
+    self.rm(self.destdir / "usr/lib/qt6/bin/testSetWorkingDirectory")
+    self.rm(self.destdir / "usr/lib/qt6/bin/testGuiProcess")
+    self.rm(self.destdir / "usr/lib/qt6/bin/testForwarding")
+    self.rm(self.destdir / "usr/lib/qt6/bin/testDetached")
+    self.rm(self.destdir / "usr/lib/qt6/bin/syslocaleapp")
+    self.rm(self.destdir / "usr/lib/qt6/bin/socketprocess")
+    self.rm(self.destdir / "usr/lib/qt6/bin/qfileopeneventexternal")
+    self.rm(self.destdir / "usr/lib/qt6/bin/qcommandlineparser_test_helper")
+    self.rm(self.destdir / "usr/lib/qt6/bin/paster")
+    self.rm(self.destdir / "usr/lib/qt6/bin/modal_helper")
+    self.rm(self.destdir / "usr/lib/qt6/bin/fileWriterProcess")
+    self.rm(self.destdir / "usr/lib/qt6/bin/echo")
+    self.rm(self.destdir / "usr/lib/qt6/bin/desktopsettingsaware_helper")
+    self.rm(self.destdir / "usr/lib/qt6/bin/crashingServer")
+    self.rm(self.destdir / "usr/lib/qt6/bin/copier")
+    self.rm(self.destdir / "usr/lib/qt6/bin/clientserver")
     self.install_file(self.files_path / "target_qt.conf", "usr/lib/qt6/bin")
     # eliminate hardlinks
     for f in (self.destdir / "usr/lib/qt6/bin").glob("*6"):

--- a/contrib/qt6-qtdeclarative/template.py
+++ b/contrib/qt6-qtdeclarative/template.py
@@ -26,7 +26,65 @@ debug_level = 1  # defatten, especially with LTO
 # FIXME
 hardening = ["!int"]
 # TODO
-options = ["!check", "!cross"]
+options = ["!cross"]
+
+
+def do_check(self):
+    # with offscreen    : 13% tests passed, 146 tests failed out of 167
+    # +QML2_IMPORT_PATH : 78% tests passed,  37 tests failed out of 167
+    excl_list = [
+        "test_qml_app_deployment",  # missing /usr/lib/cmake/Qt6Quick/Qt6QuickConfig.cmake
+        "module_includes",          # Could NOT find Qt6 (missing: Qt6_DIR)
+        "cmake_tooling_imports",    # missing /usr/lib/cmake/Qt6Qml/Qt6QmlConfig.cmake
+        "empty_qmldir",             # missing /usr/lib/cmake/Qt6Qml/Qt6QmlConfig.cmake
+        "qmlquery",                 # missing /usr/lib/cmake/Qt6Qml/Qt6QmlConfig.cmake
+        "qtquickcompiler",          # missing /usr/lib/cmake/Qt6Qml/Qt6QmlConfig.cmake
+        "cmake_test_common_import_path",    # missing /usr/lib/cmake/Qt6Qml/Qt6QmlConfig.cmake
+        "tst_qqmlapplicationengine",        # tst_qqmlapplicationengine::application(delayed quit) 'QString(testStdErr).endsWith(QString(expectedStdErr))' returned FALSE.
+        "tst_qqmljsscope",          # missing builtins.qmltypes, jsroot.qmltypes
+        "tst_qdebugmessageservice",         # Could not launch app  "/usr/lib/qt6/bin/qml"
+        "tst_qqmldebugtranslationclient",   # Could not launch app  "/usr/lib/qt6/bin/qml"
+        "tst_qqmldebugjs",          # Could not launch app  "/usr/lib/qt6/bin/qmlscene"
+        "tst_qqmlinspector",        # Could not launch app  "/usr/lib/qt6/bin/qml"
+        "tst_qqmlprofilerservice",  # Could not launch app  "/usr/lib/qt6/bin/qmlscene"
+        "tst_qqmlenginedebuginspectorintegration",  # Could not launch app  "/usr/lib/qt6/bin/qml"
+        "tst_qqmlenginecontrol",    # Could not launch app  "/usr/lib/qt6/bin/qmlscene"
+        "tst_qqmldebuggingenabler",     # Could not launch app  "/usr/lib/qt6/bin/qmlscene"
+        "tst_qqmldebugprocess",     # Timeout while waiting for QML debugging messages
+        "tst_qqmlpreview",          # Could not launch app  "/usr/lib/qt6/bin/qml"
+        "tst_qmlformat",            # qmlformat executable not found (looked for /usr/lib/qt6/bin/qmlformat)
+        "tst_qmlimportscanner",     # qmlimportscanner executable not found (looked for /usr/lib/qt6/libexec/qmlimportscanner)
+        "tst_qmllint",              # qmllint executable not found (looked for /usr/lib/qt6/bin/qmllint)
+        "tst_qmltc_qprocess",       # qmltc executable not found (looked for /usr/lib/qt6/bin/qmltc)
+        "tst_qmlplugindump",        # qmlplugindump executable not found (looked for /usr/lib/qt6/bin/qmlplugindump)
+        "tst_qml",                  # tst_qml::initTestCase() 'QFileInfo(qmlPath).exists()' returned FALSE. ()
+        "tst_qqmlextensionplugin",  # tst_qqmlextensionplugin::iidCheck() ASSERT failure in QTest::fetchData(): "Test data requested, but no testdata available"
+        "text",                     # test failed
+        "tst_qmldomitem",           # Error: Could not find builtins.qmltypes file
+        "tst_dom_all",              # Error: Could not find builtins.qmltypes file
+        "tst_basic",                # test failed
+        "tst_fusion",               # test failed
+        "tst_imagine",              # why ?
+        "tst_material",             # why ?
+        "tst_universal",            # why ?
+        "tst_qquickiconimage",      # execution failed with exit code Segmentation fault
+        "tst_qquickfiledialogimpl",     # why ?
+        "tst_qquickfolderdialogimpl",   # test failed
+    ]
+    self.do(
+        "ctest",
+        "-E",
+        "(" + "|".join(excl_list) + ")",
+        wrksrc=self.make_dir,
+        env={
+            "QT_QPA_PLATFORM": "offscreen",
+            "CTEST_OUTPUT_ON_FAILURE": "True",
+            # qml stuff is not yet installed
+            "QML2_IMPORT_PATH": str(
+                self.chroot_cwd / f"{self.make_dir}/lib/qt6/qml"
+            ),
+        },
+    )
 
 
 def post_install(self):

--- a/contrib/qt6-qtshadertools/template.py
+++ b/contrib/qt6-qtshadertools/template.py
@@ -2,6 +2,8 @@ pkgname = "qt6-qtshadertools"
 pkgver = "6.5.0"
 pkgrel = 0
 build_style = "cmake"
+configure_args = ["-DQT_BUILD_TESTS=ON"]
+make_check_env = {"QT_QPA_PLATFORM": "offscreen"}
 hostmakedepends = ["cmake", "ninja", "pkgconf", "perl", "qt6-qtbase"]
 makedepends = ["qt6-qtbase-devel"]
 depends = [f"qt6-qtshadertools-libs={pkgver}-r{pkgrel}"]
@@ -16,7 +18,7 @@ debug_level = 1  # defatten, especially with LTO
 # FIXME
 hardening = ["!int"]
 # TODO
-options = ["!check", "!cross"]
+options = ["!cross"]
 
 
 @subpackage("qt6-qtshadertools-libs")

--- a/contrib/qt6-qtsvg/template.py
+++ b/contrib/qt6-qtsvg/template.py
@@ -5,6 +5,7 @@ build_style = "cmake"
 configure_args = [
     "-DQT_BUILD_TESTS=ON",
 ]
+make_check_env = {"QT_QPA_PLATFORM": "offscreen"}
 hostmakedepends = ["cmake", "ninja", "pkgconf", "perl", "qt6-qtbase"]
 makedepends = ["qt6-qtbase-devel"]
 pkgdesc = "Qt6 SVG component"
@@ -17,8 +18,6 @@ sha256 = "64ca7e61f44d51e28bcbb4e0509299b53a9a7e38879e00a7fe91643196067a4f"
 debug_level = 1  # defatten, especially with LTO
 # FIXME
 hardening = ["!int"]
-# TODO
-options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/qt6-qtwayland/template.py
+++ b/contrib/qt6-qtwayland/template.py
@@ -14,6 +14,7 @@ hostmakedepends = [
     "qt6-qtdeclarative-devel",
 ]
 makedepends = ["qt6-qtbase-devel", "qt6-qtdeclarative-devel"]
+checkdepends = ["mesa-dri"]
 pkgdesc = "Qt6 Wayland component"
 license = (
     "LGPL-2.1-only AND LGPL-3.0-only AND GPL-3.0-only WITH Qt-GPL-exception-1.0"
@@ -25,7 +26,20 @@ debug_level = 1  # defatten, especially with LTO
 # FIXME
 hardening = ["!int"]
 # TODO
-options = ["!check", "!cross"]
+options = ["!cross"]
+
+
+def do_check(self):
+    self.do(
+        "ctest",
+        "-E",
+        "tst_seatv4$",
+        wrksrc=self.make_dir,
+        env={
+            "QT_QPA_PLATFORM": "offscreen",
+            "CTEST_OUTPUT_ON_FAILURE": "True",
+        },
+    )
 
 
 @subpackage("qt6-qtwayland-devel")


### PR DESCRIPTION
some initial work on testing for qt6 packages, probably too verbose and not enough accurate ?
non-check changes on `contrib/qt6-qtbase` should be reorganized separately, ie mode dedicated commits ?