### PR TITLE
main/mesa: disable radeonsi glthread to fix artifacting

### DIFF
--- a/main/mesa/patches/no-radeonsi-glthread.patch
+++ b/main/mesa/patches/no-radeonsi-glthread.patch
@@ -1,0 +1,15 @@
+From https://gitlab.freedesktop.org/mesa/mesa/-/commit/796af8e7, this
+resolves various OpenGL artifacts seen on AMD cards starting with Mesa
+23.1.x (test: scrolling in epiphany), disable glthread until a (more)
+proper solution.
+
+--- a/src/gallium/drivers/radeonsi/driinfo_radeonsi.h
++++ b/src/gallium/drivers/radeonsi/driinfo_radeonsi.h
+@@ -1,7 +1,6 @@
+ // DriConf options specific to radeonsi
+ DRI_CONF_SECTION_PERFORMANCE
+ DRI_CONF_ADAPTIVE_SYNC(true)
+-DRI_CONF_MESA_GLTHREAD(true)
+ DRI_CONF_SECTION_END
+ 
+ DRI_CONF_SECTION_DEBUG

--- a/main/mesa/template.py
+++ b/main/mesa/template.py
@@ -1,6 +1,6 @@
 pkgname = "mesa"
 pkgver = "23.1.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "-Dglvnd=false",


### PR DESCRIPTION
From https://gitlab.freedesktop.org/mesa/mesa/-/commit/796af8e7, this resolves various OpenGL artifacts seen on AMD cards starting with Mesa 23.1.x (test: scrolling in epiphany), disable `glthread` until a (more) proper solution.