### PR TITLE
Add Prism Launcher (7.0) and dependencies

### DIFF
--- a/contrib/extra-cmake-modules/template.py
+++ b/contrib/extra-cmake-modules/template.py
@@ -1,0 +1,23 @@
+pkgname = "extra-cmake-modules"
+pkgver = "5.107.0"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja"]
+pkgdesc = "Extra modules and scripts for CMake"
+maintainer = "aurelia <git@elia.garden>"
+license = "BSD-3-Clause"
+url = "https://github.com/KDE/extra-cmake-modules"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "b59d1bd4723be532ada21c1e584e2e61940e066f7ace0131173095431700bec3"
+# 10 out of 83 tests fail? It still seemed to run fine when building with it.
+#  2 - ExecuteKDEModules
+#  3 - KDEFetchTranslations
+#  4 - KDEInstallDirsTest.vars_in_sync_no_args
+#  5 - KDEInstallDirsTest.not_cache_variable
+#  6 - KDEInstallDirsTest.vars_in_sync_kde_arg
+#  7 - KDEInstallDirsTest.vars_in_sync_cmake_arg
+# 16 - ecm_add_tests-single_tests
+# 17 - ecm_add_tests_did_run-single_tests
+# 18 - ecm_add_tests-multi_tests
+# 19 - ecm_add_tests_did_run-multi_tests
+options = ["!check"]

--- a/contrib/prismlauncher/template.py
+++ b/contrib/prismlauncher/template.py
@@ -1,0 +1,24 @@
+pkgname = "prismlauncher"
+pkgver = "7.0"
+pkgrel = 0
+build_style = "cmake"
+configure_env = {"JAVA_HOME": "/usr/lib/jvm/java-17-openjdk"}
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "extra-cmake-modules",
+    "qt6-qtbase",
+    "openjdk17-jdk",
+]
+makedepends = [
+    "qt6-qtbase-devel",
+    "qt6-qt5compat-devel",
+    "qt6-qtsvg-devel",
+    "zlib-devel",
+]
+pkgdesc = "Minecraft launcher with multiple instances support"
+maintainer = "aurelia <git@elia.garden>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/PrismLauncher/PrismLauncher"
+source = f"{url}/releases/download/{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "aef3d368aea8c5c65d6db0d258ef3d0a2965a009f1311568190d2b557ec01833"

--- a/contrib/qt6-qt5compat-devel
+++ b/contrib/qt6-qt5compat-devel
@@ -1,0 +1,1 @@
+qt6-qt5compat

--- a/contrib/qt6-qt5compat/template.py
+++ b/contrib/qt6-qt5compat/template.py
@@ -1,0 +1,29 @@
+pkgname = "qt6-qt5compat"
+pkgver = "6.5.0"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja", "pkgconf", "qt6-qtbase"]
+makedepends = ["qt6-qtbase-devel"]
+pkgdesc = "Module containing unsuppored Qt5 APIs"
+maintainer = "aurelia <git@elia.garden>"
+license = (
+    "LGPL-2.1-only AND LGPL-3.0-only AND GPL-3.0-only WITH Qt-GPL-exception-1.0"
+)
+url = "https://www.qt.io"
+source = f"https://download.qt.io/official_releases/qt/{pkgver[:-2]}/{pkgver}/submodules/qt5compat-everywhere-src-{pkgver}.tar.xz"
+sha256 = "a9e2f53a193fc2e131b01a2f6e7a1fbfe31309c2413fdc213e5a81c558c21261"
+# TODO
+options = ["!check"]
+
+
+@subpackage("qt6-qt5compat-devel")
+def _devel(self):
+    self.depends += [f"{pkgname}={pkgver}-r{pkgrel}"]
+    return self.default_devel(
+        extra=[
+            "usr/lib/qt6/metatypes",
+            "usr/lib/qt6/mkspecs",
+            "usr/lib/qt6/modules",
+            "usr/lib/*.prl",
+        ]
+    )

--- a/contrib/qt6-qt5compat/update.py
+++ b/contrib/qt6-qt5compat/update.py
@@ -1,0 +1,5 @@
+url = [
+    "https://download.qt.io/official_releases/qt",
+    f"https://download.qt.io/official_releases/qt/{self.template.pkgver[:-2]}",
+]
+pattern = r">([\d.]+)/<"


### PR DESCRIPTION
This PR adds PrismLauncher, along with 2 build dependencies it needed (qt6-5compat, extra-cmake-modules).
This is my first PR, so I hope I got the templates right, especially since I wasn't sure of a good way to specify the Java installation for PL.
It builds and runs fine on x86; it should too on ARM and PPC but I was unable to test it due to not having any hardware available.