### PR TITLE
Add powertop (2.15) and dependencies

### DIFF
--- a/contrib/autoconf-archive/template.py
+++ b/contrib/autoconf-archive/template.py
@@ -1,0 +1,11 @@
+pkgname = "autoconf-archive"
+pkgver = "2023.02.20"
+pkgrel = 0
+build_style = "gnu_configure"
+makedepends = ["autoconf", "automake", "texinfo"]
+pkgdesc = "Collection of re-usable Autoconf macros"
+maintainer = "stbk <stbk@elia.garden>"
+license = "GPL-3.0-or-later"
+url = "https://www.gnu.org/software/autoconf-archive"
+source = f"$(GNU_SITE)/{pkgname}/{pkgname}-{pkgver}.tar.xz"
+sha256 = "71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33"

--- a/contrib/powertop/template.py
+++ b/contrib/powertop/template.py
@@ -1,0 +1,21 @@
+pkgname = "powertop"
+pkgver = "2.15"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--disable-nls"]
+configure_gen = ["./autogen.sh"]
+hostmakedepends = ["autoconf", "automake", "libtool", "pkgconf"]
+makedepends = [
+    "autoconf-archive",
+    "gettext-tiny-devel",
+    "libnl-devel",
+    "linux-headers",
+    "ncurses-devel",
+    "pciutils-devel",
+]
+pkgdesc = "Diagnostic tool for power usage"
+maintainer = "stbk <stbk@elia.garden>"
+license = "GPL-2.0-only"
+url = "https://github.com/fenrus75/powertop"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "e58ab3fd7b8ff5f4dd0d17f11848817e7d83c0a6918145ac81de03b5dccf8f49"


### PR DESCRIPTION
This PR adds powertop and autoconf-archive, which it requires as a build dependency.
These packages were authored and will be maintained by stbk; I am creating the PR for her since she does not have a GitHub account and will do so for future PRs. We hope this is acceptable.
As with my PL PR, this was tested and works on x86. (And this time, it's properly formatted from the get-go...)
