### PR TITLE
Add zoxide (0.9.1)

### DIFF
--- a/contrib/zoxide/template.py
+++ b/contrib/zoxide/template.py
@@ -1,0 +1,29 @@
+pkgname = "zoxide"
+pkgver = "0.9.1"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo"]
+makedepends = ["rust"]
+pkgdesc = "Fuzzy cd command for interactive shells"
+maintainer = "aurelia <git@elia.garden>"
+license = "MIT"
+url = "https://github.com/ajeetdsouza/zoxide"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "7af5965e0f0779a5ea9135ee03c51b1bb1d84b578af0a7eb2bd13dbf34a342dd"
+
+
+def post_install(self):
+    self.install_man("man/man1/*.1", glob=True)
+    self.install_file(
+        "contrib/completions/zoxide.bash",
+        "usr/share/bash-completion/completions",
+        name="zoxide",
+    )
+    self.install_file(
+        "contrib/completions/_zoxide",
+        "usr/share/zsh/site-functions",
+    )
+    self.install_file(
+        "contrib/completions/zoxide.fish",
+        "usr/share/fish/completions",
+    )

--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -51,13 +51,16 @@ def get_environment(pkg, jobs=None):
     return env
 
 
-# very preliminary, no error checking, etc
+# Configure cargo to use vendored sources
 def setup_vendor(pkg, vendor_path="vendor", wrksrc=None):
     dirn = pkg.cwd
     if wrksrc is not None:
         dirn = dirn / wrksrc
-    pkg.mkdir(dirn / ".cargo")
-    with open(dirn / ".cargo/config.toml", "w") as cf:
+
+    # Make sure to append in case a config is already present;
+    # `parents` ensures the directory is allowed to exist already
+    pkg.mkdir(dirn / ".cargo", parents=True)
+    with open(dirn / ".cargo/config.toml", "a") as cf:
         cf.write(
             f"""
 [source.crates-io]


### PR DESCRIPTION
Adds a package for zoxide.
Since zoxide already had a `.cargo/config.toml` in the project dir, the code for configuring vendoring sources threw an error.
I modified it to append to the file instead, which felt like the right approach and fixes this issue.
