### PR TITLE
Fix bluetoothd service file

### DIFF
--- a/main/bluez/files/bluetoothd
+++ b/main/bluez/files/bluetoothd
@@ -3,7 +3,7 @@
 # TODO: log output to syslog redirection
 
 type            = process
-command         = /usr/libexec/bluetoooth/bluetoothd -n
+command         = /usr/libexec/bluetooth/bluetoothd -n
 before          = login.target
 depends-on      = init-local.target
 depends-on      = dbus

--- a/main/bluez/template.py
+++ b/main/bluez/template.py
@@ -1,6 +1,6 @@
 pkgname = "bluez"
 pkgver = "5.66"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--disable-systemd",


### PR DESCRIPTION
There was an extra 'o' in the directory name preventing it from starting.