### PR TITLE
contrib/fd: new package (8.7.0)

### DIFF
--- a/contrib/fd/template.py
+++ b/contrib/fd/template.py
@@ -1,0 +1,22 @@
+pkgname = "fd"
+pkgver = "8.7.0"
+pkgrel = 0
+build_style = "cargo"
+# disable the default use-jemalloc and completions features
+make_build_args = ["--no-default-features"]
+make_install_args = ["--no-default-features"]
+make_check_args = ["--no-default-features"]
+hostmakedepends = ["cargo"]
+makedepends = ["rust"]
+pkgdesc = "Simple, fast and user-friendly alternative to find"
+maintainer = "Wesley Moore <wes@wezm.net>"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/sharkdp/fd"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "13da15f3197d58a54768aaad0099c80ad2e9756dd1b0c7df68c413ad2d5238c9"
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")
+    self.install_man("doc/fd.1", "fd.1")
+    self.install_completion("contrib/completion/_fd", "zsh")


### PR DESCRIPTION
Template for `fd`. I have disabled the default cargo features:

- `use-jemalloc`: fails to build
- `completions`: this is unused

Only zsh completions are included as generating bash and fish completions requires invoking the built binary, which I assume will not work when cross-compiling.

I was a little unsure of the best way to pass `--no-default-features` to cargo. Setting `make_*_args` works for build and check but setting `make_install_args` overwrites the default behavior (of passing `--path .`), so I instead invoke `install` manually to preserve that default behavior.