### PR TITLE
Add alacritty (0.12.1) and its dependencies

### DIFF
--- a/contrib/alacritty-devel
+++ b/contrib/alacritty-devel
@@ -1,0 +1,1 @@
+alacritty

--- a/contrib/alacritty/template.py
+++ b/contrib/alacritty/template.py
@@ -1,0 +1,54 @@
+pkgname = "alacritty"
+pkgver = "0.12.1"
+pkgrel = 0
+build_style = "cargo"
+make_install_args = ["--path", "alacritty"]
+hostmakedepends = [
+    "cargo",
+    "cargo-auditable",
+    "cmake",
+    "fontconfig-devel",
+    "freetype-devel",
+    "gmake",
+    "libxcb-devel",
+    "libxkbcommon-devel",
+    "pkgconf",
+    "python",
+    "rust",
+]
+depends = ["ncurses-base", "wayland", "libxi", "libxcursor"]
+pkgdesc = "Cross-platform, GPU-accelerated terminal emulator"
+maintainer = "nbfritch <nbfritch@gmail.com>"
+license = "Apache-2.0"
+url = "https://github.com/alacritty/alacritty"
+source = (
+    f"https://github.com/alacritty/alacritty/archive/refs/tags/v{pkgver}.tar.gz"
+)
+sha256 = "14bce0bfc538872c97e0e38b9233a9d1fa992dcf83a22b6035da5fe58a55bc6c"
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")
+    self.install_file(
+        "extra/completions/alacritty.bash",
+        "usr/share/bash-completion/completions",
+        name="alacritty",
+    )
+    self.install_file(
+        "extra/completions/_alacritty",
+        "usr/share/zsh/site-functions",
+    )
+    self.install_file(
+        "extra/completions/alacritty.fish",
+        "usr/share/fish/completions",
+    )
+    self.install_file("extra/linux/Alacritty.desktop", "usr/share/applications")
+    self.install_file(
+        "extra/linux/org.alacritty.Alacritty.appdata.xml",
+        "usr/share/metainfo/org.alacritty.Alacritty.appdata.xml",
+    )
+    self.install_file(
+        "extra/logo/alacritty-term.svg",
+        "usr/share/icons/hicolor/scalable/apps/",
+        name="Alacritty",
+    )

--- a/contrib/cargo-auditable-devel
+++ b/contrib/cargo-auditable-devel
@@ -1,0 +1,1 @@
+cargo-auditable

--- a/contrib/cargo-auditable/template.py
+++ b/contrib/cargo-auditable/template.py
@@ -1,0 +1,13 @@
+pkgname = "cargo-auditable"
+pkgver = "0.6.1"
+pkgrel = 0
+build_style = "cargo"
+make_install_args = ["--path", "cargo-auditable"]
+hostmakedepends = ["cargo"]
+makedepends = ["rust"]
+pkgdesc = "Cargo wrapper for embedding auditing data"
+maintainer = "nbfritch <nbfritch@gmail.com>"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/rust-secure-code/cargo-auditable"
+source = f"https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "091dc954c09408a9a2bdf1b01fa34f3e4bf7a7621966d2f4c4d5fc689a3baaf4"


### PR DESCRIPTION
This PR adds the alacritty terminal emulator and cargo-auditable, which it requires as a build dependency.
These patches have been verified to build and work on x86_64.

The build successfully completed on aarch64, but there is some problem rendering fonts when running.
