### PR TITLE
contrib/wireguard-tools: new package (1.0.20210914)

### DIFF
--- a/contrib/wireguard-tools-wg-quick
+++ b/contrib/wireguard-tools-wg-quick
@@ -1,0 +1,1 @@
+wireguard-tools

--- a/contrib/wireguard-tools/files/wg-quick-all
+++ b/contrib/wireguard-tools/files/wg-quick-all
@@ -1,0 +1,7 @@
+# wg-quick service
+
+type               = scripted
+command            = /usr/libexec/wg-quick-all up
+stop-command       = /usr/libexec/wg-quick-all down
+before             = pre-network.target
+depends-on         = init-done.target

--- a/contrib/wireguard-tools/files/wg-quick-all.sh
+++ b/contrib/wireguard-tools/files/wg-quick-all.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export PATH=/usr/bin
+set -e
+
+for cfg in /etc/wireguard/*.conf; do
+    [ -r "$cfg" ] || continue
+    wg-quick "$1" "${cfg}"
+done

--- a/contrib/wireguard-tools/patches/fix-wg-quick-stat.patch
+++ b/contrib/wireguard-tools/patches/fix-wg-quick-stat.patch
@@ -1,0 +1,11 @@
+--- a/src/wg-quick/linux.bash	2023-07-06 12:34:06.238940919 
++++ b/src/wg-quick/linux.bash	2023-07-06 12:33:43.997941426 
+@@ -44,7 +44,7 @@
+ 	[[ -e $CONFIG_FILE ]] || die "\`$CONFIG_FILE' does not exist"
+ 	[[ $CONFIG_FILE =~ (^|/)([a-zA-Z0-9_=+.-]{1,15})\.conf$ ]] || die "The config file must be a valid interface name, followed by .conf"
+ 	CONFIG_FILE="$(readlink -f "$CONFIG_FILE")"
+-	((($(stat -c '0%#a' "$CONFIG_FILE") & $(stat -c '0%#a' "${CONFIG_FILE%/*}") & 0007) == 0)) || echo "Warning: \`$CONFIG_FILE' is world accessible" >&2
++	((($(stat -f '0%#p' "$CONFIG_FILE") & $(stat -f '0%#p' "${CONFIG_FILE%/*}") & 0007) == 0)) || echo "Warning: \`$CONFIG_FILE' is world accessible" >&2
+ 	INTERFACE="${BASH_REMATCH[2]}"
+ 	shopt -s nocasematch
+ 	while read -r line || [[ -n $line ]]; do

--- a/contrib/wireguard-tools/template.py
+++ b/contrib/wireguard-tools/template.py
@@ -1,0 +1,56 @@
+pkgname = "wireguard-tools"
+pkgver = "1.0.20210914"
+pkgrel = 0
+build_style = "makefile"
+make_cmd = "gmake"
+make_dir = "src"
+make_install_args = [
+    "WITH_BASHCOMPLETION=yes",
+    "WITH_WGQUICK=yes",
+    "WITH_SYSTEMDUNITS=no",
+]
+hostmakedepends = ["gmake", "pkgconf", "bash"]
+makedepends = ["linux-headers"]
+checkdepends = ["clang-analyzer", "perl"]
+pkgdesc = "Next generation secure network tunnel - tools for configuration"
+maintainer = "flukey <flukey@vapourmail.eu>"
+license = "GPL-2.0-only"
+url = "https://www.wireguard.com"
+source = f"https://git.zx2c4.com/{pkgname}/snapshot/{pkgname}-{pkgver}.tar.xz"
+sha256 = "97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac"
+tool_flags = {
+    "CFLAGS": ['-DRUNSTATEDIR="/run"'],
+}
+hardening = ["vis", "cfi"]
+# requires gcc
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_dir("etc/wireguard", mode=0o700, empty=True)
+    self.install_file(
+        self.files_path / "wg-quick-all.sh",
+        "usr/libexec",
+        mode=0o755,
+        name="wg-quick-all",
+    )
+    self.install_service(self.files_path / "wg-quick-all")
+
+
+@subpackage("wireguard-tools-wg-quick")
+def _wgquick(self):
+    self.depends = [
+        f"{pkgname}={pkgver}-r{pkgrel}",
+        "bash",
+        "iproute2",
+        "openresolv",
+    ]
+    self.pkgdesc = f"{pkgdesc} (wg-quick script)"
+
+    return [
+        "etc/dinit.d/wg-quick-all",
+        "usr/bin/wg-quick",
+        "usr/libexec/wg-quick-all",
+        "usr/share/bash-completion/**/wg-quick",
+        "usr/share/man/man?/wg-quick.?",
+    ]


### PR DESCRIPTION
Some notes:

- Had to use `tool_flags` to fix a Makefile problem, hope this is correct
- Wasn't sure whether to use /run or /var/run as RUNSTATEDIR, upstream defaults to /var/run
- My wg-quick dinit service forces the user to use /etc/wireguard/wg0.conf as their config, systemd allows template units, e.g. the user could specify `systemd start wg-quick@myconfig`, but I don't see a way of doing that with dinit?
- wg-quick script can use either iptables or nftables to set its rules, it prefers nftables, but I'm not sure how to specify iptables OR nftables as a dependency