### PR TITLE
contrib/fdupes: new package (2.2.1)

### DIFF
--- a/contrib/fdupes/template.py
+++ b/contrib/fdupes/template.py
@@ -1,0 +1,17 @@
+pkgname = "fdupes"
+pkgver = "2.2.1"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_gen = []
+makedepends = ["ncurses-devel", "pcre2-devel"]
+pkgdesc = "Tool for identifying and/or deleting duplicate files"
+maintainer = "autumnontape <autumn@cyfox.net>"
+license = "MIT"
+url = "https://github.com/adrianlopezroche/fdupes"
+source = f"{url}/releases/download/v{pkgver}/fdupes-{pkgver}.tar.gz"
+sha256 = "846bb79ca3f0157856aa93ed50b49217feb68e1b35226193b6bc578be0c5698d"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("README")


### PR DESCRIPTION
Part 2 of 3 of tools for squishing Btrfs filesystems, though this one can be used for other purposes, too. I tried the package, and it works for me.

The license text is part of the README... I checked what other packages in cports do in that situation, and it looks like they just install the whole README to /usr/share/licenses, so I did that too.