### PR TITLE
contrib/compsize: new package (1.5)

### DIFF
--- a/contrib/compsize/template.py
+++ b/contrib/compsize/template.py
@@ -1,0 +1,24 @@
+pkgname = "compsize"
+pkgver = "1.5"
+pkgrel = 0
+build_style = "makefile"
+make_cmd = "gmake"
+hostmakedepends = ["gmake"]
+makedepends = ["linux-headers", "libbtrfs-devel"]
+pkgdesc = "Tool to find compression types and ratios of files in Btrfs"
+maintainer = "autumnontape <autumn@cyfox.net>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/kilobyte/compsize"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "8b15b528f6cf95ff99d2ddfd7bce87271fd1356c875e5f5895ed83caf6952535"
+hardening = ["vis", "cfi"]
+# no test suite exists
+options = ["!check"]
+
+
+# the makefile's install rule has problems with trying to
+# use directories that don't exist, and these are the only
+# two files it installs anyway, so we do it ourselves
+def do_install(self):
+    self.install_bin("compsize")
+    self.install_man("compsize.8")


### PR DESCRIPTION
Part 3 of 3 of tools for squishing Btrfs filesystems. I tried the package, and it works for me.

Defining `do_install` seemed cleaner to me, but the make install rule could probably be coerced into working.