### PR TITLE
contrib/duperemove: update to 0.12

### DIFF
--- a/contrib/duperemove/patches/dont-require-git.patch
+++ b/contrib/duperemove/patches/dont-require-git.patch
@@ -1,0 +1,14 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,5 @@
+-VERSION=$(shell git describe --abbrev=4 --dirty --always --tags;)
+-ifeq ($(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;), 0)
+-	IS_RELEASE=1
+-else
+-	IS_RELEASE=0
+-endif
++VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags;)
++IS_RELEASE ?= $(if $(filter $(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;),0),1,0)
+ 
+ CC ?= gcc
+ CFLAGS ?= -Wall -ggdb

--- a/contrib/duperemove/template.py
+++ b/contrib/duperemove/template.py
@@ -1,8 +1,12 @@
 pkgname = "duperemove"
-pkgver = "0.11.3"
+pkgver = "0.12"
 pkgrel = 0
 build_style = "makefile"
 make_cmd = "gmake"
+make_build_env = {
+    "VERSION": f"v{pkgver}",
+    "IS_RELEASE": "1",
+}
 make_install_args = ["SBINDIR=/usr/bin"]
 hostmakedepends = ["gmake", "pkgconf"]
 makedepends = ["glib-devel", "sqlite-devel", "linux-headers"]
@@ -11,7 +15,8 @@ maintainer = "autumnontape <autumn@cyfox.net>"
 license = "GPL-2.0-only AND BSD-2-Clause"
 url = "https://github.com/markfasheh/duperemove"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "4161e6a7e9b53bb2c190e48eba0aa3028aca27874751aec351550dbae4964da0"
+sha256 = "53c0e1526d8bdb16ff18ad8a417570c829f8a11dea27060061c73dd6387326f4"
+tool_flags = {"CFLAGS": ["-std=gnu2x"]}
 hardening = ["vis", "cfi"]
 # no test suite exists
 options = ["!check"]


### PR DESCRIPTION
`-std=gnu2x` is required for `[[maybe_unused]]`. I'll submit the Makefile patch upstream as well.