### PR TITLE
main/base-cbuild-host: add python to dependencies

### DIFF
--- a/main/base-cbuild-host/template.py
+++ b/main/base-cbuild-host/template.py
@@ -1,8 +1,15 @@
 pkgname = "base-cbuild-host"
 pkgver = "0.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meta"
-depends = ["apk-tools", "openssl", "git", "bubblewrap", "chimerautils"]
+depends = [
+    "apk-tools",
+    "openssl",
+    "git",
+    "bubblewrap",
+    "chimerautils",
+    "python",
+]
 pkgdesc = "Everything one needs to use cbuild and cports"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "custom:meta"


### PR DESCRIPTION
Without Python as a dependency, the procedure documented in the documentation to install this package to pull in all of cbuild's dependencies is incorrect.