### PR TITLE
contrib/qemu-user: page-align initial brk(0)

### DIFF
--- a/contrib/qemu-user/template.py
+++ b/contrib/qemu-user/template.py
@@ -1,6 +1,6 @@
 pkgname = "qemu-user"
 pkgver = "8.0.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 # TODO vde liburing libssh capstone
 configure_args = [

--- a/contrib/qemu/patches/fix-brk0.patch
+++ b/contrib/qemu/patches/fix-brk0.patch
@@ -1,0 +1,30 @@
+From d28b3c90cfad1a7e211ae2bce36ecb9071086129 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Thu, 6 Jul 2023 13:34:19 +0200
+Subject: [PATCH] linux-user: Make sure initial brk(0) is page-aligned
+
+Fixes: 86f04735ac ("linux-user: Fix brk() to release pages")
+Signed-off-by: Andreas Schwab <schwab@suse.de>
+Message-Id: <mvmpm55qnno.fsf@suse.de>
+Reviewed-by: Richard Henderson <richard.henderson@linaro.org>
+Signed-off-by: Richard Henderson <richard.henderson@linaro.org>
+---
+ linux-user/syscall.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index b78eb686d8..02d3b6c90a 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -806,7 +806,7 @@ static abi_ulong brk_page;
+ 
+ void target_set_brk(abi_ulong new_brk)
+ {
+-    target_brk = new_brk;
++    target_brk = TARGET_PAGE_ALIGN(new_brk);
+     brk_page = HOST_PAGE_ALIGN(target_brk);
+ }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
This fixes running practically anything on an older musl env like Void Linux aarch64 under x86_64 host; the following is an example test:
```
fetch https://repo-default.voidlinux.org/live/current/void-aarch64-musl-ROOTFS-20230628.tar.xz
mkdir rootfs && tar xf void-aarch64-musl-ROOTFS-20230628.tar.xz -C rootfs && doas chroot rootfs /bin/ls
```