### PR TITLE
contrib/wl-clipboard: new package (2.2.0)

### DIFF
--- a/contrib/wl-clipboard/template.py
+++ b/contrib/wl-clipboard/template.py
@@ -1,0 +1,18 @@
+pkgname = "wl-clipboard"
+pkgver = "2.2.0"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = [
+    "meson",
+    "pkgconf",
+    "wayland-progs",
+]
+makedepends = ["wayland-devel", "wayland-protocols"]
+depends = ["xdg-utils"]
+pkgdesc = "Command-line copy/paste utilities for Wayland"
+maintainer = "Wesley Moore <wes@wezm.net>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/bugaevc/wl-clipboard"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "414005cfa229d0e54f89a0d9a8473938e4c29adc21a9e556847a4d44ad508874"
+hardening = ["vis", "!cfi"]


### PR DESCRIPTION
I marked cfi as not enabled as the tool crashes with Illegal instruction when enabled.

Is there a way to capture optional dependencies? Looking through the docs and templates it appears not. `wl-clipboard` is an optional dependency of Neovim. When present it enables yank/paste from the system clipboard. `wl-clipboard` itself has [optional runtime dependencies](https://github.com/bugaevc/wl-clipboard/blob/master/BUILDING.md) on `xdg-utils` and `/etc/mime.types` (doesn't look like we have a package providing that so far).