### PR TITLE
contrib/tig: fix intermittent overflow and crash

### DIFF
--- a/contrib/tig/patches/fix-overflow.patch
+++ b/contrib/tig/patches/fix-overflow.patch
@@ -1,0 +1,29 @@
+commit a1ef9815fcdc029755ec8a07c2c1be01684245d6
+Author: Wesley Moore <wes@wezm.net>
+Date:   Tue Aug 1 20:48:26 2023 +1000
+
+    Initialise struct timezone
+    
+    On musl libc gettimeofday (which is used by time_now) does not
+    populate the timezone struct passed to it as POSIX says:
+    
+    > If tzp is not a null pointer, the behavior is unspecified.
+    
+    tz_minuteswest is later multiplied by 60 which can overflow. When tig
+    is compiled with integer overflow hardening (as is done on Chimera
+    Linux) via the clang option -fsanitize=signed-integer-overflow this can
+    result in tig crashing due to the overflow.
+
+diff --git a/src/main.c b/src/main.c
+index 2401295..d9b5f61 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -122,7 +122,7 @@ main_add_changes_commit(struct view *view, enum line_type type, const char *pare
+ 	struct graph *graph = state->graph;
+ 	struct commit commit = {{0}};
+ 	struct timeval now;
+-	struct timezone tz;
++	struct timezone tz = {0};
+ 
+ 	if (!parent)
+ 		return true;

--- a/contrib/tig/template.py
+++ b/contrib/tig/template.py
@@ -1,6 +1,6 @@
 pkgname = "tig"
 pkgver = "2.5.8"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 make_dir = "."


### PR DESCRIPTION
Adds a patch to prevent an intermittent crash. `gettimeofday` doesn't populate the tz argument, tig multiplies the unintialized value by 60, which can overflow triggering a crash due to the `int` hardening option (`-fsanitize=signed-integer-overflow,integer-divide-by-zero`). I submitted it upstream but the repo hasn't shown a lot of activity lately so might take a while to make it into a release. https://github.com/jonas/tig/pull/1291