### PR TITLE
contrib/foot: update to 1.15.2

### DIFF
--- a/contrib/foot/template.py
+++ b/contrib/foot/template.py
@@ -1,5 +1,5 @@
 pkgname = "foot"
-pkgver = "1.14.0"
+pkgver = "1.15.2"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -26,7 +26,7 @@ maintainer = "flukey <flukey@vapourmail.eu>"
 license = "MIT"
 url = "https://codeberg.org/dnkl/foot"
 source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "9a306951bc6bdce150364bccb0fb4b67720f50e98e9ac1de89792c1c1aa30690"
+sha256 = "914b883589cc8790030f85cbbc3b3e12685988189305017d4e32babde459b7bd"
 hardening = ["vis", "cfi"]
 
 


### PR DESCRIPTION
https://codeberg.org/dnkl/foot/releases/tag/1.15.0  
https://codeberg.org/dnkl/foot/releases/tag/1.15.1  
https://codeberg.org/dnkl/foot/releases/tag/1.15.2

there's utmp-backend options now, but they're not that relevant