### PR TITLE
contrib/nicotine-plus: new package (3.2.9)

### DIFF
--- a/contrib/nicotine-plus/template.py
+++ b/contrib/nicotine-plus/template.py
@@ -1,0 +1,29 @@
+pkgname = "nicotine-plus"
+pkgver = "3.2.9"
+pkgrel = 0
+build_style = "python_pep517"
+make_check_target = "test/unit"
+hostmakedepends = [
+    "gettext-tiny",
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
+checkdepends = [
+    "python-pytest",
+    "python-semidbm",
+]
+depends = [
+    "gtk+3",
+    "python-gobject",
+    "python-semidbm",
+]
+pkgdesc = "Graphical client for the Soulseek network"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-3.0-or-later"
+url = "https://nicotine-plus.github.io/nicotine-plus"
+source = (
+    f"https://github.com/Nicotine-Plus/nicotine-plus/archive/{pkgver}.tar.gz"
+)
+sha256 = "aeaf45742a915345d1635f36ca334c3f332788c7a27262408be9998985f99e41"

--- a/contrib/python-semidbm/template.py
+++ b/contrib/python-semidbm/template.py
@@ -1,0 +1,23 @@
+pkgname = "python-semidbm"
+pkgver = "0.5.1"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
+checkdepends = [
+    "python-pytest",
+]
+pkgdesc = "DBM interface for Python"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "BSD-3-Clause"
+url = "https://github.com/jamesls/semidbm"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "d1f10454d4f80d682e25964e93cc798df7a249efcb7eb8d5ebe71b104b34e77e"
+
+
+def post_install(self):
+    self.install_license("COPYING")


### PR DESCRIPTION
semidbm is some ancient thing, but the other alternative is python-gdbm by adding gdbm to python itself (it's technically splittable but iirc the .so still links it so i don't think it's possible with -z now (?))