### PR TITLE
contrib/qbittorrent: new package (4.5.4)

### DIFF
--- a/contrib/qbittorrent/template.py
+++ b/contrib/qbittorrent/template.py
@@ -1,0 +1,33 @@
+pkgname = "qbittorrent"
+pkgver = "4.5.4"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DQT6=ON",
+    "-DSTACKTRACE=OFF",
+]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "qt6-qtbase",
+    "qt6-qttools",
+]
+makedepends = [
+    "boost-devel",
+    "libtorrent-rasterbar-devel",
+    "openssl-devel",
+    "qt6-qtbase-devel",
+    "qt6-qttools-devel",
+    "qt6-qtsvg-devel",
+]
+depends = ["qt6-qtsvg"]
+pkgdesc = "QT-based torrent client"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-2.0-or-later"
+url = "https://www.qbittorrent.org"
+source = f"https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-{pkgver}.tar.gz"
+sha256 = "ded3a1ffba1e97ecde3862714bea9e9a1cc7275c29545d81976174ac5760bab5"
+# FIXME: BitTorrent::SessionImpl::SessionImpl cfi crash
+hardening = ["vis"]
+# don't build
+options = ["!check"]

--- a/contrib/qbittorrent/update.py
+++ b/contrib/qbittorrent/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/qbittorrent/qBittorrent/tags"
+pattern = r"/tags/release-([0-9.]+).tar.gz"


### PR DESCRIPTION
what doesn't work (daemon, not here anymore):

- daemon doesn't actually start:
  `alert : Could not create required directory '/.cache/qBittorrent'`
  the working-dir chroots to /var/lib/qbittorrent and i assume something goes wrong here with the mkdir from the daemon itself after (it uses cwd as home)..

- the group is on the wrong package
  the _qbittorrent user/group should only be on -nox, but it doesn't work to put it there with self.system_users, and you get `chown: _qbittorrent: illegal group name`