### PR TITLE
contrib/cvise: new package (2.8.0)

### DIFF
--- a/contrib/cvise/template.py
+++ b/contrib/cvise/template.py
@@ -1,0 +1,40 @@
+pkgname = "cvise"
+pkgver = "2.8.0"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = [
+    "clang-tools-extra",
+    "cmake",
+    "flex",
+    "ninja",
+]
+makedepends = [
+    "clang-devel",
+    "llvm-devel",
+]
+depends = [
+    "clang",
+    "python-chardet",
+    "python-pebble",
+    "python-psutil",
+    "unifdef",
+]
+checkdepends = depends + [
+    "python-pytest",
+]
+pkgdesc = "Python port of C-Reduce, for program testcase minimisation"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "NCSA"
+url = "https://github.com/marxin/cvise"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "cb0bd15885b18b4e79be216c6ca7bed546defc0e9b533d6103868580c690a1a1"
+
+
+def do_check(self):
+    # this one test fails but everything else is fine
+    self.do("pytest", "-k", "not test_simple_reduction", wrksrc=self.make_dir)
+
+
+def post_install(self):
+    self.install_license("COPYING")
+    self.rm(self.destdir / "usr/share/cvise/tests", recursive=True)

--- a/contrib/python-pebble/template.py
+++ b/contrib/python-pebble/template.py
@@ -1,0 +1,19 @@
+pkgname = "python-pebble"
+pkgver = "5.0.3"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
+checkdepends = [
+    "python-pytest",
+]
+pkgdesc = "Multi-threading and processing for python"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "LGPL-3.0-or-later"
+url = "https://github.com/noxdafox/pebble"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "c85b91ab752900c9a857a7ecd8981a5efa41918e50a4b52c20e69964b3d3dac3"


### PR DESCRIPTION
this links libclang/libllvm, but is actively maintained and is already 17-compatible on master with minor changes, so it doesn't block the toolchain