### PR TITLE
cbuild: use -v instead of -x for go build

### DIFF
--- a/src/cbuild/util/golang.py
+++ b/src/cbuild/util/golang.py
@@ -85,7 +85,7 @@ class Golang:
         return self._invoke("mod", ["download"], 1, False, None, env, wrksrc)
 
     def build(self, args=[], jobs=None, env={}, wrksrc=None):
-        myargs = ["-x"]  # increase go verbosity
+        myargs = ["-v"]  # increase go verbosity
 
         tags = self.template.go_build_tags
 


### PR DESCRIPTION
-v prints each module that gets compiled, -x spams the fuck out of the logs with a thousand lines of output for anything