### PR TITLE
contrib/alacritty: new package (0.12.2)

### DIFF
--- a/contrib/alacritty-terminfo
+++ b/contrib/alacritty-terminfo
@@ -1,0 +1,1 @@
+alacritty

--- a/contrib/alacritty/template.py
+++ b/contrib/alacritty/template.py
@@ -1,0 +1,45 @@
+pkgname = "alacritty"
+pkgver = "0.12.2"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo", "cmake", "pkgconf", "python", "ncurses"]
+makedepends = ["fontconfig-devel", "freetype-devel", "libxcb-devel", "rust"]
+depends = [f"alacritty-terminfo={pkgver}-r{pkgrel}"]
+pkgdesc = "Cross-platform, GPU-accelerated terminal emulator"
+maintainer = "nbfritch <nbfritch@gmail.com>"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/alacritty/alacritty"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "285b44d2d2e83118ab7fe61d575811bb85d5e21147808171bd0e583e9e794748"
+
+
+def do_install(self):
+    self.cargo.install(wrksrc="alacritty")
+    self.install_man("extra/alacritty.man", name="alacritty", cat=1)
+    self.install_man("extra/alacritty-msg.man", name="alacritty-msg", cat=1)
+    self.install_license("LICENSE-MIT")
+    self.install_completion("extra/completions/alacritty.bash", "bash")
+    self.install_completion("extra/completions/alacritty.fish", "fish")
+    self.install_completion("extra/completions/_alacritty", "zsh")
+    self.install_file("extra/linux/Alacritty.desktop", "usr/share/applications")
+    self.install_file(
+        "extra/logo/alacritty-term.svg",
+        "usr/share/icons/hicolor/scalable/apps/",
+        name="Alacritty.svg",
+    )
+    self.install_dir("usr/share/terminfo")
+    self.do(
+        "tic",
+        "-xe",
+        "alacritty,alacritty-direct",
+        "-o",
+        self.chroot_destdir / "usr/share/terminfo",
+        "extra/alacritty.info",
+    )
+
+
+@subpackage("alacritty-terminfo")
+def _tinfo(self):
+    self.pkgdesc = f"{pkgdesc} (terminfo data)"
+
+    return ["usr/share/terminfo"]


### PR DESCRIPTION
This is a continuation of #204 I've bumped it to the latest release, slimmed down the dependencies, added man pages and terminfo, and updated it to use `install_completion`.

I'm having trouble with cross-compilation though. I'm getting a lot of errors such as these but I'm not sure what's different with this codebase to other Rust ones I've packaged:

```
error[E0463]: can't find crate for `core`
  |
  = note: the `aarch64-chimera-linux-musl` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-chimera-linux-musl`

error[E0463]: can't find crate for `compiler_builtins`

For more information about this error, try `rustc --explain E0463`.
error[E0463]: can't find crate for `core`
 --> /builddir/alacritty-0.12.2/vendor/lazy_static/src/inline_lazy.rs:8:1
  |
8 | extern crate core;
  | ^^^^^^^^^^^^^^^^^^ can't find crate
  |
  = note: the `aarch64-chimera-linux-musl` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-chimera-linux-musl`

error[E0463]: can't find crate for `std`
 --> /builddir/alacritty-0.12.2/vendor/lazy_static/src/inline_lazy.rs:9:1
  |
9 | extern crate std;
  | ^^^^^^^^^^^^^^^^^ can't find crate
  |
  = note: the `aarch64-chimera-linux-musl` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-chimera-linux-musl`
```