### PR TITLE
contrib/intel-media-driver: new package (23.3.1)

### DIFF
--- a/contrib/intel-gmmlib-devel
+++ b/contrib/intel-gmmlib-devel
@@ -1,0 +1,1 @@
+intel-gmmlib

--- a/contrib/intel-gmmlib/template.py
+++ b/contrib/intel-gmmlib/template.py
@@ -1,0 +1,30 @@
+pkgname = "intel-gmmlib"
+pkgver = "22.3.9"
+pkgrel = 0
+# supported platforms
+archs = ["aarch64", "x86_64"]
+build_style = "cmake"
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+]
+pkgdesc = "Intel Graphics Memory Management Library"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "MIT"
+url = "https://github.com/intel/gmmlib"
+source = f"https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-{pkgver}.tar.gz"
+sha256 = "62d2f8333f1da3361952546a83dd40d1eb23d8bddacf67a160e63f565b68b5a6"
+# FIXME: cfi testsuite sigill
+hardening = ["vis"]
+# check cross: testsuite runs as part of install(), disabling that also doesn't build it..
+options = ["!check", "!cross"]
+
+
+def post_install(self):
+    self.install_license("LICENSE.md")
+
+
+@subpackage("intel-gmmlib-devel")
+def _devel(self):
+    return self.default_devel()

--- a/contrib/intel-gmmlib/update.py
+++ b/contrib/intel-gmmlib/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/intel/gmmlib/tags"
+pattern = r">intel-gmmlib-([\d.]+)<"

--- a/contrib/intel-media-driver-devel
+++ b/contrib/intel-media-driver-devel
@@ -1,0 +1,1 @@
+intel-media-driver

--- a/contrib/intel-media-driver/template.py
+++ b/contrib/intel-media-driver/template.py
@@ -1,0 +1,41 @@
+pkgname = "intel-media-driver"
+pkgver = "23.3.1"
+pkgrel = 0
+# doesn't build elsewhere
+archs = ["x86_64"]
+build_style = "cmake"
+configure_args = [
+    "-DINSTALL_DRIVER_SYSCONF=OFF",
+    "-DMEDIA_BUILD_FATAL_WARNINGS=OFF",
+]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+]
+makedepends = [
+    "intel-gmmlib-devel",
+    "libpciaccess-devel",
+    "libva-devel",
+    "libx11-devel",
+    "linux-headers",
+]
+pkgdesc = "Intel Media Driver for VAAPI"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "BSD-3-Clause"
+url = "https://github.com/intel/media-driver"
+source = f"https://github.com/intel/media-driver/archive/refs/tags/intel-media-{pkgver}.tar.gz"
+sha256 = "ce929da08ea917e4bb133ae67b5de42dce9c459b06a2670358a6ada00c48db58"
+# FIXME: cfi
+hardening = ["vis"]
+# no tests
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE.md")
+
+
+@subpackage("intel-media-driver-devel")
+def _devel(self):
+    return self.default_devel()

--- a/contrib/intel-media-driver/update.py
+++ b/contrib/intel-media-driver/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/intel/media-driver/tags"
+pattern = r">intel-media-([\d.]+)<"


### PR DESCRIPTION
mostly just pulled from https://github.com/chimera-linux/cports/pull/153, since this is needed for vaapi decode, the rest is for the "encode" capabilities