### PR TITLE
contrib/execline: new package (2.9.3.0)

### DIFF
--- a/contrib/execline-devel
+++ b/contrib/execline-devel
@@ -1,0 +1,1 @@
+execline

--- a/contrib/execline/template.py
+++ b/contrib/execline/template.py
@@ -1,0 +1,33 @@
+pkgname = "execline"
+pkgver = "2.9.3.0"
+pkgrel = 0
+build_style = "configure"
+configure_args = [
+    "--prefix=/usr",
+    "--disable-allstatic",
+    "--enable-multicall",
+    "--enable-shared",
+    "--libdir=/usr/lib",
+]
+make_cmd = "gmake"
+hostmakedepends = ["gmake"]
+makedepends = ["skalibs-devel"]
+pkgdesc = "Small non-interactive scripting language"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "ISC"
+url = "https://skarnet.org/software/execline"
+source = f"https://skarnet.org/software/execline/execline-{pkgver}.tar.gz"
+sha256 = "c8027fa70922d117cdee8cc20d277e38d03fd960e6d136d8cec32603d4ec238d"
+# vis breaks symbols
+hardening = []
+# no tests
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("COPYING")
+
+
+@subpackage("execline-devel")
+def _devel(self):
+    return self.default_devel()

--- a/contrib/skalibs-devel
+++ b/contrib/skalibs-devel
@@ -1,0 +1,1 @@
+skalibs

--- a/contrib/skalibs/template.py
+++ b/contrib/skalibs/template.py
@@ -1,0 +1,29 @@
+pkgname = "skalibs"
+pkgver = "2.13.1.1"
+pkgrel = 0
+build_style = "configure"
+configure_args = [
+    "--dynlibdir=/usr/lib",
+    "--libdir=/usr/lib",
+]
+make_cmd = "gmake"
+hostmakedepends = ["gmake"]
+pkgdesc = "Set of general-purpose C programming libraries for skarnet software"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "ISC"
+url = "https://skarnet.org/software/skalibs"
+source = f"https://skarnet.org/software/skalibs/skalibs-{pkgver}.tar.gz"
+sha256 = "b272a1ab799f7fac44b9b4fb5ace78a9616b2fe4882159754b8088c4d8199e33"
+# vis breaks symbols
+hardening = []
+# no tests
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("COPYING")
+
+
+@subpackage("skalibs-devel")
+def _devel(self):
+    return self.default_devel()


### PR DESCRIPTION
funnily this squats things like /usr/bin/cd, but nothing actually puts anything in such names since they are shell builtins. probably safe?