### PR TITLE
contrib/zoxide: update to 0.9.2

### DIFF
--- a/contrib/zoxide/patches/remove-gnu-ls-arg.patch
+++ b/contrib/zoxide/patches/remove-gnu-ls-arg.patch
@@ -1,0 +1,11 @@
+--- zoxide-0.9.2/src/util.rs	2023-08-04 12:27:38.000000000 +1000
++++ zoxide-0.9.2-patched/src/util.rs	2023-08-14 09:14:16.966394108 +1000
+@@ -60,7 +60,7 @@
+         self.args([
+             // Non-POSIX args are only available on certain operating systems.
+             if cfg!(target_os = "linux") {
+-                r"--preview=\command -p ls -Cp --color=always --group-directories-first {2..}"
++                r"--preview=\command -p ls -Cp --color=always {2..}"
+             } else {
+                 r"--preview=\command -p ls -Cp {2..}"
+             },

--- a/contrib/zoxide/template.py
+++ b/contrib/zoxide/template.py
@@ -1,5 +1,5 @@
 pkgname = "zoxide"
-pkgver = "0.9.1"
+pkgver = "0.9.2"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo"]
@@ -9,7 +9,7 @@ maintainer = "aurelia <git@elia.garden>"
 license = "MIT"
 url = "https://github.com/ajeetdsouza/zoxide"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "7af5965e0f0779a5ea9135ee03c51b1bb1d84b578af0a7eb2bd13dbf34a342dd"
+sha256 = "a6c2d993a02211c3d23b242c2c6faab9a2648be7a45ad1ff0586651ac827e914"
 
 
 def post_install(self):


### PR DESCRIPTION
Update to the new release https://github.com/ajeetdsouza/zoxide/releases/tag/v0.9.2

I also fixed the interactive preview. It was passing an unsupported argument to `ls` resulting in the following in the preview window:

```
│ ┌───────────────────────────────────────────────────────────────────────────────────────────────────┐│
│ │ ls: unrecognized option: group-directories-first                                                  ││
│ │ usage: ls [-ABCFGHILPRSTabcdfghiklmnpqrstuvwxy1,] [--color=when] [-D format] [file ...]           ││
│ │                                                                                                   ││
│ └───────────────────────────────────────────────────────────────────────────────────────────────────┘│
```