### PR TITLE
contrib/fonts-tex-gyre-otf: new package (2.501)

### DIFF
--- a/contrib/fonts-tex-gyre-otf/template.py
+++ b/contrib/fonts-tex-gyre-otf/template.py
@@ -1,0 +1,13 @@
+pkgname = "fonts-tex-gyre-otf"
+pkgver = "2.501"
+pkgrel = 0
+pkgdesc = "TeX Gyre Collection of Fonts"
+maintainer = "Wesley Moore <wes@wezm.net>"
+license = "OFL-1.1"
+url = "https://www.gust.org.pl/projects/e-foundry/tex-gyre/index_html"
+source = f"https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg{pkgver.replace('.', '_')}otf.zip"
+sha256 = "d7f8be5317bec4e644cf16c5abf876abeeb83c43dbec0ccb4eee4516b73b1bbe"
+
+
+def do_install(self):
+    self.install_file("*.otf", "usr/share/fonts/tex-gyre", glob=True)

--- a/contrib/fonts-tex-gyre-otf/update.py
+++ b/contrib/fonts-tex-gyre-otf/update.py
@@ -1,0 +1,2 @@
+url = "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+pattern = r"tg([\d_]+)otf\.zip"


### PR DESCRIPTION
This collection of fonts provides well designed alternatives to some common proprietary fonts/base PostScript fonts such as Helvetica, Palatino, Times, and Century Schoolbook.

~~Had to disable the update check, don't think there's a way to automate it.~~