### PR TITLE
contrib/notmuch: disable cfi

### DIFF
--- a/contrib/notmuch/template.py
+++ b/contrib/notmuch/template.py
@@ -1,6 +1,6 @@
 pkgname = "notmuch"
 pkgver = "0.37"
-pkgrel = 1
+pkgrel = 2
 build_style = "configure"
 configure_args = ["--prefix=/usr"]
 make_cmd = "gmake"
@@ -22,7 +22,8 @@ license = "GPL-3.0-or-later"
 url = "https://notmuchmail.org"
 source = f"{url}/releases/notmuch-{pkgver}.tar.xz"
 sha256 = "0e766df28b78bf4eb8235626ab1f52f04f1e366649325a8ce8d3c908602786f6"
-hardening = ["vis", "cfi"]
+# FIXME: cfi
+hardening = ["vis"]
 # FIXME: they hang forever, after failing a test for -v not silencing output in harness
 options = ["!check"]
 


### PR DESCRIPTION
crashes when importing new