### PR TITLE
main/pipewire: update to 0.3.78

### DIFF
--- a/main/pipewire/template.py
+++ b/main/pipewire/template.py
@@ -1,5 +1,5 @@
 pkgname = "pipewire"
-pkgver = "0.3.77"
+pkgver = "0.3.78"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -69,7 +69,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://pipewire.org"
 source = f"https://gitlab.freedesktop.org/{pkgname}/{pkgname}/-/archive/{pkgver}/{pkgname}-{pkgver}.tar.gz"
-sha256 = "7e405d84cf3535d1f1a5fff01c13b2cb7f420b1a9242469d56ac8fd5b2f36139"
+sha256 = "fea26577d41ef74f34932aeba4ccdc7813605f4734b66e17dc96b8b9032b7087"
 # FIXME int: e.g. https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2968
 hardening = ["!int"]
 


### PR DESCRIPTION
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.78