### PR TITLE
contrib/linux-tools: new package (6.4.12)

### DIFF
--- a/contrib/cpupower
+++ b/contrib/cpupower
@@ -1,0 +1,1 @@
+linux-tools

--- a/contrib/libcpupower
+++ b/contrib/libcpupower
@@ -1,0 +1,1 @@
+linux-tools

--- a/contrib/libcpupower-devel
+++ b/contrib/libcpupower-devel
@@ -1,0 +1,1 @@
+linux-tools

--- a/contrib/linux-tools/patches/install.patch
+++ b/contrib/linux-tools/patches/install.patch
@@ -1,0 +1,36 @@
+diff --git a/tools/power/cpupower/Makefile b/tools/power/cpupower/Makefile
+index 59bfa05de..c658d3d4f 100644
+--- a/tools/power/cpupower/Makefile
++++ b/tools/power/cpupower/Makefile
+@@ -289,19 +289,20 @@ install-tools: $(OUTPUT)cpupower
+ 	$(INSTALL_SCRIPT) cpupower-completion.sh '$(DESTDIR)${bash_completion_dir}/cpupower'
+ 
+ install-man:
+-	$(INSTALL_DATA) -D man/cpupower.1 $(DESTDIR)${mandir}/man1/cpupower.1
+-	$(INSTALL_DATA) -D man/cpupower-frequency-set.1 $(DESTDIR)${mandir}/man1/cpupower-frequency-set.1
+-	$(INSTALL_DATA) -D man/cpupower-frequency-info.1 $(DESTDIR)${mandir}/man1/cpupower-frequency-info.1
+-	$(INSTALL_DATA) -D man/cpupower-idle-set.1 $(DESTDIR)${mandir}/man1/cpupower-idle-set.1
+-	$(INSTALL_DATA) -D man/cpupower-idle-info.1 $(DESTDIR)${mandir}/man1/cpupower-idle-info.1
+-	$(INSTALL_DATA) -D man/cpupower-set.1 $(DESTDIR)${mandir}/man1/cpupower-set.1
+-	$(INSTALL_DATA) -D man/cpupower-info.1 $(DESTDIR)${mandir}/man1/cpupower-info.1
+-	$(INSTALL_DATA) -D man/cpupower-monitor.1 $(DESTDIR)${mandir}/man1/cpupower-monitor.1
+-	$(INSTALL_DATA) -D man/cpupower-powercap-info.1 $(DESTDIR)${mandir}/man1/cpupower-powercap-info.1
++	$(INSTALL) -d $(DESTDIR)${mandir}/man1/
++	$(INSTALL_DATA) man/cpupower.1 $(DESTDIR)${mandir}/man1/cpupower.1
++	$(INSTALL_DATA) man/cpupower-frequency-set.1 $(DESTDIR)${mandir}/man1/cpupower-frequency-set.1
++	$(INSTALL_DATA) man/cpupower-frequency-info.1 $(DESTDIR)${mandir}/man1/cpupower-frequency-info.1
++	$(INSTALL_DATA) man/cpupower-idle-set.1 $(DESTDIR)${mandir}/man1/cpupower-idle-set.1
++	$(INSTALL_DATA) man/cpupower-idle-info.1 $(DESTDIR)${mandir}/man1/cpupower-idle-info.1
++	$(INSTALL_DATA) man/cpupower-set.1 $(DESTDIR)${mandir}/man1/cpupower-set.1
++	$(INSTALL_DATA) man/cpupower-info.1 $(DESTDIR)${mandir}/man1/cpupower-info.1
++	$(INSTALL_DATA) man/cpupower-monitor.1 $(DESTDIR)${mandir}/man1/cpupower-monitor.1
++	$(INSTALL_DATA) man/cpupower-powercap-info.1 $(DESTDIR)${mandir}/man1/cpupower-powercap-info.1
+ 
+ install-gmo: create-gmo
+ 	$(INSTALL) -d $(DESTDIR)${localedir}
+ 	for HLANG in $(LANGUAGES); do \
+ 		echo '$(INSTALL_DATA) -D $(OUTPUT)po/$$HLANG.gmo $(DESTDIR)${localedir}/$$HLANG/LC_MESSAGES/cpupower.mo'; \
+ 		$(INSTALL_DATA) -D $(OUTPUT)po/$$HLANG.gmo $(DESTDIR)${localedir}/$$HLANG/LC_MESSAGES/cpupower.mo; \
+ 	done;
+ 
+ install-bench: compile-bench

--- a/contrib/linux-tools/template.py
+++ b/contrib/linux-tools/template.py
@@ -1,0 +1,77 @@
+pkgname = "linux-tools"
+pkgver = "6.4.12"
+pkgrel = 0
+build_style = "makefile"
+make_cmd = "gmake"
+_make_args = [
+    "-C",
+    "tools",
+    # FIXME: cpufreq-bench is completely broken with optimisations because of
+    # int UB that gets optimised out and then breaks in div-by-zero
+    "CPUFREQ_BENCH=0",
+    "LLVM=1",
+    "NLS=false",
+    "WERROR=0",
+    "libdir=/usr/lib",
+    "mandir=/usr/share/man",
+    "prefix=/usr",
+    "sbindir=/usr/bin",
+]
+make_build_target = ""
+make_build_args = _make_args + [
+    "cpupower",
+]
+make_install_target = ""
+make_install_args = _make_args + [
+    "cpupower_install",
+]
+hostmakedepends = [
+    "gmake",
+]
+makedepends = [
+    "linux-headers",
+    "pciutils-devel",
+]
+pkgdesc = "Linux Kernel userspace tools"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-2.0-only"
+url = "https://www.kernel.org"
+source = f"https://cdn.kernel.org/pub/linux/kernel/v{pkgver[:pkgver.find('.')]}.x/linux-{pkgver}.tar.xz"
+sha256 = "cca91be956fe081f8f6da72034cded96fe35a50be4bfb7e103e354aa2159a674"
+# vis breaks everything
+hardening = []
+# nah 💀
+options = ["!check"]
+
+
+def init_build(self):
+    self.make_build_args += [f"CC={self.get_tool('CC')}"]
+
+
+@subpackage("cpupower")
+def _cpupower(self):
+    self.pkgdesc = "Linux standard cpu power management tool"
+    return [
+        "usr/bin/cpupower",
+        "usr/share/bash-completion/completions/cpupower",
+        "usr/share/man/man1/cpupower*",
+    ]
+
+
+@subpackage("libcpupower")
+def _libcpupower(self):
+    self.pkgdesc = "Linux cpupower library"
+    return [
+        "usr/lib/libcpupower.so.*",
+    ]
+
+
+@subpackage("libcpupower-devel")
+def _libcpupower_devel(self):
+    self.pkgdesc = "Linux cpupower library (development files)"
+    return [
+        "usr/include/cpufreq.h",
+        "usr/include/cpuidle.h",
+        "usr/include/powercap.h",
+        "usr/lib/libcpupower.*",
+    ]


### PR DESCRIPTION
starting with cpupower only because it's at least easy to build

of course, linux-tools itself will remain empty since everything should be neatly split