### PR TITLE
main/gtk4: make ignore pattern more concise and future-proof

### DIFF
--- a/main/gtk4/update.py
+++ b/main/gtk4/update.py
@@ -1,3 +1,3 @@
 url = "https://gitlab.gnome.org/GNOME/gtk/-/tags"
 pkgname = "gtk"
-ignore = ["4.[79].*", "4.11.*", "4.13.*", "4.15.*"]
+ignore = ["4.*[13579].*"]


### PR DESCRIPTION
Confirmed working (as far as I can tell) with `pkgver = "4.0"`:
```
main/gtk4: 4.0 -> 4.6.9
main/gtk4: 4.0 -> 4.8.3
main/gtk4: 4.0 -> 4.10.0
main/gtk4: 4.0 -> 4.10.1
main/gtk4: 4.0 -> 4.10.2
main/gtk4: 4.0 -> 4.10.3
main/gtk4: 4.0 -> 4.10.4
main/gtk4: 4.0 -> 4.10.5
main/gtk4: 4.0 -> 4.12.0
```

Void also does something similar but in reverse (matching `pattern` instead of `ignore`): https://github.com/void-linux/void-packages/blob/master/srcpkgs/gtk4/update