### PR TITLE
riscv64 OpenSBI & U-Boot updates

### DIFF
--- a/contrib/u-boot-sifive_unmatched/template.py
+++ b/contrib/u-boot-sifive_unmatched/template.py
@@ -1,5 +1,5 @@
 pkgname = "u-boot-sifive_unmatched"
-pkgver = "2023.04"
+pkgver = "2023.07.02"
 pkgrel = 0
 archs = ["riscv64"]
 build_style = "u_boot"
@@ -21,7 +21,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-only AND BSD-3-Clause"
 url = "https://www.denx.de/wiki/U-Boot"
 source = f"https://ftp.denx.de/pub/u-boot/u-boot-{pkgver}.tar.bz2"
-sha256 = "e31cac91545ff41b71cec5d8c22afd695645cd6e2a442ccdacacd60534069341"
+sha256 = "6b6a48581c14abb0f95bd87c1af4d740922406d7b801002a9f94727fdde021d5"
 env = {
     "U_BOOT_TRIPLET": "riscv64-unknown-elf",
     "U_BOOT_TARGETS": "spl/u-boot-spl.bin u-boot.itb",

--- a/main/opensbi/patches/clang16.patch
+++ b/main/opensbi/patches/clang16.patch
@@ -1,0 +1,50 @@
+From 94197a8c49751eabe73ff2849fce183ac8ead3fd Mon Sep 17 00:00:00 2001
+From: Mitchell Horne <mhorne@freebsd.org>
+Date: Sun, 6 Aug 2023 10:45:36 +0530
+Subject: [PATCH] fw_base.S: Fix assembler error with clang 16+
+
+Attempting to build OpenSBI with clang 16 and the following command:
+
+   $ make LLVM=1 PLATFORM=generic
+
+Results in the following error:
+
+    AS        platform/generic/firmware/fw_dynamic.o
+   /tmp/fw_dynamic-d000a6.s:429:9: error: symbol '_fw_start' can not be undefined in a subtraction expression
+    .dword _fw_rw_start - _fw_start
+
+Work around this issue by eliminating the __fw_rw_offset variable and
+performing the offset calculation at run-time instead. This takes
+advantage of the fact that the a4 register contains the value of
+_fw_start.
+
+Signed-off-by: Mitchell Horne <mhorne@FreeBSD.org>
+Reviewed-by: Anup Patel <anup@brainfault.org>
+---
+ firmware/fw_base.S | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/firmware/fw_base.S b/firmware/fw_base.S
+index b94742395..ca34b4ccc 100644
+--- a/firmware/fw_base.S
++++ b/firmware/fw_base.S
+@@ -309,8 +309,8 @@ _scratch_init:
+ 	REG_S	a5, SBI_SCRATCH_FW_SIZE_OFFSET(tp)
+ 
+ 	/* Store R/W section's offset in scratch space */
+-	lla	a4, __fw_rw_offset
+-	REG_L	a5, 0(a4)
++	lla	a5, _fw_rw_start
++	sub	a5, a5, a4
+ 	REG_S	a5, SBI_SCRATCH_FW_RW_OFFSET(tp)
+ 
+ 	/* Store fw_heap_offset and fw_heap_size in scratch space */
+@@ -536,8 +536,6 @@ _link_start:
+ 	RISCV_PTR	FW_TEXT_START
+ _link_end:
+ 	RISCV_PTR	_fw_reloc_end
+-__fw_rw_offset:
+-	RISCV_PTR	_fw_rw_start - _fw_start
+ 
+ 	.section .entry, "ax", %progbits
+ 	.align 3

--- a/main/opensbi/template.py
+++ b/main/opensbi/template.py
@@ -1,5 +1,5 @@
 pkgname = "opensbi"
-pkgver = "1.2"
+pkgver = "1.3.1"
 pkgrel = 0
 build_style = "makefile"
 make_cmd = "gmake"
@@ -16,7 +16,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-2-Clause"
 url = "https://github.com/riscv-software-src/opensbi"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "8fcbce598a73acc2c7f7d5607d46b9d5107d3ecbede8f68f42631dcfc25ef2b2"
+sha256 = "ee5be2c582f9a837e9db88368220758e014dd694b566bb6c8efe1e50cfad0004"
 hardening = ["!int"]
 # no test suite
 options = ["!check", "!lto", "!strip", "!debug", "foreignelf"]


### PR DESCRIPTION
This OpenSBI ver should be capable of booting VisionFive 2 as per https://rvspace.org/en/project/JH7110_Upstream_Plan, testing that later :)