### PR TITLE
contrib/rust-analyzer: use unwind panic strategy

### DIFF
--- a/contrib/rust-analyzer/template.py
+++ b/contrib/rust-analyzer/template.py
@@ -1,6 +1,6 @@
 pkgname = "rust-analyzer"
-pkgver = "2023.08.21"
-pkgrel = 1
+pkgver = "2023.08.28"
+pkgrel = 0
 build_style = "cargo"
 make_env = {"CARGO_PROFILE_RELEASE_PANIC": "unwind"}
 hostmakedepends = ["cargo"]
@@ -10,7 +10,7 @@ maintainer = "psykose <alice@ayaya.dev>"
 license = "Apache-2.0 OR MIT"
 url = "https://github.com/rust-lang/rust-analyzer"
 source = f"{url}/archive/refs/tags/{pkgver.replace('.', '-')}.tar.gz"
-sha256 = "5a2965f3776f6fb6972e5d017fee62b56db04967ddc81d7a83f602c5d6ca2b5f"
+sha256 = "af7600354d44d9016c8ffb6f612f30b87260b3e5c4fa28c4f65989edc93718c3"
 # invokes rustfmt via rustup arg, also take longer to build than the actual
 # build..
 options = ["!check"]

--- a/contrib/rust-analyzer/template.py
+++ b/contrib/rust-analyzer/template.py
@@ -1,7 +1,8 @@
 pkgname = "rust-analyzer"
 pkgver = "2023.08.21"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
+make_env = {"CARGO_PROFILE_RELEASE_PANIC": "unwind"}
 hostmakedepends = ["cargo"]
 makedepends = ["rust"]
 pkgdesc = "Rust compiler LSP server"


### PR DESCRIPTION
rust-analyzer wasn't working for me with Neovim or Helix. It would start but nearly immediately exit with no reason. Eventually I was able to capture it in the debugger:

```
* thread #10, name = 'Worker', stop reason = signal SIGABRT
  * frame #0: 0x00007f00cb69a137 ld-musl-x86_64.so.1`__restore_sigs [inlined] __syscall4(n=14, a1=2, a2=139641312158528, a3=0, a4=8) at syscall_arch.h:38:2
    frame #1: 0x00007f00cb69a123 ld-musl-x86_64.so.1`__restore_sigs(set=0x00007f00c6cea340) at block.c:43:2
    frame #2: 0x00007f00cb69a2d3 ld-musl-x86_64.so.1`raise(sig=6) at raise.c:11:2
    frame #3: 0x00007f00cb65823e ld-musl-x86_64.so.1`abort at abort.c:11:2
    frame #4: 0x000055a0d0719e27 rust-analyzer`panic_abort::__rust_start_panic::abort::hf5ec61c6639c7f8d (.llvm.2600056918071265335) + 7
    frame #5: 0x000055a0d0a7de96 rust-analyzer`rust_panic + 6
    frame #6: 0x000055a0d0a7de81 rust-analyzer`std::panicking::rust_panic_without_hook::ha5316eb3b2e11d8d (.llvm.17785024755292283938) + 49
    frame #7: 0x000055a0d0a77816 rust-analyzer`std::panic::resume_unwind::h0d9179d0c7630435 + 6
    frame #8: 0x000055a0d0a3f533 rust-analyzer`salsa::Cancelled::throw::hbe07a0bbc3f63328 + 19
    frame #9: 0x000055a0d0a3cf7d rust-analyzer`salsa::runtime::Runtime::unwind_cancelled::h1f4ea1db68c48589 + 13
    frame #10: 0x000055a0d062ef00 rust-analyzer`salsa::Database::unwind_if_cancelled::hb25578c40a631384 + 416
⋮
```

This led me to Salsa, which appears to rely on unwinding to implement cancellation of queries:

https://github.com/salsa-rs/salsa/blob/d4a94fbf07bb837f3d9d0a4caa5db4d5db29243f/src/lib.rs#L637-L657

[cbuild sets Rust's panic strategy to abort](https://github.com/chimera-linux/cports/blob/df309b84add2f94437956b9e539ce72d8cbf0cac/src/cbuild/util/cargo.py#L21), which breaks this behaviour. This PR enables the unwind panic strategy for rust-analyzer. With this change in place I've confirmed rust-analyzer now works in Helix:

![Screenshot from 2023-08-28 20-22-33](https://github.com/chimera-linux/cports/assets/21787/a727a9f4-050c-48b4-9732-2e6304425450)

**Edit:** CI failed because there's a new r-a release so I pushed a commit to update it as well.