### PR TITLE
contrib/ncdu: build against linux-headers

### DIFF
--- a/contrib/ncdu/template.py
+++ b/contrib/ncdu/template.py
@@ -1,13 +1,13 @@
 pkgname = "ncdu"
 pkgver = "1.18.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 hostmakedepends = [
     "autoconf",
     "automake",
     "pkgconf",
 ]
-makedepends = ["ncurses-devel"]
+makedepends = ["ncurses-devel", "linux-headers"]
 pkgdesc = "Disk usage analyzer with an ncurses interface"
 maintainer = "psykose <alice@ayaya.dev>"
 license = "MIT"


### PR DESCRIPTION
It is required to make the `--exclude-kernfs` argument available:
```
$ ncdu --exclude-kernfs
The --exclude-kernfs flag is currently only supported on Linux.
```