### PR TITLE
main/pipewire: update to 0.3.79

### DIFF
--- a/main/pipewire/template.py
+++ b/main/pipewire/template.py
@@ -1,6 +1,6 @@
 pkgname = "pipewire"
-pkgver = "0.3.78"
-pkgrel = 1
+pkgver = "0.3.79"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "--auto-features=enabled",
@@ -77,7 +77,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://pipewire.org"
 source = f"https://gitlab.freedesktop.org/{pkgname}/{pkgname}/-/archive/{pkgver}/{pkgname}-{pkgver}.tar.gz"
-sha256 = "fea26577d41ef74f34932aeba4ccdc7813605f4734b66e17dc96b8b9032b7087"
+sha256 = "d5808abaf6e56b1f268a468dafc2fe9ca9efcc7cfea19f6d47ad5769271afce9"
 # FIXME int: e.g. https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2968
 hardening = ["!int"]
 


### PR DESCRIPTION
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.79