### PR TITLE
main/vala: update to 0.56.13

### DIFF
--- a/main/vala/template.py
+++ b/main/vala/template.py
@@ -1,5 +1,5 @@
 pkgname = "vala"
-pkgver = "0.56.12"
+pkgver = "0.56.13"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
@@ -21,7 +21,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later"
 url = "https://wiki.gnome.org/Projects/Vala"
 source = f"$(GNOME_SITE)/vala/{pkgver[0:pkgver.rfind('.')]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "92c9d54b7cbea3a97077e5d981c8d1b5d06eb285ed159aecab9c58d110253559"
+sha256 = "4988223036c7e1e4874c476d0de8bd9cbe500ee25ef19a76e560dc0b6d56ae07"
 
 
 tool_flags = {"CFLAGS": ["-Wno-incompatible-function-pointer-types"]}


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/vala/-/blob/66dd0937d8b9f29c801c9e7340a404ae4bbfdd1f/NEWS