### PR TITLE
main/glib: update to 2.76.5

### DIFF
--- a/main/glib/template.py
+++ b/main/glib/template.py
@@ -1,5 +1,5 @@
 pkgname = "glib"
-pkgver = "2.76.4"
+pkgver = "2.76.5"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -35,7 +35,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later"
 url = "https://wiki.gnome.org/Projects/GLib"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda"
+sha256 = "ed3a9953a90b20da8e5578a79f7d1c8a532eacbe2adac82aa3881208db8a3abe"
 # FIXME int - e.g. g_ascii_strtoll fails
 hardening = ["!int"]
 # cyclic with desktop-file-utils


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/glib/-/blob/2218ee6f7e043c605bcc7ab95378e92ad48564f4/NEWS