### PR TITLE
main/at-spi2-core: update to 2.48.4

### DIFF
--- a/main/at-spi2-core/template.py
+++ b/main/at-spi2-core/template.py
@@ -1,5 +1,5 @@
 pkgname = "at-spi2-core"
-pkgver = "2.48.3"
+pkgver = "2.48.4"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -23,7 +23,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/at-spi2-core"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "37316df43ca9989ce539d54cf429a768c28bb38a0b34950beadd0421827edf55"
+sha256 = "29ecb12992e8339675f5d755c8735ea3ea298379cfa2c93fde96bee5dc57a515"
 # non-trivial dbus setup
 options = ["!check", "!cross"]
 


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/at-spi2-core/-/blob/ebfda3a63fc351f977d5428b1e7e1979c8edb5c5/NEWS