### PR TITLE
main/graphviz: update to 9.0.0

### DIFF
--- a/main/graphviz/template.py
+++ b/main/graphviz/template.py
@@ -1,5 +1,5 @@
 pkgname = "graphviz"
-pkgver = "8.1.0"
+pkgver = "9.0.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--disable-lefty"]
@@ -39,7 +39,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "EPL-1.0"
 url = "https://graphviz.org"
 source = f"https://gitlab.com/{pkgname}/{pkgname}/-/archive/{pkgver}/{pkgname}-{pkgver}.tar.gz"
-sha256 = "2e4dfee3c24925ad51d1e76a9fb2b19b26a5a0049ef7be6d3e52667aac72eabe"
+sha256 = "504d19b5d0e5398a57e9d9de42393f90b9e79aff0969b4ebc3b891ccb39602ed"
 # expects already installed graphviz
 # testing is via pytest
 options = ["!check"]

--- a/main/imagemagick/template.py
+++ b/main/imagemagick/template.py
@@ -1,7 +1,7 @@
 pkgname = "imagemagick"
 _pver = "7.1.1-15"
 pkgver = _pver.replace("-", ".")
-pkgrel = 2
+pkgrel = 3
 build_style = "gnu_configure"
 configure_args = [
     "--disable-static",

--- a/main/vala/template.py
+++ b/main/vala/template.py
@@ -1,6 +1,6 @@
 pkgname = "vala"
 pkgver = "0.56.13"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 hostmakedepends = [


### PR DESCRIPTION
https://gitlab.com/graphviz/graphviz/-/blob/e0548e996d38d1f4e20aa73c8bf83fc852d973fb/CHANGELOG.md  

like in 8 theres a bunch of breaking changes but no soname bumps, even though symbols are removed