### PR TITLE
main/shadow: enable bcrypt hash support

### DIFF
--- a/main/shadow/template.py
+++ b/main/shadow/template.py
@@ -1,6 +1,6 @@
 pkgname = "shadow"
 pkgver = "4.14.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--enable-shared",
@@ -9,6 +9,7 @@ configure_args = [
     "--with-libpam",
     "--with-acl",
     "--with-attr",
+    "--with-bcrypt",
     "--without-libbsd",
     "--without-selinux",
     "--without-nscd",


### PR DESCRIPTION
this now shows up in e.g. chpasswd --crypt-method.

unlike glibc, musl supports bcrypt in standard crypt interface, without requiring libxcrypt. it's also generally better to pick than sha512.  

---

unrelatedly, i'd say it's better to pick bcrypt as the default hash for /etc/shadow creations, but i'm not sure how good the compatibility with glibc would be (it doesn't support it, but a libxcrypt-enabled glibc would afaik..), which could be troublesome when using a shadow from chimera on a glibc system (?)