### PR TITLE
cbuild: print -h by default when no argument passed

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -271,7 +271,15 @@ def handle_options():
         default=opt_acceptsum,
         help="Accept mismatched checksums when fetching.",
     )
-    parser.add_argument("command", nargs="+", help="The command to issue.")
+    parser.add_argument(
+        "command",
+        nargs="+",
+        help="The command to issue. See Commands in Usage.md.",
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
     cmdline = parser.parse_args()
 


### PR DESCRIPTION
cbuild cannot do anything without a command (error: the following arguments are required: command), so just print the help instead of nothing with an empty argv  

also hint at where the list of commands is

---

this is slightly friendlier than doing nothing and having the help under -h; no point in hiding the help output by default