### PR TITLE
cbuild: use cmake --install instead of make tool

### DIFF
--- a/src/cbuild/build_style/cmake.py
+++ b/src/cbuild/build_style/cmake.py
@@ -14,7 +14,7 @@ def do_check(self):
 
 
 def do_install(self):
-    self.make.install(args_use_env=(self.make_cmd == "ninja"))
+    cmake.install(self)
 
 
 def use(tmpl):

--- a/src/cbuild/util/cmake.py
+++ b/src/cbuild/util/cmake.py
@@ -100,6 +100,23 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
     )
 
 
+def install(pkg, build_dir=None, extra_args=[], env={}):
+    if not build_dir:
+        build_dir = pkg.make_dir
+    renv = {"DESTDIR": pkg.chroot_destdir}
+    env.update(renv)
+
+    pkg.do(
+        *pkg.make_install_wrapper,
+        "cmake",
+        "--install",
+        ".",
+        *extra_args,
+        wrksrc=build_dir,
+        env=renv,
+    )
+
+
 def ctest(pkg, build_dir=None, extra_args=[], env={}):
     if not build_dir:
         build_dir = pkg.make_dir


### PR DESCRIPTION
this avoids rebuilds at install phase in at least some cases, since this tracks that the project is already built better for some reason..

closes #570