### PR TITLE
main/python-typing_extensions: update to 4.8.0

### DIFF
--- a/main/python-typing_extensions/template.py
+++ b/main/python-typing_extensions/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-typing_extensions"
-pkgver = "4.7.1"
+pkgver = "4.8.0"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = ["python-build", "python-installer", "python-flit_core"]
@@ -9,6 +9,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "Python-2.0"
 url = "https://github.com/python/typing"
 source = f"$(PYPI_SITE)/t/typing_extensions/typing_extensions-{pkgver}.tar.gz"
-sha256 = "b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+sha256 = "df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
 # in early path
 options = ["!check"]


### PR DESCRIPTION
https://github.com/python/typing_extensions/releases/tag/4.8.0