### PR TITLE
cbuild: use `meson test`/`meson install` directly

### DIFF
--- a/src/cbuild/build_style/meson.py
+++ b/src/cbuild/build_style/meson.py
@@ -10,11 +10,11 @@ def do_build(self):
 
 
 def do_check(self):
-    self.make.check()
+    meson.check(self)
 
 
 def do_install(self):
-    self.make.install(args_use_env=True)
+    meson.install(self)
 
 
 def use(tmpl):

--- a/src/cbuild/util/meson.py
+++ b/src/cbuild/util/meson.py
@@ -111,3 +111,36 @@ def configure(pkg, meson_dir=None, build_dir=None, extra_args=[], env={}):
         build_dir,
         env=eenv,
     )
+
+
+def check(pkg, build_dir=None, extra_args=[], env={}):
+    if not build_dir:
+        build_dir = pkg.make_dir
+
+    pkg.do(
+        *pkg.make_check_wrapper,
+        "meson",
+        "test",
+        "--no-rebuild",
+        "--print-errorlogs",
+        *extra_args,
+        wrksrc=build_dir,
+        env=env,
+    )
+
+
+def install(pkg, build_dir=None, extra_args=[], env={}):
+    if not build_dir:
+        build_dir = pkg.make_dir
+
+    renv = {"DESTDIR": str(pkg.chroot_destdir)}
+    renv.update(env)
+
+    pkg.do(
+        "meson",
+        "install",
+        "--no-rebuild",
+        *extra_args,
+        wrksrc=build_dir,
+        env=renv,
+    )


### PR DESCRIPTION
this lets us directly pass args to meson for test/install that aren't possible otherwise via the `ninja` call
- for install, this is useful to skip a layer of indirection as ninja calls back out to `meson install` and lets perhaps --skip-subprojects be used, etc
- for check, this allows passing extra args later such as -t and friends