### PR TITLE
main/python-trove-classifiers: update to 2023.9.19

### DIFF
--- a/main/python-trove-classifiers/template.py
+++ b/main/python-trove-classifiers/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-trove-classifiers"
-pkgver = "2023.8.7"
+pkgver = "2023.9.19"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = [
@@ -16,6 +16,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "Apache-2.0"
 url = "https://github.com/pypa/trove-classifiers"
 source = f"$(PYPI_SITE)/t/trove-classifiers/trove-classifiers-{pkgver}.tar.gz"
-sha256 = "c9f2a0a85d545e5362e967e4f069f56fddfd91215e22ffa48c66fb283521319a"
+sha256 = "3e700af445c802f251ce2b741ee78d2e5dfa5ab8115b933b89ca631b414691c9"
 # cycle
 options = ["!check"]


### PR DESCRIPTION
https://github.com/pypa/trove-classifiers/releases/tag/2023.9.19