### PR TITLE
contrib/gas: new package (2.41)

### DIFF
--- a/contrib/gas/template.py
+++ b/contrib/gas/template.py
@@ -1,0 +1,44 @@
+pkgname = "gas"
+pkgver = "2.41"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = [
+    "--disable-gold",
+    "--disable-gprof",
+    "--disable-gprofng",
+    "--disable-ld",
+    "--disable-multilib",
+    "--disable-nls",
+    "--disable-shared",
+    "--disable-werror",
+    "--with-system-zlib",
+    "--with-zstd",
+]
+# require a very specific autotools
+configure_gen = []
+make_cmd = "gmake"
+hostmakedepends = [
+    "gmake",
+    "pkgconf",
+    "texinfo",
+]
+makedepends = [
+    "zlib-devel",
+    "zstd-devel",
+]
+pkgdesc = "GNU Assembler"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-2.0-or-later"
+url = "https://www.gnu.org/software/binutils"
+source = f"https://ftp.gnu.org/gnu/binutils/binutils-{pkgver}.tar.xz"
+sha256 = "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450"
+hardening = ["vis", "cfi"]
+# todo
+options = ["!cross"]
+
+
+def do_install(self):
+    self.install_bin(self.cwd / self.make_dir / "gas/as-new", name="gas")
+    self.install_man(self.cwd / self.make_dir / "gas/doc/as.1")
+    # also make it as(1) since nothing else provides it
+    self.install_link("gas", "usr/bin/as")

--- a/contrib/gas/update.py
+++ b/contrib/gas/update.py
@@ -1,0 +1,1 @@
+pkgname = "binutils"


### PR DESCRIPTION
closes #582 

nothing else seems to provide /usr/bin/as in general, so even though almost nothing will use this, it doesn't really hurt to have it where it's really required for something particular