### PR TITLE
contrib/wlsunset: disable int

### DIFF
--- a/contrib/wlsunset/template.py
+++ b/contrib/wlsunset/template.py
@@ -1,6 +1,6 @@
 pkgname = "wlsunset"
 pkgver = "0.3.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = ["meson", "pkgconf", "scdoc"]
 makedepends = ["wayland-devel", "wayland-protocols"]
@@ -10,7 +10,8 @@ license = "MIT"
 url = "https://git.sr.ht/~kennylevinsen/wlsunset"
 source = f"{url}/archive/{pkgver}.tar.gz"
 sha256 = "9ece2570c3427888a493cd33a129e82634475e6e9286ed729af24fba07ab5424"
-hardening = ["vis", "cfi"]
+# FIXME int: recalc_stops() fails NullabilityReturn
+hardening = ["!int", "vis", "cfi"]
 
 
 def post_install(self):


### PR DESCRIPTION
crashes instantly on use