### PR TITLE
main/openssh: enable libfido2 security key support ← main/libfido2: new package (1.13.0) ← main/libcbor: new package (0.10.2)

### DIFF
--- a/main/libcbor-devel
+++ b/main/libcbor-devel
@@ -1,0 +1,1 @@
+libcbor

--- a/main/libcbor/template.py
+++ b/main/libcbor/template.py
@@ -1,0 +1,22 @@
+pkgname = "libcbor"
+pkgver = "0.10.2"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DBUILD_SHARED_LIBS=ON", "-DWITH_EXAMPLES=OFF"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+pkgdesc = "CBOR serialization format implementation for C"
+maintainer = "Val Packett <val@packett.cool>"
+license = "MIT"
+url = "https://github.com/pjk/libcbor"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "e75f712215d7b7e5c89ef322a09b701f7159f028b8b48978865725f00f79875b"
+# requires extra deps
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE.md")
+
+@subpackage("libcbor-devel")
+def _devel(self):
+    return self.default_devel()

--- a/main/libfido2-devel
+++ b/main/libfido2-devel
@@ -1,0 +1,1 @@
+libfido2

--- a/main/libfido2/template.py
+++ b/main/libfido2/template.py
@@ -1,0 +1,21 @@
+pkgname = "libfido2"
+pkgver = "1.13.0"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DBUILD_STATIC_LIBS=OFF", "-DBUILD_EXAMPLES=OFF"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = ["libcbor-devel", "openssl-devel", "zlib-devel", "udev-devel", "linux-headers"]
+pkgdesc = "CBOR serialization format implementation for C"
+maintainer = "Val Packett <val@packett.cool>"
+license = "BSD-2-Clause"
+url = "https://developers.yubico.com/libfido2"
+source = f"https://developers.yubico.com/libfido2/Releases/libfido2-{pkgver}.tar.gz"
+sha256 = "51d43727e2a1c4544c7fd0ee47786f443e39f1388ada735a509ad4af0a2459ca"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+@subpackage("libfido2-devel")
+def _devel(self):
+    return self.default_devel()

--- a/main/openssh/template.py
+++ b/main/openssh/template.py
@@ -1,6 +1,6 @@
 pkgname = "openssh"
 pkgver = "9.4p1"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
     "--datadir=/usr/share/openssh",
@@ -18,6 +18,7 @@ configure_args = [
     "--with-privsep-path=/var/chroot/ssh",
     "--with-xauth=/usr/bin/xauth",
     "--with-ssl-engine",
+    "--with-security-key-builtin",
     "--disable-strip",
     "ac_cv_header_sys_cdefs_h=false",
 ]
@@ -30,6 +31,7 @@ makedepends = [
     "zlib-devel",
     "libldns-devel",
     "openssl-devel",
+    "libfido2-devel",
 ]
 pkgdesc = "OpenSSH free Secure Shell (SSH) client and server implementation"
 maintainer = "q66 <q66@chimera-linux.org>"


### PR DESCRIPTION
hah, and in order to push my first package I needed to enable security keys in openssh…

yeah, new `main` stuff required.. well, FreeBSD has had to import all of this directly into base so.