### PR TITLE
main/python-charset-normalizer: update to 3.3.0

### DIFF
--- a/main/python-charset-normalizer/template.py
+++ b/main/python-charset-normalizer/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-charset-normalizer"
-pkgver = "3.2.0"
+pkgver = "3.3.0"
 pkgrel = 0
 build_style = "python_module"
 hostmakedepends = ["python-setuptools"]
@@ -10,7 +10,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://charset-normalizer.readthedocs.io"
 source = f"https://github.com/Ousret/charset_normalizer/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "8f8c0a09ab745efc68ce4c1b85292ded2f06ea106f8086f614a0a9403c3dde0a"
+sha256 = "bf2970e07cae5d97f71861e856e8d4114d995285ffa8ca536776c1c04fd46943"
 # dependency of pytest
 options = ["!check"]
 


### PR DESCRIPTION
https://github.com/Ousret/charset_normalizer/releases/tag/3.3.0