### PR TITLE
cbuild: explicitly disable apk interactivity

### DIFF
--- a/src/cbuild/apk/cli.py
+++ b/src/cbuild/apk/cli.py
@@ -118,6 +118,7 @@ def call(
     cmd = [
         paths.apk(),
         subcmd,
+        "--no-interactive",
         "--root",
         root if root else paths.bldroot(),
         "--repositories-file",


### PR DESCRIPTION
when /etc/apk/interactive is touched on the host, every apk call by cbuild prompts the user, but for cbuild specifically we don't want apk to give interactive prompts