### PR TITLE
cbuild: always call apk with --no-interactive

### DIFF
--- a/src/cbuild/apk/cli.py
+++ b/src/cbuild/apk/cli.py
@@ -122,6 +122,7 @@ def call(
         root if root else paths.bldroot(),
         "--repositories-file",
         "/dev/null",
+        "--no-interactive",
     ]
     if arch:
         cmd += ["--arch", arch]


### PR DESCRIPTION
Otherwise existance of host `/etc/apk/interactive` could affect `cbuild`.

This might be too naïve of a fix, not sure yet and needs proper testing.