### PR TITLE
main/python-urllib3: update to 2.0.6

### DIFF
--- a/main/python-urllib3/template.py
+++ b/main/python-urllib3/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-urllib3"
-pkgver = "2.0.5"
+pkgver = "2.0.6"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = ["python-build", "python-installer", "python-hatchling"]
@@ -9,7 +9,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://urllib3.readthedocs.io"
 source = f"$(PYPI_SITE)/u/urllib3/urllib3-{pkgver}.tar.gz"
-sha256 = "13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594"
+sha256 = "b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
 # unpackaged dependency
 options = ["!check", "brokenlinks"]
 


### PR DESCRIPTION
https://github.com/urllib3/urllib3/releases/tag/2.0.6