### PR TITLE
contrib/hyperfine: update to 1.18.0

### DIFF
--- a/contrib/hyperfine/template.py
+++ b/contrib/hyperfine/template.py
@@ -1,5 +1,5 @@
 pkgname = "hyperfine"
-pkgver = "1.17.0"
+pkgver = "1.18.0"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo"]
@@ -9,7 +9,7 @@ maintainer = "psykose <alice@ayaya.dev>"
 license = "MIT OR Apache-2.0"
 url = "https://github.com/sharkdp/hyperfine"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "3dcd86c12e96ab5808d5c9f3cec0fcc04192a87833ff009063c4a491d5487b58"
+sha256 = "fea7b92922117ed04b9c84bb9998026264346768804f66baa40743c5528bed6b"
 
 
 def post_install(self):


### PR DESCRIPTION
https://github.com/sharkdp/hyperfine/releases/tag/v1.18.0