### PR TITLE
main/linux-headers: update to 6.5.5

### DIFF
--- a/main/linux-headers/template.py
+++ b/main/linux-headers/template.py
@@ -1,14 +1,14 @@
 pkgname = "linux-headers"
-pkgver = "6.1.19"
+pkgver = "6.5.5"
 pkgrel = 0
 make_cmd = "gmake"
 hostmakedepends = ["gmake", "perl"]
 pkgdesc = "Linux API headers for userland development"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-only"
-url = "http://www.kernel.org"
+url = "https://www.kernel.org"
 source = f"$(KERNEL_SITE)/kernel/v{pkgver[0]}.x/linux-{pkgver}.tar.xz"
-sha256 = "9e991c6e5f6c1ca45eea98c55e82ef6ae3dccc73b3e8a655c8665e585f5a8647"
+sha256 = "8cf10379f7df8ea731e09bff3d0827414e4b643dd41dc99d0af339669646ef95"
 # nothing to test
 options = ["!check"]
 


### PR DESCRIPTION
this allows using new defines for software that makes use of them. one example is https://codeberg.org/dnkl/foot/commit/61eb56dfda605427156b52d019be4bf5ce84c3aa ; compiling with 6.3+ headers would allow it to be set, but is still backwards compatible because unknown flags are just ignored.

in general, the headers are backwards compatible. having older headers doesn't improve compatibility with older kernels; it only prevents applications from using newer features/defines, without benefit to people using the older LTS series (it works either way), and with a negative to people using latest stable (loss of potential feature).