### PR TITLE
cbuild: don't follow symlinks in xattr check

### DIFF
--- a/src/cbuild/hooks/post_install/098_check_xattrs.py
+++ b/src/cbuild/hooks/post_install/098_check_xattrs.py
@@ -5,7 +5,7 @@ def invoke(pkg):
     badattrs = []
 
     for v in pkg.destdir.rglob("*"):
-        xl = os.listxattr(v)
+        xl = os.listxattr(v, follow_symlinks=False)
 
         # nothing to do
         if len(xl) == 0:


### PR DESCRIPTION
dangling links are allowed for e.g. -devel packages, and this just crashes on that since every file is individually checked, links can just be non-followed