### PR TITLE
main/libnotify: update to 0.8.3

### DIFF
--- a/main/libnotify/template.py
+++ b/main/libnotify/template.py
@@ -1,5 +1,5 @@
 pkgname = "libnotify"
-pkgver = "0.8.2"
+pkgver = "0.8.3"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -26,7 +26,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later"
 url = "https://gitlab.gnome.org/GNOME/libnotify"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616"
+sha256 = "ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0"
 
 
 @subpackage("libnotify-devel")


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libnotify/-/blob/3f2882d1b49996748cf1b0a8f7862b2592d8042d/NEWS