### PR TITLE
contrib/qt6ct: rebuild for qt6 6.6

### DIFF
--- a/contrib/qt6ct/template.py
+++ b/contrib/qt6ct/template.py
@@ -1,6 +1,6 @@
 pkgname = "qt6ct"
 pkgver = "0.9"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = ["cmake", "ninja", "qt6-qttools", "qt6-qtbase"]
 makedepends = ["qt6-qtbase-devel", "qt6-qttools-devel"]


### PR DESCRIPTION
Using qt6ct to theme qt programs results fails to apply themes with this error
`qt6ct: qt6ct is compiled against incompatible Qt version (6.5.3).`
Rebuilding against qt 6.6 fixes this.