### PR TITLE
contrib/gamescope: update to 3.12.7

### DIFF
--- a/contrib/gamescope/patches/missing-include.patch
+++ b/contrib/gamescope/patches/missing-include.patch
@@ -1,0 +1,18 @@
+commit 7f3f3b8e77a5414d824d7a9bed738f6af5f4ab0c
+Author: q66 <q66@chimera-linux.org>
+Date:   Sat Oct 14 16:37:14 2023 +0200
+
+    add missing include
+
+diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
+index 4d040f0..3b3bbac 100644
+--- a/src/rendervulkan.hpp
++++ b/src/rendervulkan.hpp
+@@ -9,6 +9,7 @@
+ #include <unordered_map>
+ #include <array>
+ #include <bitset>
++#include <mutex>
+ 
+ #include "main.hpp"
+ 

--- a/contrib/gamescope/patches/system-spirv-headers.patch
+++ b/contrib/gamescope/patches/system-spirv-headers.patch
@@ -1,0 +1,19 @@
+commit 3136f9ead217b68d00d66ef26ae9ff8f354f5d91
+Author: q66 <q66@chimera-linux.org>
+Date:   Sat Oct 14 16:36:01 2023 +0200
+
+    use system spirv-headers
+
+diff --git a/src/meson.build b/src/meson.build
+index c63cbd7..0afe796 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -94,7 +94,7 @@ reshade_src = [
+ reshade_include = include_directories([
+   'reshade/source',
+   'reshade/include',
+-  '../thirdparty/SPIRV-Headers/include/spirv/unified1'
++  '/usr/include/spirv/unified1'
+ ])
+ 
+ src = [

--- a/contrib/gamescope/template.py
+++ b/contrib/gamescope/template.py
@@ -1,6 +1,6 @@
 pkgname = "gamescope"
-pkgver = "3.12.5"
-pkgrel = 1
+pkgver = "3.12.7"
+pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
     "cmake",
@@ -8,6 +8,7 @@ hostmakedepends = [
     "meson",
     "ninja",
     "pkgconf",
+    "spirv-headers",
 ]
 makedepends = [
     "benchmark-devel",
@@ -42,16 +43,19 @@ source = [
     f"{url}/archive/refs/tags/{pkgver}.tar.gz",
     "https://github.com/ValveSoftware/openvr/archive/1a0ea26642e517824b66871e6a12280a426cfec3.tar.gz",
     "https://github.com/Joshua-Ashton/vkroots/archive/26757103dde8133bab432d172b8841df6bb48155.tar.gz",
+    "https://github.com/Joshua-Ashton/reshade/archive/9fdbea6892f9959fdc18095d035976c574b268b7.tar.gz",
 ]
 source_paths = [
     ".",
     "subprojects/openvr",
     "subprojects/vkroots",
+    "src/reshade",
 ]
 sha256 = [
-    "32a020e35b8443862c900306fb6edb84a8ecb009c89184d2062b0b8ce2811e17",
+    "e062eb541e20959cd3d64e79c1c31fe3bf1d773afd3da5816011f07424e33bcb",
     "6285504e64a37df47856ffa4a12709d0703da37ee1b0c9fe9e8e52a55127dd7d",
     "adf158c3da572f1dfaa6e1a7a51943aafb824222e77f512a4666472d71321244",
+    "165726ad21fbfc221c0363e40b597834068a416a11a1204ae2ac6d13ec161035",
 ]
 # sus
 options = ["!cross"]


### PR DESCRIPTION
segfaults after a few seconds:

```
(lldb) bt
* thread #1, name = 'gamescope-wl', stop reason = signal SIGSEGV
  * frame #0: 0x0000000000000000
    frame #1: 0x0000564abaa43104 gamescope`present_wait_thread_func() at rendervulkan.cpp:2555:5
    frame #2: 0x0000564abaa155fa gamescope`void* std::__1::__thread_proxy[abi:v160006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)()>>(void*) [inlined] decltype(std::declval<void (*)()>()()) std::__1::__invoke[abi:v160006]<void (*)()>(__f=0x00007fb23f911e98) at invoke.h:394:23
    frame #3: 0x0000564abaa155f7 gamescope`void* std::__1::__thread_proxy[abi:v160006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)()>>(void*) [inlined] void std::__1::__thread_execute[abi:v160006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)()>(__t=size=2, (null)=<unavailable>) at thread:282:5
    frame #4: 0x0000564abaa155f7 gamescope`void* std::__1::__thread_proxy[abi:v160006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)()>>(__vp=0x00007fb23f911e90) at thread:293:5
    frame #5: 0x00007fb2406b266b ld-musl-x86_64.so.1`start(p=0x00007fb2305f6130) at pthread_create.c:208:17
    frame #6: 0x00007fb2406b5383 ld-musl-x86_64.so.1`__clone + 47
(lldb) quit
```

Blame points to https://github.com/ValveSoftware/gamescope/commit/1bb7ef50ba6b44811ea7349df4365fec41652aee