### PR TITLE
contrib/tailscale: new package (1.50.1)

### DIFF
--- a/contrib/tailscale/files/tailscaled
+++ b/contrib/tailscale/files/tailscaled
@@ -1,0 +1,8 @@
+# tailscaled service
+
+type            = process
+command         = /usr/bin/tailscaled
+depends-on      = network.target
+depends-on      = local.target
+restart         = true
+smooth-recovery = true

--- a/contrib/tailscale/template.py
+++ b/contrib/tailscale/template.py
@@ -1,0 +1,26 @@
+pkgname = "tailscale"
+pkgver = "1.50.1"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    f"-ldflags=-X tailscale.com/version.longStamp={pkgver} -X tailscale.com/version.shortStamp={pkgver}"
+]
+hostmakedepends = ["go"]
+depends = ["iptables", "ca-certificates"]
+pkgdesc = "Mesh VPN daemon based on WireGuard"
+maintainer = "Val Packett <val@packett.cool>"
+license = "BSD-3-Clause"
+url = "https://github.com/tailscale/tailscale"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "183a7d559590a759dd77aa9c2b65486ab6e13c26f3c07fad0b536e318ad5e233"
+options = ["!debug"]
+
+
+def do_build(self):
+    self.golang.build(wrksrc="cmd/tailscaled")
+    self.golang.build(wrksrc="cmd/tailscale")
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+    self.install_service(self.files_path / "tailscaled", enable=True)

--- a/src/cbuild/core/profile.py
+++ b/src/cbuild/core/profile.py
@@ -245,7 +245,7 @@ def _get_rustflags(
 
 def _get_goflags(self, name, extra_flags, debug, hardening, opts, stage, shell):
     hard = _get_harden(self, hardening, opts, stage)
-    bflags = []
+    bflags = ["-mod=readonly", "-modcacherw"]
 
     if hard["pie"]:
         bflags.append("-buildmode=pie")

--- a/src/cbuild/util/golang.py
+++ b/src/cbuild/util/golang.py
@@ -8,6 +8,9 @@ def get_go_env(pkg):
     env = {
         "GOMODCACHE": "/cbuild_cache/golang/pkg/mod",
         "GOARCH": pkg.profile().goarch,
+        "CGO_CFLAGS": pkg.get_cflags(shell=True),
+        "CGO_CXXFLAGS": pkg.get_cxxflags(shell=True),
+        "CGO_LDFLAGS": pkg.get_ldflags(shell=True),
     }
     return env
 
@@ -85,7 +88,7 @@ class Golang:
         return self._invoke("mod", ["download"], 1, False, None, env, wrksrc)
 
     def build(self, args=[], jobs=None, env={}, wrksrc=None):
-        myargs = ["-v"]  # increase go verbosity
+        myargs = ["-v", "-trimpath"]  # increase go verbosity, fix repro builds
 
         tags = self.template.go_build_tags
 


### PR DESCRIPTION
and more golang flag stuff, similar to [what other distros do](https://shibumi.dev/posts/hardening-executables/) — actually ideally we'd also handle annoying go ldflags thing to be able to pass both `linkmode=external` and per-package stuff like those `-X` defines; not sure what the right way to do it would be though. or maybe I shouldn't touch any of that stuff…