### PR TITLE
contrib/protobuf: make -devel subpkg depend on protobuf (protoc)

### DIFF
--- a/contrib/protobuf/template.py
+++ b/contrib/protobuf/template.py
@@ -1,6 +1,6 @@
 pkgname = "protobuf"
 pkgver = "24.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DBUILD_SHARED_LIBS=ON",
@@ -50,4 +50,6 @@ def _libprotoc(self):
 
 @subpackage("protobuf-devel")
 def _devel(self):
+    self.depends += ["protobuf"]
+
     return self.default_devel()


### PR DESCRIPTION
The protobuf compiler itself is required for development so this just makes sense, it was not picked up previously due to `libprotoc` being split into its own subpackage and main pkg left with the tiny `protoc` executable.