### PR TITLE
main/libheif: update to 1.17.0

### DIFF
--- a/main/libheif/template.py
+++ b/main/libheif/template.py
@@ -1,22 +1,28 @@
 pkgname = "libheif"
-pkgver = "1.16.2"
-pkgrel = 1
+pkgver = "1.17.0"
+pkgrel = 0
 build_style = "cmake"
+configure_args = [
+    "-DWITH_DAV1D=ON",
+    "-DWITH_JPEG_DECODER=ON",
+    "-DWITH_JPEG_ENCODER=ON",
+]
 hostmakedepends = ["cmake", "ninja", "pkgconf"]
 makedepends = [
-    "libde265-devel",
-    "x265-devel",
-    "libaom-devel",
     "dav1d-devel",
+    "gdk-pixbuf-devel",
+    "libaom-devel",
+    "libde265-devel",
     "libjpeg-turbo-devel",
     "libpng-devel",
+    "x265-devel",
 ]
 pkgdesc = "HEIF and AVIF file format decoder and encoder"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-3.0-or-later"
 url = "http://www.libheif.org"
 source = f"https://github.com/strukturag/{pkgname}/archive/v{pkgver}.tar.gz"
-sha256 = "d207f2ff5c86e6af3621c237f186130b985b7a9ff657875944b58ac5d27ba71c"
+sha256 = "80185d9e7319ab2ae622a131eea11b4d573e2ece38f5a1586cf4d1ffd66bb4d7"
 hardening = ["!cfi"]  # TODO
 # needs full symbol visibility
 options = ["!check"]


### PR DESCRIPTION
also builds the gdk-pixbuf loader