### PR TITLE
contrib/greetd: new package (0.9.0)

### DIFF
--- a/contrib/greetd/files/greetd
+++ b/contrib/greetd/files/greetd
@@ -1,0 +1,7 @@
+# greetd service
+
+type            = process
+command         = /usr/bin/greetd
+depends-on      = login.target
+restart         = true
+smooth-recovery = true

--- a/contrib/greetd/files/greetd.pam
+++ b/contrib/greetd/files/greetd.pam
@@ -1,0 +1,7 @@
+#%PAM-1.0
+
+auth       required     pam_securetty.so
+auth       requisite    pam_nologin.so
+auth       include      system-local-login
+account    include      system-local-login
+session    include      system-local-login

--- a/contrib/greetd/greetd.post-deinstall
+++ b/contrib/greetd/greetd.post-deinstall
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# does not contain anything worth preserving
+rm -rf /var/lib/greetd > /dev/null 2>&1

--- a/contrib/greetd/greetd.post-install
+++ b/contrib/greetd/greetd.post-install
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# install greetd home dir
+install -d -m 755 /var/lib/greetd || :
+chown _greetd:_greetd /var/lib/greetd > /dev/null 2>&1 || :

--- a/contrib/greetd/patches/config.patch
+++ b/contrib/greetd/patches/config.patch
@@ -1,0 +1,17 @@
+--- a/config.toml
++++ b/config.toml
+@@ -1,7 +1,7 @@
+ [terminal]
+ # The VT to run the greeter on. Can be "next", "current" or a number
+ # designating the VT.
+-vt = 1
++vt = 7
+ 
+ # The default session, also known as the greeter.
+ [default_session]
+@@ -13,4 +13,4 @@
+ # The user to run the command as. The privileges this user must have depends
+ # on the greeter. A graphical greeter may for example require the user to be
+ # in the `video` group.
+-user = "greeter"
++user = "_greetd"

--- a/contrib/greetd/template.py
+++ b/contrib/greetd/template.py
@@ -1,0 +1,48 @@
+pkgname = "greetd"
+pkgver = "0.9.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = [
+    "bmake",
+    "cargo",
+    "pkgconf",
+    "scdoc",
+]
+makedepends = [
+    "linux-pam-devel",
+    "rust-std",
+]
+pkgdesc = "Minimal and flexible login manager daemon"
+maintainer = "natthias <natthias@proton.me>"
+license = "GPL-3.0-or-later"
+url = "https://git.sr.ht/~kennylevinsen/greetd"
+source = f"https://git.sr.ht/~kennylevinsen/greetd/archive/{pkgver}.tar.gz"
+sha256 = "a0cec141dea7fd7838b60a52237692d0fd5a0169cf748b8f8379d8409a3768eb"
+
+system_users = [
+    {
+        "name": "_greetd",
+        "id": None,
+        "home": "/var/lib/greetd",
+    }
+]
+
+
+def post_build(self):
+    self.do("make", "-C", "man", "all")
+
+
+def do_install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/agreety")
+    self.install_bin(f"target/{self.profile().triplet}/release/fakegreet")
+    self.install_bin(f"target/{self.profile().triplet}/release/greetd")
+
+    self.install_man("man/*.1", glob=True)
+    self.install_man("man/*.5", glob=True)
+    self.install_man("man/*.7", glob=True)
+
+    self.install_file("config.toml", "etc/greetd")
+    self.install_file(
+        self.files_path / "greetd.pam", "etc/pam.d", name="greetd"
+    )
+    self.install_service(self.files_path / "greetd")

--- a/contrib/tuigreet/template.py
+++ b/contrib/tuigreet/template.py
@@ -1,0 +1,13 @@
+pkgname = "tuigreet"
+pkgver = "0.8.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo"]
+makedepends = ["rust-std"]
+depends = ["greetd"]
+pkgdesc = "Console greeter for greetd"
+maintainer = "natthias <natthias@proton.me>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/apognu/tuigreet"
+source = f"https://github.com/apognu/tuigreet/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "ed371ebe288a3e5782f01681c6c4ed4786b470184af286fa0e7b8898e47c154e"


### PR DESCRIPTION
This is my first time attempting to upstream a package, hopefully I get this right.

This MR also provides a contrib/tuigreet package, which can be used as a greeter for greetd. I also don't know if I got the dinit service right, but it works locally.

Both packages have been tested, and built on x86_64, as it is the only hardware I have. All tier 1 and tier 3 architectures cross compile successfully.