### PR TITLE
main/xdg-desktop-portal-gtk: update to 1.15.0

### DIFF
--- a/main/xdg-desktop-portal-gtk/template.py
+++ b/main/xdg-desktop-portal-gtk/template.py
@@ -1,14 +1,22 @@
 pkgname = "xdg-desktop-portal-gtk"
-pkgver = "1.14.1"
+pkgver = "1.15.1"
 pkgrel = 0
-build_style = "gnu_configure"
-make_cmd = "gmake"
-hostmakedepends = ["pkgconf", "glib-devel", "gmake", "gettext"]
+build_style = "meson"
+configure_args = [
+    # pulls gnome-desktop
+    "-Dwallpaper=disabled",
+]
+hostmakedepends = [
+    "gettext",
+    "glib-devel",
+    "meson",
+    "pkgconf",
+]
 makedepends = [
-    "gtk+3-devel",
-    "xdg-desktop-portal-devel",
     "fontconfig-devel",
     "gsettings-desktop-schemas-devel",
+    "gtk+3-devel",
+    "xdg-desktop-portal-devel",
 ]
 depends = ["xdg-desktop-portal"]
 pkgdesc = "Gtk implementation of xdg-desktop-portal"
@@ -16,11 +24,8 @@ maintainer = "eater <=@eater.me>"
 license = "LGPL-2.1-or-later"
 url = "https://github.com/flatpak/xdg-desktop-portal-gtk"
 source = f"https://github.com/flatpak/xdg-desktop-portal-gtk/releases/download/{pkgver}/xdg-desktop-portal-gtk-{pkgver}.tar.xz"
-sha256 = "3ee2a992187eabb237a76170a7dead2a3bcea2edbf59344647cc0d1c640a5700"
+sha256 = "425551ca5f36451d386d53599d95a3a05b94020f1a4927c5111a2c3ba3a0fe4c"
 
 
 def post_install(self):
     self.rm(self.destdir / "usr/lib/systemd", recursive=True)
-
-
-configure_gen = []


### PR DESCRIPTION
versioning scheme changed in https://discourse.gnome.org/t/xdg-desktop-portal-gtk-versioning-scheme-change/17698/1  

https://github.com/flatpak/xdg-desktop-portal-gtk/releases/tag/1.15.0