### PR TITLE
contrib/sbctl: new package (0.12)

### DIFF
--- a/contrib/sbctl/patches/use-llvm-objcopy.patch
+++ b/contrib/sbctl/patches/use-llvm-objcopy.patch
@@ -1,0 +1,35 @@
+--- bundles.go	2023-10-20 20:54:47.000000000 +0200
++++ bundles.go	2023-11-23 10:58:52.631410393 +0100
+@@ -154,17 +154,7 @@
+ 		return false, err
+ 	}
+ 	e.Close()
+-	s := e.Sections[len(e.Sections)-1]
+ 
+-	vma := uint64(s.VirtualAddress) + uint64(s.VirtualSize)
+-	switch e := e.OptionalHeader.(type) {
+-	case *pe.OptionalHeader32:
+-		vma += uint64(e.ImageBase)
+-	case *pe.OptionalHeader64:
+-		vma += e.ImageBase
+-	}
+-	vma = roundUpToBlockSize(vma)
+-
+ 	var args []string
+ 	for _, s := range sections {
+ 		if s.file == "" {
+@@ -188,13 +178,11 @@
+ 		args = append(args,
+ 			"--add-section", fmt.Sprintf("%s=%s", s.section, s.file),
+ 			"--set-section-flags", fmt.Sprintf("%s=%s", s.section, flags),
+-			"--change-section-vma", fmt.Sprintf("%s=%#x", s.section, vma),
+ 		)
+-		vma += roundUpToBlockSize(uint64(fi.Size()))
+ 	}
+ 
+ 	args = append(args, bundle.EFIStub, bundle.Output)
+-	cmd := exec.Command("objcopy", args...)
++	cmd := exec.Command("llvm-objcopy", args...)
+ 	cmd.Stdout = os.Stdout
+ 	cmd.Stderr = os.Stderr
+ 	if err := cmd.Run(); err != nil {

--- a/contrib/sbctl/template.py
+++ b/contrib/sbctl/template.py
@@ -1,0 +1,58 @@
+pkgname = "sbctl"
+pkgver = "0.12"
+pkgrel = 0
+build_style = "go"
+make_build_args = ["./cmd/sbctl"]
+hostmakedepends = ["go", "asciidoc", "gmake"]
+depends = [
+    "llvm-binutils",  # required to generate EFI bundles
+]
+pkgdesc = "Secure Boot key manager"
+maintainer = "flukey <flukey@vapourmail.eu>"
+license = "MIT"
+url = "https://github.com/Foxboron/sbctl"
+source = f"{url}/releases/download/{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "72475519733385b0effb422ff058e95f0282fa93eccf03df07e3402736646b97"
+options = ["!cross"]
+
+
+def post_build(self):
+    # Generate man page, bmake doesn't work
+    self.do("gmake", "man")
+
+    # Generate bash completions
+    with open(self.cwd / "sbctl.bash", "w") as cf:
+        self.do(
+            self.make_dir + "/sbctl",
+            "completion",
+            "bash",
+            stdout=cf,
+        )
+
+    # Generate zsh completions
+    with open(self.cwd / "sbctl.zsh", "w") as cf:
+        self.do(
+            self.make_dir + "/sbctl",
+            "completion",
+            "zsh",
+            stdout=cf,
+        )
+
+    # Generate fish completions
+    with open(self.cwd / "sbctl.fish", "w") as cf:
+        self.do(
+            self.make_dir + "/sbctl",
+            "completion",
+            "fish",
+            stdout=cf,
+        )
+
+
+def post_install(self):
+    self.install_man("docs/sbctl.8")
+
+    self.install_completion("sbctl.bash", "bash")
+    self.install_completion("sbctl.zsh", "zsh")
+    self.install_completion("sbctl.fish", "fish")
+
+    self.install_license("LICENSE")


### PR DESCRIPTION
I use this tool to manage my Secure Boot setup.

Default path for keys and database files is `/usr/share/secureboot`, some distros change this to `/etc/secureboot`.