### PR TITLE
main/nghttp2: update to 1.58.0

### DIFF
--- a/main/nghttp2/template.py
+++ b/main/nghttp2/template.py
@@ -1,5 +1,5 @@
 pkgname = "nghttp2"
-pkgver = "1.57.0"
+pkgver = "1.58.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_gen = []
@@ -19,7 +19,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://nghttp2.org"
 source = f"https://github.com/tatsuhiro-t/{pkgname}/releases/download/v{pkgver}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "9210b0113109f43be526ac5835d58a701411821a4d39e155c40d67c40f47a958"
+sha256 = "4a68a3040da92fd9872c056d0f6b0cd60de8410de10b578f8ade9ecc14d297e0"
 # FIXME cfi; reproduces in e.g. libsoup
 hardening = ["vis", "!cfi"]
 


### PR DESCRIPTION
https://github.com/nghttp2/nghttp2/releases/tag/v1.58.0