### PR TITLE
main/python-charset-normalizer: update to 3.3.1

### DIFF
--- a/main/python-charset-normalizer/template.py
+++ b/main/python-charset-normalizer/template.py
@@ -1,8 +1,13 @@
 pkgname = "python-charset-normalizer"
-pkgver = "3.3.0"
+pkgver = "3.3.1"
 pkgrel = 0
-build_style = "python_module"
-hostmakedepends = ["python-setuptools"]
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
 checkdepends = ["python-pytest"]
 depends = ["python"]
 pkgdesc = "Encoding and language detection"
@@ -10,7 +15,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://charset-normalizer.readthedocs.io"
 source = f"https://github.com/Ousret/charset_normalizer/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "bf2970e07cae5d97f71861e856e8d4114d995285ffa8ca536776c1c04fd46943"
+sha256 = "82fba49093b118ecb75724413d5838c66b3269491aecda33199e17b5487a3444"
 # dependency of pytest
 options = ["!check"]
 


### PR DESCRIPTION
https://github.com/Ousret/charset_normalizer/releases/tag/3.3.1