### PR TITLE
main/opusfile: disable cfi

### DIFF
--- a/main/opusfile/template.py
+++ b/main/opusfile/template.py
@@ -1,8 +1,8 @@
 pkgname = "opusfile"
 pkgver = "0.12"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
-hostmakedepends = ["pkgconf"]
+hostmakedepends = ["automake", "libtool", "pkgconf"]
 makedepends = ["libogg-devel", "opus-devel", "openssl-devel"]
 pkgdesc = "Library for opening, seeking, and decoding .opus files"
 maintainer = "q66 <q66@chimera-linux.org>"
@@ -10,7 +10,8 @@ license = "BSD-3-Clause"
 url = "https://www.opus-codec.org"
 source = f"http://downloads.xiph.org/releases/opus/{pkgname}-{pkgver}.tar.gz"
 sha256 = "118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b"
-hardening = ["vis", "cfi"]
+# FIXME cfi crashes in deadbeef when loading a .ogg
+hardening = ["vis", "!cfi"]
 
 
 def post_install(self):
@@ -21,6 +22,3 @@ def post_install(self):
 @subpackage("opusfile-devel")
 def _devel(self):
     return self.default_devel()
-
-
-configure_gen = []


### PR DESCRIPTION
crashes in deadbeef when loading a .ogg  

---

```
(lldb) bt
* thread #1, name = 'deadbeef-main', stop reason = signal SIGILL: illegal instruction operand
  * frame #0: 0x00007fffe73f5a13 libopusfile.so.0`op_test_callbacks [inlined] op_open1(_of=0x00007fffe6106f30, _stream=0x00007fffecc0a840, _cb=0x00007fffe7985de0, _initial_data=0x0000000000000000, _initial_bytes=0) at opusfile.c:0
    frame #1: 0x00007fffe73f5a11 libopusfile.so.0`op_test_callbacks(_stream=0x00007fffecc0a840, _cb=0x00007fffe7985de0, _initial_data=0x0000000000000000, _initial_bytes=0, _error=0x00007fffffff5360) at opusfile.c:1608:9
    frame #2: 0x00007fffe73f5c2f libopusfile.so.0`op_open_callbacks(_stream=<unavailable>, _cb=<unavailable>, _initial_data=<unavailable>, _initial_bytes=<unavailable>, _error=<unavailable>) at opusfile.c:1625:6
    frame #3: 0x00007fffe797f6f8 opus.so`opusdec_insert [inlined] opus_file_open(fp=0x00007fffecc0a840) at opus.c:96:12
    frame #4: 0x00007fffe797f6d8 opus.so`opusdec_insert(plt=0x00007fffee703070, after=0x00007fffebd18c00, fname="/mnt/storage-1/soulseek/cypis/Chamskie Disco/1 - Intro.ogg") at opus.c:524:29
    frame #5: 0x00005555555717f4 deadbeef`plt_insert_file_int(visibility=0, flags=<unavailable>, plt=0x00007fffee703070, after=<unavailable>, fname="/mnt/storage-1/soulseek/cypis/Chamskie Disco/1 - Intro.ogg", pabort=0x00007fffffffb8ec, callback=0x0000000000000000, callback_with_result=0x0000000000000000, user_data=0x0000000000000000) at playlist.c:1122:58
    frame #6: 0x00005555555722d4 deadbeef`plt_insert_dir_int(visibility=0, flags=0, plt=0x00007fffee703070, vfs=0x0000000000000000, after=0x00007fffebd18c00, dirname="/mnt/storage-1/soulseek/cypis/Chamskie Disco", pabort=0x00007fffffffb8ec, callback=0x0000000000000000, callback_with_result=0x0000000000000000, user_data=0x0000000000000000) at playlist.c:1427:28
    frame #7: 0x000055555557231d deadbeef`plt_insert_dir_int(visibility=0, flags=0, plt=0x00007fffee703070, vfs=0x0000000000000000, after=0x00007fffebd18c00, dirname="/mnt/storage-1/soulseek/cypis", pabort=0x00007fffffffb8ec, callback=0x0000000000000000, callback_with_result=0x0000000000000000, user_data=0x0000000000000000) at playlist.c:1424:28
    frame #8: 0x000055555557231d deadbeef`plt_insert_dir_int(visibility=0, flags=0, plt=0x00007fffee703070, vfs=0x0000000000000000, after=0x00007fffebd16e40, dirname="/mnt/storage-1/soulseek", pabort=0x00007fffffffb8ec, callback=0x0000000000000000, callback_with_result=0x0000000000000000, user_data=0x0000000000000000) at playlist.c:1424:28
    frame #9: 0x000055555557a9d4 deadbeef`plt_add_dir2(visibility=<unavailable>, plt=0x00007fffee703070, dirname=<unavailable>, callback=<unavailable>, user_data=<unavailable>) at playlist.c:3961:22
    frame #10: 0x000055555558af45 deadbeef`server_exec_command_line at main.c:528:13
    frame #11: 0x000055555558aeb1 deadbeef`server_exec_command_line(cmdline=<unavailable>, len=<unavailable>, sendback=<unavailable>, sbsize=0) at main.c:478:13
    frame #12: 0x000055555558cb2c deadbeef`main(argc=2, argv=<unavailable>) at main.c:1503:19
(lldb) x/1i  $pc
->  0x7fffe73f5a13: 67 0f b9 40 02  other       ud1l   0x2(%eax), %eax
```