### PR TITLE
contrib/audacity: update to 3.4.0

### DIFF
--- a/contrib/audacity/patches/opusfile.patch
+++ b/contrib/audacity/patches/opusfile.patch
@@ -1,0 +1,12 @@
+type that makes the link empty
+--- a/cmake-proxies/cmake-modules/Findopusfile.cmake
++++ b/cmake-proxies/cmake-modules/Findopusfile.cmake
+@@ -24,7 +24,7 @@
+          add_library( opusfile::opusfile INTERFACE IMPORTED GLOBAL )
+ 
+          target_include_directories( opusfile::opusfile INTERFACE ${opusfile_INCLUDE_DIR} "${opusfile_INCLUDE_DIR}/opus" )
+-         target_link_libraries( opusfile::opusfile INTERFACE ${Oopusfile_LIBRARIES} )
++         target_link_libraries( opusfile::opusfile INTERFACE ${opusfile_LIBRARIES} )
+       endif()
+ 
+       mark_as_advanced(

--- a/contrib/audacity/template.py
+++ b/contrib/audacity/template.py
@@ -1,6 +1,6 @@
 pkgname = "audacity"
-pkgver = "3.3.3"
-pkgrel = 1
+pkgver = "3.4.0"
+pkgrel = 0
 build_style = "cmake"
 configure_args = [
     # release
@@ -16,8 +16,6 @@ configure_args = [
     "-Daudacity_has_vst3=OFF",
     "-Daudacity_lib_preference=system",
     "-Daudacity_obey_system_dependencies=ON",
-    # trash lib
-    "-Daudacity_use_libmad=local",
     # doesn't work with system version
     "-Daudacity_use_portsmf=local",
 ]
@@ -42,9 +40,11 @@ makedepends = [
     "lilv-devel",
     "lv2",
     "mpg123-devel",
+    "opusfile-devel",
     "pipewire-jack-devel",
     "portaudio-devel",
     "portmidi-devel",
+    "rapidjson",
     "soundtouch-devel",
     "soxr-devel",
     "sqlite-devel",
@@ -61,7 +61,7 @@ maintainer = "psykose <alice@ayaya.dev>"
 license = "GPL-3.0-or-later"
 url = "https://www.audacityteam.org"
 source = f"https://github.com/audacity/audacity/releases/download/Audacity-{pkgver}/audacity-sources-{pkgver}.tar.gz"
-sha256 = "3d9ff1fc6a0ecd6591f19445c77c80774d364b268da652760829cf3598e08071"
+sha256 = "1f6fafb6ee7beaa5d3fd4f6ce46b3274d5278046494efb7066e801aa49d28a37"
 # vis breaks symbols
 hardening = []
 # check: dont care

--- a/contrib/rapidjson/patches/disable-bad-flags.patch
+++ b/contrib/rapidjson/patches/disable-bad-flags.patch
@@ -1,0 +1,54 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9fc5273..3991718 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,7 +50,7 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -73,7 +73,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror -Wno-missing-field-initializers")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-field-initializers")
+     if (RAPIDJSON_BUILD_CXX11)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     endif()
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index 4d448cc..47d19ed 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -26,9 +26,9 @@ include_directories("../include/")
+ add_definitions(-D__STDC_FORMAT_MACROS)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -Wextra -Weffc++ -Wswitch-default")
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
+ endif()
+ 
+ foreach (example ${EXAMPLES})
+diff --git a/test/unittest/CMakeLists.txt b/test/unittest/CMakeLists.txt
+index b3204d6..d1c0add 100644
+--- a/test/unittest/CMakeLists.txt
++++ b/test/unittest/CMakeLists.txt
+@@ -37,9 +37,9 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal")
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
+     # If the user is running a newer version of Clang that includes the
+     # -Wdouble-promotion, we will ignore that warning.
+     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.7)

--- a/contrib/rapidjson/patches/no-vendor-gtest.patch
+++ b/contrib/rapidjson/patches/no-vendor-gtest.patch
@@ -1,0 +1,11 @@
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -8,7 +8,7 @@ IF(GTESTSRC_FOUND)
+         set(gtest_force_shared_crt ON)
+     endif()
+ 
+-    add_subdirectory(${GTEST_SOURCE_DIR} ${CMAKE_BINARY_DIR}/googletest)
++#   add_subdirectory(${GTEST_SOURCE_DIR} ${CMAKE_BINARY_DIR}/googletest)
+     include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
+ 
+     set(TEST_LIBRARIES gtest gtest_main)

--- a/contrib/rapidjson/template.py
+++ b/contrib/rapidjson/template.py
@@ -1,0 +1,33 @@
+# header files only
+pkgname = "rapidjson"
+pkgver = "1.1.0"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DGTESTSRC_FOUND=ON",
+    "-DGTEST_SOURCE_DIR=.",
+    "-DRAPIDJSON_BUILD_DOC=OFF",
+    "-DRAPIDJSON_BUILD_EXAMPLES=OFF",
+    "-DRAPIDJSON_BUILD_CXX11=OFF",
+]
+make_check_args = ["-E", "valgrind_unittest"]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+]
+makedepends = [
+    "gtest-devel",
+]
+pkgdesc = "JSON parser/generator for C++"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "MIT"
+url = "https://rapidjson.org"
+source = (
+    f"https://github.com/Tencent/rapidjson/archive/refs/tags/v{pkgver}.tar.gz"
+)
+sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
+
+
+def post_install(self):
+    self.install_license("license.txt")


### PR DESCRIPTION
the new opus import/export doesn't actually work and just fails to load mod-opus with ENOTTY. strace doesn't say anything interesting because every single module load does ioctl TIOCGWINSZ on the cfg file fd which fails with that, but only mod-opus fails to load..