### PR TITLE
main/musl: fix update-check after switch to git snapshot

### DIFF
--- a/main/musl-mallocng/update.py
+++ b/main/musl-mallocng/update.py
@@ -1,1 +1,2 @@
 pkgname = "musl"
+url = "http://www.musl-libc.org/releases"

--- a/main/musl/update.py
+++ b/main/musl/update.py
@@ -1,2 +1,1 @@
-pkgname = "musl"
 url = "http://www.musl-libc.org/releases"


### PR DESCRIPTION
Presumably we still want to know when a new release is done so we can stop using a git snapshot.