### PR TITLE
main/iso-codes: rebuild with gmake

### DIFF
--- a/main/iso-codes/template.py
+++ b/main/iso-codes/template.py
@@ -1,9 +1,10 @@
 pkgname = "iso-codes"
 pkgver = "4.15.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_gen = []
-hostmakedepends = ["gettext", "python", "pkgconf"]
+make_cmd = "gmake"
+hostmakedepends = ["gettext", "python", "pkgconf", "gmake"]
 pkgdesc = "List of country, language and currency names"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later"


### PR DESCRIPTION
This brings in the missing `.json` (such as `iso_3166-1.json`) and locale files which [`ki18n`](https://github.com/JamiKettunen/cports/blob/plasma6/contrib/ki18n/template.py) tests depend on for example.

Additionally there I needed `iso-codes-locale` instead of just `iso-codes` as otherwise I saw the following (but I suppose that's ok perhaps?)
```
FAIL!  : KCountrySubdivisionTest::testLookup() Compared values are not the same
   Actual   (s.name())                : "Wien"
   Expected (QStringLiteral("Vienne")): "Vienne"
   Loc: [../autotests/kcountrysubdivisiontest.cpp(50)]
```
Fixes https://github.com/chimera-linux/cports/issues/667.