### PR TITLE
main/gtkmm: sync ignore pattern with gtk4

### DIFF
--- a/main/gtkmm/update.py
+++ b/main/gtkmm/update.py
@@ -1,2 +1,2 @@
 url = "https://gitlab.gnome.org/GNOME/gtkmm/-/tags"
-ignore = ["4.1[13579].*"]
+ignore = ["4.*[13579].*"]


### PR DESCRIPTION
Will also ignore e.g. future unstable 4.21 release. Seeing bff9df418 reminded me of #413:
```
Checking for updates: gtkmm=4.0
Found update.py, using overrides...
Adding 'https://gitlab.gnome.org/GNOME/gtkmm/-/tags' for version check...
Fetching 'https://gitlab.gnome.org/GNOME/gtkmm/-/tags' for version checks...
Checking found version: 3.24.5
Checking found version: 3.24.6
Checking found version: 3.24.7
Checking found version: 3.24.8
Checking found version: 4.0.2
Checking found version: 4.2.0
Checking found version: 4.4.0
Checking found version: 4.6.0
Checking found version: 4.6.1
Checking found version: 4.7.1
Ignoring version '4.7.1' (due to '4.*[13579].*')
Checking found version: 4.8.0
Checking found version: 4.9.1
Ignoring version '4.9.1' (due to '4.*[13579].*')
Checking found version: 4.9.2
Ignoring version '4.9.2' (due to '4.*[13579].*')
Checking found version: 4.9.3
Ignoring version '4.9.3' (due to '4.*[13579].*')
Checking found version: 4.10.0
Checking found version: 4.11.1
Ignoring version '4.11.1' (due to '4.*[13579].*')
Checking found version: 4.11.2
Ignoring version '4.11.2' (due to '4.*[13579].*')
Checking found version: 4.11.3
Ignoring version '4.11.3' (due to '4.*[13579].*')
Checking found version: 4.12.0
Checking found version: 4.13.1
Ignoring version '4.13.1' (due to '4.*[13579].*')
main/gtkmm: 4.0 -> 4.0.2
main/gtkmm: 4.0 -> 4.2.0
main/gtkmm: 4.0 -> 4.4.0
main/gtkmm: 4.0 -> 4.6.0
main/gtkmm: 4.0 -> 4.6.1
main/gtkmm: 4.0 -> 4.8.0
main/gtkmm: 4.0 -> 4.10.0
main/gtkmm: 4.0 -> 4.12.0
```