### PR TITLE
contrib/netavark: install to usr/libexec/podman instead

### DIFF
--- a/contrib/netavark/template.py
+++ b/contrib/netavark/template.py
@@ -1,6 +1,6 @@
 pkgname = "netavark"
 pkgver = "1.8.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 hostmakedepends = ["cargo", "go-md2man", "protoc"]
 makedepends = ["linux-headers", "rust-std"]
@@ -10,3 +10,11 @@ license = "Apache-2.0"
 url = "https://github.com/containers/netavark"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "b1422ef6927458e9f80f7d322b751e29ab5d04d8ed6cb065baa82fa4291af10f"
+
+
+def do_install(self):
+    self.install_file(
+        f"target/{self.profile().triplet}/release/netavark",
+        "usr/libexec/podman",
+        0o755,
+    )


### PR DESCRIPTION
the project makefile install rule puts it in LIBEXECPODMAN; this is where other tools that utilise this like buildah expect to find it too.