### PR TITLE
main/lcms2: fix update-check

### DIFF
--- a/main/lcms2/update.py
+++ b/main/lcms2/update.py
@@ -1,0 +1,1 @@
+pattern = r"lcms([0-9.]+).tar.gz"


### PR DESCRIPTION
Not sure what happened here but perhaps the recently tagged 2.16 release candidate broke it? There's also an incorrectly named [`lcm2.16rc1`](https://github.com/mm2/Little-CMS/releases/tag/lcm2.16rc1) tag as well on top of [`lcms2.16rc1`](https://github.com/mm2/Little-CMS/releases/tag/lcms2.16rc1)

Either way this seems to work but I'm not sure it's the best solution:
```
Checking for updates: lcms2=2.15
Found update.py, using overrides...
Adding 'https://littlecms.com' for version check...
Adding 'https://github.com/mm2/Little-CMS/releases/download/lcms2.15/' for version check...
Fetching 'https://littlecms.com' for version checks...
Fetching 'https://github.com/mm2/Little-CMS/tags' for version checks...
Checking found version: 2.13
Checking found version: 2.13.1
Checking found version: 2.14
Checking found version: 2.15
```