### PR TITLE
contrib/fonts-noto-emoji-ttf: new package (2.042)

### DIFF
--- a/contrib/fonts-noto-emoji-ttf/files/66-noto-color-emoji.conf
+++ b/contrib/fonts-noto-emoji-ttf/files/66-noto-color-emoji.conf
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+
+<!--
+Set Noto Color Emoji as fallback for Noto family
+-->
+
+<fontconfig>
+    <match target="scan">
+        <test name="family"><string>Noto Color Emoji</string></test>
+        <edit name="charset" mode="assign">
+            <minus>
+            <name>charset</name>
+                <charset><range>
+                    <int>0x0000</int>
+                    <int>0x00FF</int>
+                </range></charset>
+            </minus>
+        </edit>
+    </match>
+    <match>
+        <test name="family" compare="contains"><string>Noto </string></test>
+        <edit name="family" mode="append" binding="weak">
+            <string>Noto Color Emoji</string>
+        </edit>
+    </match>
+</fontconfig>
+

--- a/contrib/fonts-noto-emoji-ttf/template.py
+++ b/contrib/fonts-noto-emoji-ttf/template.py
@@ -1,0 +1,17 @@
+pkgname = "fonts-noto-emoji-ttf"
+pkgver = "2.042"
+pkgrel = 0
+pkgdesc = "Google Noto emoji fonts"
+maintainer = "GeopJr <evan@geopjr.dev>"
+license = "OFL-1.1"
+url = "https://github.com/googlefonts/noto-emoji"
+source = f"{url}/archive/v{pkgver}/font-noto-emoji-{pkgver}.tar.gz"
+sha256 = "b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9"
+
+
+def do_install(self):
+    self.install_file(
+        self.files_path / "66-noto-color-emoji.conf",
+        "usr/share/fontconfig/conf.avail",
+    )
+    self.install_file("fonts/NotoColorEmoji.ttf", "usr/share/fonts/noto")


### PR DESCRIPTION
The fontconfig is taken from [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/noto-fonts-emoji/-/blob/main/66-noto-color-emoji.conf?ref_type=heads)