### PR TITLE
vulkan-validation-layers: new package (1.3.270)

### DIFF
--- a/contrib/robin-hood-hashing/template.py
+++ b/contrib/robin-hood-hashing/template.py
@@ -1,0 +1,16 @@
+pkgname = "robin-hood-hashing"
+pkgver = "3.11.5"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DRH_STANDALONE_PROJECT=OFF"]
+hostmakedepends = ["cmake", "ninja"]
+pkgdesc = "Fast & memory efficient hashtable based on robin hood hashing"
+maintainer = "flukey <flukey@vapourmail.eu>"
+license = "MIT"
+url = "https://github.com/martinus/robin-hood-hashing"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "3693e44dda569e9a8b87ce8263f7477b23af448a3c3600c8ab9004fe79c20ad0"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/contrib/vulkan-utility-libraries-devel-static
+++ b/contrib/vulkan-utility-libraries-devel-static
@@ -1,0 +1,1 @@
+vulkan-utility-libraries

--- a/contrib/vulkan-utility-libraries/template.py
+++ b/contrib/vulkan-utility-libraries/template.py
@@ -1,0 +1,21 @@
+pkgname = "vulkan-utility-libraries"
+pkgver = "1.3.270"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja"]
+makedepends = ["vulkan-headers"]
+pkgdesc = "Vulkan Utility Libraries"
+maintainer = "flukey <flukey@vapourmail.eu>"
+license = "Apache-2.0"
+url = "https://www.khronos.org/vulkan"
+source = f"https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/v{pkgver}.tar.gz"
+sha256 = "c402174add9146e3238104dbf18e50385129ff2ef252ebae49b3c5f61ccc0286"
+
+
+@subpackage(f"{pkgname}-devel-static")
+def _devel_static(self):
+    self.pkgdesc = f"{pkgdesc} (static libraries)"
+    self.depends = []
+    self.install_if = []
+
+    return ["usr/lib/*.a"]

--- a/contrib/vulkan-validation-layers/template.py
+++ b/contrib/vulkan-validation-layers/template.py
@@ -1,0 +1,31 @@
+pkgname = "vulkan-validation-layers"
+pkgver = "1.3.270"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DBUILD_WERROR=OFF",
+    "-DBUILD_WSI_WAYLAND_SUPPORT=ON",
+    "-DBUILD_WSI_XCB_SUPPORT=ON",
+    "-DBUILD_WSI_XLIB_SUPPORT=ON",
+    "-DCMAKE_BUILD_TYPE=Release",
+]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = [
+    "libx11-devel",
+    "libxcb-devel",
+    "libxrandr-devel",
+    "robin-hood-hashing",
+    "spirv-headers",
+    "spirv-tools-devel",
+    "vulkan-headers",
+    "vulkan-loader-devel",
+    "vulkan-utility-libraries",
+    "vulkan-utility-libraries-devel-static",
+    "wayland-devel",
+]
+pkgdesc = "Vulkan Validation Layers"
+maintainer = "flukey <flukey@vapourmail.eu>"
+license = "Apache-2.0"
+url = "https://www.khronos.org/vulkan"
+source = f"https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "710bb9fc66daebe57cbab8f9fc4fe15e31068c9f9982b92a4c8e91184514a8bd"


### PR DESCRIPTION
Required by wlroots's experimental and incomplete Vulkan renderer backend. Enabled via the `WLR_RENDERER=vulkan` environment variable when launching Sway.

Could someone check the `vulkan-utility-libraries-devel-static` subpackage please, it contains a single `.a` static lib, required by vulkan-validation-layers. I wasn't really sure how to package this, so I checked existing cports packages for inspiration, hope I got it right.

robin-hood-hashing is no longer maintained but vulkan-validation-layers seems to use it still for faster hashing (though is optional).

robin-hood-hashing and vulkan-utility-libraries are both header-only packages.