### PR TITLE
main/python-trove-classifiers: update to 2023.11.22

### DIFF
--- a/main/python-trove-classifiers/template.py
+++ b/main/python-trove-classifiers/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-trove-classifiers"
-pkgver = "2023.11.14"
+pkgver = "2023.11.22"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = [
@@ -16,6 +16,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "Apache-2.0"
 url = "https://github.com/pypa/trove-classifiers"
 source = f"$(PYPI_SITE)/t/trove-classifiers/trove-classifiers-{pkgver}.tar.gz"
-sha256 = "64b5e78305a5de347f2cd7ec8c12d704a3ef0cb85cc10c0ca5f73488d1c201f8"
+sha256 = "c31a7e92f965f060a244b57d8ed5ee6f53fcb413ee17ce790e00577cb369ad99"
 # cycle
 options = ["!check"]


### PR DESCRIPTION
https://github.com/pypa/trove-classifiers/releases/tag/2023.11.22