### PR TITLE
contrib/webp-pixbuf-loader: new package (0.2.5)

### DIFF
--- a/contrib/webp-pixbuf-loader/patches/update-webp-dependency-constraint.patch
+++ b/contrib/webp-pixbuf-loader/patches/update-webp-dependency-constraint.patch
@@ -1,0 +1,34 @@
+From 834657c8d189b6b0354401a00a842f539d7c29e4 Mon Sep 17 00:00:00 2001
+From: Rui Chen <rui@chenrui.dev>
+Date: Fri, 22 Sep 2023 15:28:35 -0400
+Subject: [PATCH] fix: update webp dependency constraint
+
+Signed-off-by: Rui Chen <rui@chenrui.dev>
+---
+ meson.build | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index e472cc2..c46f11b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -7,9 +7,9 @@ if gdk_pb_moddir == ''
+   gdk_pb_moddir = gdkpb.get_variable(pkgconfig: 'gdk_pixbuf_moduledir', pkgconfig_define: ['prefix', get_option('prefix')])
+ endif
+ 
+-webp = dependency('libwebp', version: '>1.3.2')
+-webpdemux = dependency('libwebpdemux', version: '>1.3.2')
+-webpmux = dependency('libwebpmux', version: '>1.3.2')
++webp = dependency('libwebp', version: '>=1.3.2')
++webpdemux = dependency('libwebpdemux', version: '>=1.3.2')
++webpmux = dependency('libwebpmux', version: '>=1.3.2')
+ 
+ pbl_webp = shared_module('pixbufloader-webp',
+                          sources: ['io-webp.c', 'io-webp-anim.c', 'io-webp-anim-iter.c'],
+@@ -30,4 +30,4 @@ configure_file(input: 'webp-pixbuf.thumbnailer.in',
+ warning('If you install this loader locally, make sure you rebuild the pixbuf loader cache')
+ warning('To rebuild the cache run: `pkg-config gdk-pixbuf-2.0 --variable=gdk_pixbuf_query_loaders` --update-cache')
+ 
+-subdir('tests')
+\ No newline at end of file
++subdir('tests')

--- a/contrib/webp-pixbuf-loader/template.py
+++ b/contrib/webp-pixbuf-loader/template.py
@@ -1,0 +1,12 @@
+pkgname = "webp-pixbuf-loader"
+pkgver = "0.2.5"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = ["meson", "pkgconf"]
+makedepends = ["gdk-pixbuf-devel", "libwebp-devel"]
+pkgdesc = "WebP image format GdkPixbuf loader"
+maintainer = "GeopJr <evan@geopjr.dev>"
+license = "LGPL-2.0-or-later"
+url = "https://github.com/aruiz/webp-pixbuf-loader"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "e1b76c538a1d3b3fc41323d044c7c84365ab9bd5ab3dcc8de7efb0c7dc2f206b"


### PR DESCRIPTION
0.2.5 has been tagged with one commit over 0.2.4 https://github.com/aruiz/webp-pixbuf-loader/commit/f7253133ba0902afbe65bd2482f3b9e1a84b58fb (for the webp CVE) but it's broken. It requires webp **>** 1.3.2 when it should be **>=**. It [has been fixed](https://github.com/aruiz/webp-pixbuf-loader/commit/834657c8) on the main branch. I set it to ignore 0.2.5 for now