### PR TITLE
contrib/scc: update to 3.2.0

### DIFF
--- a/contrib/scc/template.py
+++ b/contrib/scc/template.py
@@ -1,6 +1,6 @@
 pkgname = "scc"
-pkgver = "3.1.0"
-pkgrel = 1
+pkgver = "3.2.0"
+pkgrel = 0
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "Fast and accurate code counter"
@@ -8,7 +8,7 @@ maintainer = "Wesley Moore <wes@wezm.net>"
 license = "MIT OR Unlicense"
 url = "https://github.com/boyter/scc"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "bffea99c7f178bc48bfba3c64397d53a20a751dfc78221d347aabdce3422fd20"
+sha256 = "69cce0b57e66c736169bd07943cdbe70891bc2ff3ada1f4482acbd1335adbfad"
 # objcopy fails on ppc
 options = ["!debug"]
 

--- a/src/cbuild/core/profile.py
+++ b/src/cbuild/core/profile.py
@@ -245,7 +245,7 @@ def _get_rustflags(
 
 def _get_goflags(self, name, extra_flags, debug, hardening, opts, stage, shell):
     hard = _get_harden(self, hardening, opts, stage)
-    bflags = ["-mod=readonly", "-modcacherw"]
+    bflags = ["-modcacherw"]
 
     if hard["pie"]:
         bflags.append("-buildmode=pie")


### PR DESCRIPTION
Updates scc and drops `-mod=readonly` as discussed in #999.

Fixes #999