### PR TITLE
main/ostree: build with libarchive support

### DIFF
--- a/main/ostree/template.py
+++ b/main/ostree/template.py
@@ -1,6 +1,6 @@
 pkgname = "ostree"
 pkgver = "2023.7"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--with-builtin-grub2-mkconfig",
@@ -33,6 +33,7 @@ makedepends = [
     "linux-headers",
     "openssl-devel",
     "xz-devel",
+    "libarchive-devel",
 ]
 checkdepends = ["attr-progs", "bsdtar", "gnupg", "xz"]
 pkgdesc = "Operating system and container binary deployment and upgrades"


### PR DESCRIPTION
The Fedora flatpak repository at least appears to need support for parsing tar files directly.
![image](https://github.com/chimera-linux/cports/assets/47358222/df87ebc0-9835-45b1-a33c-d6e8c58bf2b1)

