### PR TITLE
xclip & pyclip

### DIFF
--- a/contrib/python-pyclip-wayland
+++ b/contrib/python-pyclip-wayland
@@ -1,0 +1,1 @@
+python-pyclip

--- a/contrib/python-pyclip-x11
+++ b/contrib/python-pyclip-x11
@@ -1,0 +1,1 @@
+python-pyclip

--- a/contrib/python-pyclip/template.py
+++ b/contrib/python-pyclip/template.py
@@ -1,0 +1,39 @@
+pkgname = "python-pyclip"
+pkgver = "0.7.0"
+pkgrel = 0
+build_style = "python_pep517"
+make_check_wrapper = ["xvfb-run"]
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
+depends = ["python"]
+checkdepends = ["python-pytest", "xclip", "xserver-xorg-xvfb"]
+pkgdesc = "Python cross-platform clipboard module"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "Apache-2.0"
+url = "https://github.com/spyoungtech/pyclip"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "6fd5e0eaa40ff349959d1cee2872eee90ae32065cc5df9714b1066981535acde"
+# 11/16 tests fail with exit code 1 & "Error: Can't open display: (null)" even under xvfb
+options = ["!check"]
+
+
+@subpackage("python-pyclip-wayland")
+def _wayland(self):
+    self.pkgdesc += " (Wayland support)"
+    self.install_if = [f"{pkgname}={pkgver}-r{pkgrel}"]
+    self.depends = ["wl-clipboard"]
+    self.build_style = "meta"
+    return []
+
+
+@subpackage("python-pyclip-x11")
+def _x11(self):
+    self.pkgdesc += " (X11 support)"
+    self.install_if = [f"{pkgname}={pkgver}-r{pkgrel}"]
+    self.depends = ["xclip"]
+    self.build_style = "meta"
+    return []

--- a/contrib/xclip/template.py
+++ b/contrib/xclip/template.py
@@ -1,0 +1,20 @@
+pkgname = "xclip"
+pkgver = "0.13"
+pkgrel = 0
+build_style = "gnu_configure"
+make_cmd = "gmake"
+make_dir = "."
+hostmakedepends = ["automake", "gmake"]
+makedepends = ["libxmu-devel"]
+checkdepends = ["psmisc", "xserver-xorg-xvfb"]
+pkgdesc = "Command line interface to the X11 clipboard"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/astrand/xclip"
+source = f"{url}/archive/{pkgver}.tar.gz"
+sha256 = "ca5b8804e3c910a66423a882d79bf3c9450b875ac8528791fb60ec9de667f758"
+hardening = ["vis", "cfi"]
+
+
+def do_check(self):
+    self.do("xvfb-run", "./xctest")


### PR DESCRIPTION
If someone has an idea about the failing tests for `python-pyclip` here's the log: https://paste.c-net.org/4xpexgjmyico

I would've liked to make `python-pyclip-(wayland|x11)` only install if you had some Wayland desktop / Xorg or Xwayland but I don't think that's really feasible and doesn't really matter anyway. If someone doesn't want one they can e.g. `apk add '!python-pyclip-x11'` or whatever