### PR TITLE
contrib/fonts-noto-sans-cjk: new package (2.004)

### DIFF
--- a/contrib/fonts-noto-sans-cjk-extra
+++ b/contrib/fonts-noto-sans-cjk-extra
@@ -1,0 +1,1 @@
+fonts-noto-sans-cjk

--- a/contrib/fonts-noto-sans-cjk-extra-otf
+++ b/contrib/fonts-noto-sans-cjk-extra-otf
@@ -1,0 +1,1 @@
+fonts-noto-sans-cjk

--- a/contrib/fonts-noto-sans-cjk-extra-ttf
+++ b/contrib/fonts-noto-sans-cjk-extra-ttf
@@ -1,0 +1,1 @@
+fonts-noto-sans-cjk

--- a/contrib/fonts-noto-sans-cjk-otf
+++ b/contrib/fonts-noto-sans-cjk-otf
@@ -1,0 +1,1 @@
+fonts-noto-sans-cjk

--- a/contrib/fonts-noto-sans-cjk-ttf
+++ b/contrib/fonts-noto-sans-cjk-ttf
@@ -1,0 +1,1 @@
+fonts-noto-sans-cjk

--- a/contrib/fonts-noto-sans-cjk/files/70-noto-sans-cjk.conf
+++ b/contrib/fonts-noto-sans-cjk/files/70-noto-sans-cjk.conf
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK HK</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans Mono CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans Mono CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK HK</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/contrib/fonts-noto-sans-cjk/template.py
+++ b/contrib/fonts-noto-sans-cjk/template.py
@@ -1,0 +1,73 @@
+pkgname = "fonts-noto-sans-cjk"
+pkgver = "2.004"
+pkgrel = 0
+pkgdesc = "Google Noto Sans CJK fonts"
+maintainer = "GeopJr <evan@geopjr.dev>"
+license = "OFL-1.1"
+url = "https://github.com/googlefonts/noto-cjk"
+
+source = [
+    f"{url}/releases/download/Sans{pkgver}/03_NotoSansCJK-OTC.zip",
+    f"{url}/releases/download/Sans{pkgver}/04_NotoSansCJK-OTF.zip",
+]
+sha256 = [
+    "528f4e1b25ff3badb0321b38d015d954c4c0de926c7830ef50e4a1948f6a3eed",
+    "8516970d4ff5f9d1f8bdd4ad5b9d6b5e1d292c816303e288c4933390b0e8abdb",
+]
+
+
+def do_install(self):
+    self.install_file(
+        self.files_path / "70-noto-sans-cjk.conf",
+        "usr/share/fontconfig/conf.avail",
+    )
+
+    self.install_file("*.ttc", "usr/share/fonts/noto", glob=True)
+    self.install_file("OTF/*/*.otf", "usr/share/fonts/noto", glob=True)
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+def _gensub(subn, subd, subc, sube):
+    @subpackage(f"{pkgname}-{subn}")
+    def _sub(self):
+        self.pkgdesc = f"{pkgdesc} - {subd}"
+        self.depends = [f"{pkgname}={pkgver}-r{pkgrel}", f"!{pkgname}-{subc}"]
+        if subn == "otf":
+            self.install_if = [f"{pkgname}={pkgver}-r{pkgrel}"]
+
+        return [
+            f"usr/share/fonts/noto/Noto*-Bold.{sube}",
+            f"usr/share/fonts/noto/Noto*-Regular.{sube}",
+        ]
+
+    @subpackage(f"{pkgname}-extra-{subn}")
+    def _sub_extra(self):
+        self.pkgdesc = f"{pkgdesc} - {subd} (additional variants)"
+        self.depends = [
+            f"{pkgname}-extra={pkgver}-r{pkgrel}",
+            f"!{pkgname}-extra-{subc}",
+            f"!{pkgname}-{subc}",
+        ]
+        if subn == "otf":
+            self.install_if = [f"{pkgname}-extra={pkgver}-r{pkgrel}"]
+
+        return [f"usr/share/fonts/noto/*.{sube}"]
+
+
+for _subn, _subd, _subc, _sube in [
+    ("otf", "OpenType", "ttf", "otf"),
+    ("ttf", "TrueType", "otf", "ttc"),
+]:
+    _gensub(_subn, _subd, _subc, _sube)
+
+
+@subpackage("fonts-noto-sans-cjk-extra")
+def _extra(self):
+    self.pkgdesc = f"{pkgdesc} (additional variants)"
+    self.depends = [f"{pkgname}={pkgver}-r{pkgrel}"]
+    self.build_style = "meta"
+
+    return []

--- a/contrib/fonts-noto-sans-cjk/update.py
+++ b/contrib/fonts-noto-sans-cjk/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/notofonts/noto-cjk/tags"
+pattern = r"/tags/Sans([\d.]+).tar.gz"


### PR DESCRIPTION
Sans version

- Same subpackaging as #1006 
- fontconfig from Arch