### PR TITLE
contrib/android-udev-rules: update to 20231207

### DIFF
--- a/contrib/android-udev-rules/template.py
+++ b/contrib/android-udev-rules/template.py
@@ -1,5 +1,5 @@
 pkgname = "android-udev-rules"
-pkgver = "20231124"
+pkgver = "20231207"
 pkgrel = 0
 pkgdesc = (
     "Android udev rules list aimed to be the most comprehensive on the net"
@@ -8,7 +8,7 @@ maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
 license = "GPL-3.0-or-later"
 url = "https://github.com/M0Rf30/android-udev-rules"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "0de9e2fa5ee2c65d3854c3c796701de1cbf9d47f70fa261bdadba4578632733c"
+sha256 = "f8f5513e08cd0e9299ba707c9acc5dec53b9cbdc255d4bfd83abfd378928b6e6"
 options = ["!splitudev"]
 system_groups = ["adbusers"]
 


### PR DESCRIPTION
https://github.com/M0Rf30/android-udev-rules/releases/tag/20231207