### PR TITLE
main/ostree: update to 2023.8

### DIFF
--- a/main/ostree/template.py
+++ b/main/ostree/template.py
@@ -1,6 +1,6 @@
 pkgname = "ostree"
-pkgver = "2023.7"
-pkgrel = 1
+pkgver = "2023.8"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--with-builtin-grub2-mkconfig",
@@ -41,7 +41,7 @@ maintainer = "eater <=@eater.me>"
 license = "LGPL-2.0-or-later"
 url = "https://ostreedev.github.io/ostree"
 source = f"https://github.com/ostreedev/ostree/releases/download/v{pkgver}/libostree-{pkgver}.tar.xz"
-sha256 = "19cda718705f7ac8c018c939c38b1bb8412deaaa04862da98cd9fe9243f073bf"
+sha256 = "b6fffc267188e40d60755e6d7f2be65831795baa53b0fd9dd6c6809c7e54796d"
 # failing on their test harness, i will find motivation Soon
 options = ["!check"]
 


### PR DESCRIPTION
https://github.com/ostreedev/ostree/releases/tag/v2023.8