### PR TITLE
contrib/python-cryptography: update to 41.0.7

### DIFF
--- a/contrib/python-cryptography/template.py
+++ b/contrib/python-cryptography/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-cryptography"
-pkgver = "41.0.5"
+pkgver = "41.0.7"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = [
@@ -28,7 +28,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-3-Clause OR Apache-2.0"
 url = "https://github.com/pyca/cryptography"
 source = f"$(PYPI_SITE)/c/cryptography/cryptography-{pkgver}.tar.gz"
-sha256 = "392cb88b597247177172e02da6b7a63deeff1937fa6fec3bbf902ebd75d97ec7"
+sha256 = "13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc"
 # unpackaged checkdepends
 options = ["!check"]
 


### PR DESCRIPTION
https://github.com/pyca/cryptography/blob/4054596afc6f2b6cfcc54f56c35c34e0e429cb66/CHANGELOG.rst