### PR TITLE
main/glib: update to 2.78.3

### DIFF
--- a/main/glib/template.py
+++ b/main/glib/template.py
@@ -1,5 +1,5 @@
 pkgname = "glib"
-pkgver = "2.78.1"
+pkgver = "2.78.3"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -35,7 +35,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later"
 url = "https://wiki.gnome.org/Projects/GLib"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "915bc3d0f8507d650ead3832e2f8fb670fce59aac4d7754a7dab6f1e6fed78b2"
+sha256 = "609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21"
 # FIXME int - e.g. g_ascii_strtoll fails
 hardening = ["!int"]
 # cyclic with desktop-file-utils


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/glib/-/releases/2.78.2  
https://gitlab.gnome.org/GNOME/glib/-/releases/2.78.3