### PR TITLE
main/readline: fix update-check

### DIFF
--- a/main/readline/update.py
+++ b/main/readline/update.py
@@ -1,0 +1,2 @@
+url = "https://git.savannah.gnu.org/cgit/readline.git/refs/"
+pattern = r"readline-([\d.]+)\.tar"


### PR DESCRIPTION
This has been broken for over a week now with the website seemingly having some issues with the cert:
```
$ curl -v https://tiswww.cwru.edu/php/chet/readline/rltop.html
*   Trying 129.22.12.56:443...
* Connected to tiswww.cwru.edu (129.22.12.56) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS alert, unknown CA (560):
* SSL certificate problem: unable to get local issuer certificate
* Closing connection
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```
Instead just scrape the cgit refs page:
```
Checking for updates: readline=8.2.001
Found update.py, using overrides...
Adding 'https://git.savannah.gnu.org/cgit/readline.git/refs/' for version check...
Fetching 'https://git.savannah.gnu.org/cgit/readline.git/refs/' for version checks...
Checking found version: 6.3
Checking found version: 7.0
Checking found version: 8.0
Checking found version: 8.1
Checking found version: 8.2
```