### PR TITLE
contrib/fonts-noto-serif-cjk: new package (2.002)

### DIFF
--- a/contrib/fonts-noto-serif-cjk-extra
+++ b/contrib/fonts-noto-serif-cjk-extra
@@ -1,0 +1,1 @@
+fonts-noto-serif-cjk

--- a/contrib/fonts-noto-serif-cjk-extra-otf
+++ b/contrib/fonts-noto-serif-cjk-extra-otf
@@ -1,0 +1,1 @@
+fonts-noto-serif-cjk

--- a/contrib/fonts-noto-serif-cjk-extra-ttf
+++ b/contrib/fonts-noto-serif-cjk-extra-ttf
@@ -1,0 +1,1 @@
+fonts-noto-serif-cjk

--- a/contrib/fonts-noto-serif-cjk-otf
+++ b/contrib/fonts-noto-serif-cjk-otf
@@ -1,0 +1,1 @@
+fonts-noto-serif-cjk

--- a/contrib/fonts-noto-serif-cjk-ttf
+++ b/contrib/fonts-noto-serif-cjk-ttf
@@ -1,0 +1,1 @@
+fonts-noto-serif-cjk

--- a/contrib/fonts-noto-serif-cjk/files/70-noto-serif-cjk.conf
+++ b/contrib/fonts-noto-serif-cjk/files/70-noto-serif-cjk.conf
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Serif CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Serif CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK HK</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/contrib/fonts-noto-serif-cjk/template.py
+++ b/contrib/fonts-noto-serif-cjk/template.py
@@ -1,0 +1,73 @@
+pkgname = "fonts-noto-serif-cjk"
+pkgver = "2.002"
+pkgrel = 0
+pkgdesc = "Google Noto Serif CJK fonts"
+maintainer = "GeopJr <evan@geopjr.dev>"
+license = "OFL-1.1"
+url = "https://github.com/googlefonts/noto-cjk"
+
+source = [
+    f"{url}/releases/download/Serif{pkgver}/04_NotoSerifCJKOTC.zip",
+    f"{url}/releases/download/Serif{pkgver}/05_NotoSerifCJKOTF.zip",
+]
+sha256 = [
+    "941985d9fd860492d15640b53edc9668d568877140c524ccd83deb3d9b7a2950",
+    "f3c53999f0c65eae5ad73c7db34217ded4d823fb67c9f3902a4b552734e3fba0",
+]
+
+
+def do_install(self):
+    self.install_file(
+        self.files_path / "70-noto-serif-cjk.conf",
+        "usr/share/fontconfig/conf.avail",
+    )
+
+    self.install_file("OTC/*.ttc", "usr/share/fonts/noto", glob=True)
+    self.install_file("OTF/*/*.otf", "usr/share/fonts/noto", glob=True)
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+def _gensub(subn, subd, subc, sube):
+    @subpackage(f"{pkgname}-{subn}")
+    def _sub(self):
+        self.pkgdesc = f"{pkgdesc} - {subd}"
+        self.depends = [f"{pkgname}={pkgver}-r{pkgrel}", f"!{pkgname}-{subc}"]
+        if subn == "otf":
+            self.install_if = [f"{pkgname}={pkgver}-r{pkgrel}"]
+
+        return [
+            f"usr/share/fonts/noto/Noto*-Bold.{sube}",
+            f"usr/share/fonts/noto/Noto*-Regular.{sube}",
+        ]
+
+    @subpackage(f"{pkgname}-extra-{subn}")
+    def _sub_extra(self):
+        self.pkgdesc = f"{pkgdesc} - {subd} (additional variants)"
+        self.depends = [
+            f"{pkgname}-extra={pkgver}-r{pkgrel}",
+            f"!{pkgname}-extra-{subc}",
+            f"!{pkgname}-{subc}",
+        ]
+        if subn == "otf":
+            self.install_if = [f"{pkgname}-extra={pkgver}-r{pkgrel}"]
+
+        return [f"usr/share/fonts/noto/*.{sube}"]
+
+
+for _subn, _subd, _subc, _sube in [
+    ("otf", "OpenType", "ttf", "otf"),
+    ("ttf", "TrueType", "otf", "ttc"),
+]:
+    _gensub(_subn, _subd, _subc, _sube)
+
+
+@subpackage("fonts-noto-serif-cjk-extra")
+def _extra(self):
+    self.pkgdesc = f"{pkgdesc} (additional variants)"
+    self.depends = [f"{pkgname}={pkgver}-r{pkgrel}"]
+    self.build_style = "meta"
+
+    return []

--- a/contrib/fonts-noto-serif-cjk/update.py
+++ b/contrib/fonts-noto-serif-cjk/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/notofonts/noto-cjk/tags"
+pattern = r"/tags/Serif([\d.]+).tar.gz"


### PR DESCRIPTION
Serif version

- Same subpackaging as #1006 
- fontconfig from Arch
- (Sans version on #1007)