### PR TITLE
contrib/netavark: update to 1.9.0

### DIFF
--- a/contrib/netavark/template.py
+++ b/contrib/netavark/template.py
@@ -1,6 +1,6 @@
 pkgname = "netavark"
-pkgver = "1.8.0"
-pkgrel = 1
+pkgver = "1.9.0"
+pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo", "go-md2man", "protoc"]
 makedepends = ["linux-headers", "rust-std"]
@@ -9,7 +9,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "Apache-2.0"
 url = "https://github.com/containers/netavark"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "b1422ef6927458e9f80f7d322b751e29ab5d04d8ed6cb065baa82fa4291af10f"
+sha256 = "9ec50b715ded0a0699134c001656fdd1411e3fb5325d347695c6cb8cc5fcf572"
 
 
 def do_install(self):


### PR DESCRIPTION
https://github.com/containers/netavark/releases/tag/v1.9.0