### PR TITLE
main/*: embrace tmpfiles.d

### DIFF
--- a/main/chrony/files/chrony-dir
+++ b/main/chrony/files/chrony-dir
@@ -1,6 +1,0 @@
-# prepare chrony environment
-
-type       = scripted
-command    = /usr/bin/install -d -m 750 -o _chrony -g _chrony /run/chrony
-depends-on = network.target
-depends-on = local.target

--- a/main/chrony/files/chrony.conf
+++ b/main/chrony/files/chrony.conf
@@ -1,0 +1,3 @@
+# Prepare chrony environment
+
+d /run/chrony 0750 _chrony _chrony -

--- a/main/chrony/files/chronyd
+++ b/main/chrony/files/chronyd
@@ -4,5 +4,4 @@ type            = process
 command         = /usr/bin/chronyd -n -u _chrony
 depends-on      = network.target
 depends-on      = local.target
-depends-on      = chrony-dir
 smooth-recovery = true

--- a/main/chrony/template.py
+++ b/main/chrony/template.py
@@ -1,6 +1,6 @@
 pkgname = "chrony"
 pkgver = "4.5"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--with-user=_chrony",
@@ -48,8 +48,9 @@ def post_install(self):
     # default dirs
     self.install_dir("var/log/chrony", empty=True)
     self.install_dir("var/lib/chrony", empty=True)
+    # tmpfiles.d
+    self.install_file(self.files_path / "chrony.conf", "usr/lib/tmpfiles.d")
     # dinit services
-    self.install_service(self.files_path / "chrony-dir")
     self.install_service(self.files_path / "chronyd")
     self.install_service(self.files_path / "chrony", enable=True)
 

--- a/main/dbus/files/dbus
+++ b/main/dbus/files/dbus
@@ -1,7 +1,7 @@
 # dbus daemon service
 
 type               = process
-command            = /usr/libexec/dbus-daemon.wrapper --print-address=4
+command            = /usr/bin/dbus-daemon --system --nofork --nopidfile --print-address=4
 before             = login.target
-depends-on         = dbus-prepare
+depends-on         = local.target
 ready-notification = pipefd:4

--- a/main/dbus/files/dbus-daemon.wrapper
+++ b/main/dbus/files/dbus-daemon.wrapper
@@ -1,9 +1,0 @@
-#!/bin/sh
-#
-# this wrapper exists to prepare the environment ahead of launch if needed
-
-if [ ! -d "/run/dbus" ]; then
-    install -d -m 755 -g 22 -o 22 "/run/dbus"
-fi
-
-exec /usr/bin/dbus-daemon --system --nofork --nopidfile "$@"

--- a/main/dbus/files/dbus-prepare
+++ b/main/dbus/files/dbus-prepare
@@ -1,5 +1,0 @@
-# prepare dbus daemon environment
-
-type       = scripted
-command    = /usr/bin/install -d -m 755 -o dbus -g dbus /run/dbus
-depends-on = local.target

--- a/main/dbus/files/dbus.conf
+++ b/main/dbus/files/dbus.conf
@@ -1,4 +1,5 @@
-# Symlink /var/lib/dbus/machine-id to /etc/machine-id
+# Prepare dbus daemon environment, symlink /var/lib/dbus/machine-id to /etc/machine-id
 
+d /run/dbus 0755 dbus dbus -
 d /var/lib/dbus 0755 root root -
 L+ /var/lib/dbus/machine-id - - - - ../../../etc/machine-id

--- a/main/dbus/template.py
+++ b/main/dbus/template.py
@@ -1,6 +1,6 @@
 pkgname = "dbus"
 pkgver = "1.14.10"
-pkgrel = 2
+pkgrel = 3
 build_style = "gnu_configure"
 configure_args = [
     "--disable-selinux",
@@ -43,12 +43,8 @@ def post_install(self):
     self.install_dir("etc/dbus-1/session.d", empty=True)
     # service file
     self.install_file(
-        self.files_path / "dbus-daemon.wrapper", "usr/libexec", mode=0o755
-    )
-    self.install_file(
         self.files_path / "dbus-session.wrapper", "usr/libexec", mode=0o755
     )
-    self.install_service(self.files_path / "dbus-prepare")
     self.install_service(self.files_path / "dbus", enable=True)
     self.install_service(self.files_path / "dbus.user", enable=True)
     # x11 support

--- a/main/gdm/files/gdm
+++ b/main/gdm/files/gdm
@@ -2,7 +2,7 @@
 
 type            = process
 command         = /usr/bin/gdm
-depends-on      = gdm-prepare
+depends-on      = local.target
 depends-on      = login.target
 depends-on      = dbus
 depends-ms      = elogind

--- a/main/gdm/files/gdm-prepare
+++ b/main/gdm/files/gdm-prepare
@@ -1,5 +1,0 @@
-# prepare gdm environment
-
-type       = scripted
-command    = /usr/bin/install -d -m 711 -o root -g _gdm /run/gdm
-depends-on = local.target

--- a/main/gdm/files/gdm.conf
+++ b/main/gdm/files/gdm.conf
@@ -1,0 +1,3 @@
+# Prepare GDM environment
+
+d /run/gdm 0711 root _gdm -

--- a/main/gdm/template.py
+++ b/main/gdm/template.py
@@ -1,6 +1,6 @@
 pkgname = "gdm"
 pkgver = "45.0.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 # TODO: plymouth
 configure_args = [
@@ -74,7 +74,7 @@ system_users = [
 def post_install(self):
     self.install_file(self.files_path / "Xsession", "etc/gdm", mode=0o755)
 
-    self.install_service(self.files_path / "gdm-prepare")
+    self.install_file(self.files_path / "gdm.conf", "usr/lib/tmpfiles.d")
     self.install_service(self.files_path / "gdm")
 
     # drop magic nonsense with wayland disabling, we don't support

--- a/main/musl-nscd/files/nscd
+++ b/main/musl-nscd/files/nscd
@@ -1,8 +1,7 @@
 # nscd service
 
-type               = process
-command            = /usr/bin/nscd
-before             = local.target
-depends-on         = nscd-prepare
-restart            = true
-smooth-recovery    = true
+type            = process
+command         = /usr/bin/nscd
+depends-on      = local.target
+restart         = true
+smooth-recovery = true

--- a/main/musl-nscd/files/nscd-prepare
+++ b/main/musl-nscd/files/nscd-prepare
@@ -1,5 +1,0 @@
-# prepare nscd environment
-
-type       = scripted
-command    = install -d -m 755 /var/run/nscd /var/db/nscd
-depends-on = early-root-rw.target

--- a/main/musl-nscd/files/nscd.conf
+++ b/main/musl-nscd/files/nscd.conf
@@ -1,0 +1,3 @@
+# Prepare nscd environment
+
+d /run/nscd 0755 root root -

--- a/main/musl-nscd/template.py
+++ b/main/musl-nscd/template.py
@@ -1,6 +1,6 @@
 pkgname = "musl-nscd"
 pkgver = "1.1.1"
-pkgrel = 2
+pkgrel = 3
 build_style = "gnu_configure"
 configure_env = {"YACC": "bison"}
 make_cmd = "gmake"
@@ -19,7 +19,8 @@ options = ["!check"]
 
 def post_install(self):
     self.install_license("COPYRIGHT")
-    self.install_service(self.files_path / "nscd-prepare")
+    self.install_dir("var/db/nscd", empty=True)
+    self.install_file(self.files_path / "nscd.conf", "usr/lib/tmpfiles.d")
     self.install_service(self.files_path / "nscd")
 
 

--- a/main/util-linux/files/uuidd
+++ b/main/util-linux/files/uuidd
@@ -3,7 +3,7 @@
 type            = process
 command         = /usr/bin/uuidd -F -P
 before          = pre-local.target
-depends-on      = uuidd-dir
+depends-on      = early-devices.target
 run-as          = _uuidd
 restart         = true
 smooth-recovery = true

--- a/main/util-linux/files/uuidd-dir
+++ b/main/util-linux/files/uuidd-dir
@@ -1,5 +1,0 @@
-# prepare uuidd environment
-
-type       = scripted
-command    = install -d -m 755 -o _uuidd -g _uuidd /run/uuidd
-depends-on = early-devices.target

--- a/main/util-linux/files/uuidd.conf
+++ b/main/util-linux/files/uuidd.conf
@@ -1,0 +1,3 @@
+# Prepare uuidd environment
+
+d /run/uuidd 0755 _uuidd _uuidd -

--- a/main/util-linux/template.py
+++ b/main/util-linux/template.py
@@ -1,6 +1,6 @@
 pkgname = "util-linux"
-pkgver = "2.39.2"
-pkgrel = 1
+pkgver = "2.39.3"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "--auto-feature=enabled",
@@ -64,7 +64,7 @@ url = "https://www.kernel.org/pub/linux/utils/util-linux"
 source = (
     f"$(KERNEL_SITE)/utils/{pkgname}/v{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
 )
-sha256 = "87abdfaa8e490f8be6dde976f7c80b9b5ff9f301e1b67e3899e1f05a59a1531f"
+sha256 = "7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f"
 tool_flags = {"CFLAGS": ["-D_DIRENT_HAVE_D_TYPE"]}
 # checkdepends are missing
 options = ["!check"]
@@ -123,9 +123,10 @@ def post_install(self):
             force=True,
         )
 
-    # services
-    for s in ["uuidd", "uuidd-dir"]:
-        self.install_service(self.files_path / s)
+    # tmpfiles.d
+    self.install_file(self.files_path / "uuidd.conf", "usr/lib/tmpfiles.d")
+    # service
+    self.install_service(self.files_path / "uuidd")
 
 
 @subpackage("util-linux-common")


### PR DESCRIPTION
Gets rid of `*-prepare` and `*-dir` dinit services that were just creating some dirs on boot in favor of using `tmpfiles.d`; this should be fine but definitely needs to be properly tested to be sure (I only tested a GNOME VM still booted to desktop but not every individual service file modified here).

Also converted `/var/db/nscd` to an "empty" packaged dir as it didn't sound like something that needs to be created every time on boot/service start, perhaps I'm wrong though or there was some other reason to do it like this previously.

Additionally: https://github.com/util-linux/util-linux/blob/stable/v2.39/Documentation/releases/v2.39.3-ReleaseNotes