### PR TITLE
gnome bumps

### DIFF
--- a/main/evolution-data-server/template.py
+++ b/main/evolution-data-server/template.py
@@ -1,5 +1,5 @@
 pkgname = "evolution-data-server"
-pkgver = "3.50.1"
+pkgver = "3.50.2"
 pkgrel = 0
 build_style = "cmake"
 # TODO: libgdata
@@ -47,7 +47,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/evolution-data-server"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "91f4ffc38a1b8d2fe8939834449ac541c0bff4a39b444edc2a9529344a28e98a"
+sha256 = "5e66270388d50c14f3b1ae3fa0d2127b9fedce752acd393b5545281b01fc4970"
 # internally passes some stuff that only goes to linker
 tool_flags = {"CFLAGS": ["-Wno-unused-command-line-argument"]}
 options = ["!cross"]

--- a/main/gnome-bluetooth/template.py
+++ b/main/gnome-bluetooth/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnome-bluetooth"
-pkgver = "42.6"
+pkgver = "42.7"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -30,7 +30,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://wiki.gnome.org/Projects/GnomeBluetooth"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "5864fe6f1e718715db26b62201b75a59020cf4247fec37645b3559cd2dba59d0"
+sha256 = "94df1729dbec3bb105e588eaf5312bbbaa05c49ea733202a10dc3f7532bdf869"
 options = ["!cross"]
 
 

--- a/main/gnome-control-center/patches/disable-broken-test.patch
+++ b/main/gnome-control-center/patches/disable-broken-test.patch
@@ -1,0 +1,18 @@
+tries to spawn Xvfb manually
+--
+--- a/tests/network/meson.build
++++ b/tests/network/meson.build
+@@ -26,13 +26,6 @@
+       'GTK_A11Y=none',
+ ]
+ 
+-test(
+-  'test-network-panel',
+-  find_program('test-network-panel.py'),
+-      env : envs,
+-  timeout : 60
+-)
+-
+ exe = executable(
+   'test-wifi-panel-text',
+   ['test-wifi-text.c'],

--- a/main/gnome-control-center/template.py
+++ b/main/gnome-control-center/template.py
@@ -1,7 +1,8 @@
 pkgname = "gnome-control-center"
-pkgver = "45.1"
-pkgrel = 2
+pkgver = "45.2"
+pkgrel = 0
 build_style = "meson"
+make_check_wrapper = ["weston-headless-run"]
 hostmakedepends = [
     "meson",
     "pkgconf",
@@ -57,14 +58,13 @@ depends = [
     "power-profiles-daemon-meta",
     "sound-theme-freedesktop",
 ]
+checkdepends = ["python-dbusmock", "weston"] + depends
 pkgdesc = "GNOME control center"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/gnome-control-center"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "d286c7627150e112aacbb4b7b91717fad8e89076061479dfc610b2dd744b577a"
-# needs graphical environment
-options = ["!check"]
+sha256 = "0cfa3c332d6edacb73d06c6b26ffca1078e86ff59eac819b2931e0967753df70"
 
 
 @subpackage("gnome-control-center-devel")

--- a/main/gnome-disk-utility/template.py
+++ b/main/gnome-disk-utility/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnome-disk-utility"
-pkgver = "45.0"
+pkgver = "45.1"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dlogind=libelogind"]
@@ -31,6 +31,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://wiki.gnome.org/Apps/Disks"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "3d8625faa99047bc4aefd29921ad728ab4d700cff86e0f2ec67e8dba877d0dd3"
+sha256 = "540ff4ec9a6b9630003ff4cd60d624f39fe70f25a9559e5333389603c85b9529"
 # FIXME cfi
 hardening = ["vis", "!cfi"]

--- a/main/gnome-shell-extensions/template.py
+++ b/main/gnome-shell-extensions/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnome-shell-extensions"
-pkgver = "45.1"
+pkgver = "45.2"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = ["meson", "pkgconf", "gettext", "glib-devel"]
@@ -9,4 +9,4 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://wiki.gnome.org/Projects/GnomeShell/Extensions"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "242e15a0c06e820c3fd8dd6aeac1a8ef865ce58882e5975af1d65934bb4d4261"
+sha256 = "ee32f6387a2d18adbff7a956689bc747866b4a8712d73790c002abeae4ccaaaf"

--- a/main/gnome-shell/template.py
+++ b/main/gnome-shell/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnome-shell"
-pkgver = "45.1"
+pkgver = "45.2"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -54,6 +54,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://wiki.gnome.org/Projects/GnomeShell"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "15fca4bd6129a8b3f990197fbd1ee58d74b641510afaaf0882a7fa36634fc5f2"
+sha256 = "8a0cfbf872b1a762696c86e13defe9f3675e92d79514eba9d000b5b611c26a23"
 # tests need libmutter-test
 options = ["!check"]

--- a/main/gnome-software/template.py
+++ b/main/gnome-software/template.py
@@ -1,6 +1,6 @@
 pkgname = "gnome-software"
-pkgver = "45.1"
-pkgrel = 1
+pkgver = "45.2"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Dpackagekit=false",
@@ -41,7 +41,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-3.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/gnome-software"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "d72485f7a6e0917f64edbedd68fd7b57246c6ebf10c5a45108b63946635778a2"
+sha256 = "0bdd8fc0caecd6eb013c6010dbca93077397118a6ef5eaf264e2a820a292f5b7"
 # TODO
 options = ["!check"]
 

--- a/main/mutter/template.py
+++ b/main/mutter/template.py
@@ -1,5 +1,5 @@
 pkgname = "mutter"
-pkgver = "45.1"
+pkgver = "45.2"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -70,7 +70,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://wiki.gnome.org/Projects/Mutter"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "2cd3c5efb22db76c79311cb1889a1aab2feb35b4a4dd03f3822aab7999da212c"
+sha256 = "af3f989bf22a560dc2492fb8e19f9da37ce6d7144b3e051980b0d550589600dc"
 # libmutter crashes gnome-shell with some applications? FIXME debug
 hardening = ["!int"]
 # needs graphical environment

--- a/main/nautilus/template.py
+++ b/main/nautilus/template.py
@@ -1,5 +1,5 @@
 pkgname = "nautilus"
-pkgver = "45.1"
+pkgver = "45.2.1"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dtests=headless"]
@@ -31,8 +31,8 @@ pkgdesc = "GNOME file manager"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://wiki.gnome.org/Apps/Files"
-source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "23bdaa9a85466c5937a89daddd080ed03bcc2b49e8b64af607206353bde82fe3"
+source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:pkgver.find('.')]}/{pkgname}-{pkgver}.tar.xz"
+sha256 = "ba5d53df39a155562df971ef5e31e827074905d0c48eab1eb2421a10284b990d"
 options = ["!cross"]
 
 

--- a/main/python-dbusmock/template.py
+++ b/main/python-dbusmock/template.py
@@ -1,0 +1,20 @@
+pkgname = "python-dbusmock"
+pkgver = "0.30.0"
+pkgrel = 0
+build_style = "python_pep517"
+# needs upower
+make_check_args = ["-k", "not test_dbusmock_test_template"]
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools_scm",
+    "python-wheel",
+]
+depends = ["python-dbus"]
+checkdepends = ["python-gobject", "python-pytest"] + depends
+pkgdesc = "D-Bus object mocks for python"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "LGPL-3.0-or-later"
+url = "https://github.com/martinpitt/python-dbusmock"
+source = f"https://github.com/martinpitt/python-dbusmock/releases/download/{pkgver}/dist.python-dbusmock-{pkgver}.tar.gz"
+sha256 = "dbb59e715b4d88089caed950edf93c46cb5f022ceae5d8ae37064b73baf956c1"

--- a/main/webkitgtk/template.py
+++ b/main/webkitgtk/template.py
@@ -1,5 +1,5 @@
 pkgname = "webkitgtk"
-pkgver = "2.42.3"
+pkgver = "2.42.4"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -90,7 +90,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later AND BSD-2-Clause"
 url = "https://webkitgtk.org"
 source = f"{url}/releases/{pkgname}-{pkgver}.tar.xz"
-sha256 = "0a1a4630045628b3a6fe95da72dc47852cff20d66be1ac6fd0d669c88c13d8e2"
+sha256 = "52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86"
 debug_level = 1  # otherwise LTO link runs out of memory + fat debuginfo
 tool_flags = {
     "CFLAGS": ["-DNDEBUG"],

--- a/main/webkitgtk4/template.py
+++ b/main/webkitgtk4/template.py
@@ -1,6 +1,6 @@
 # mirrors the gtk3 webkitgtk template
 pkgname = "webkitgtk4"
-pkgver = "2.42.3"
+pkgver = "2.42.4"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -97,7 +97,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.1-or-later AND BSD-2-Clause"
 url = "https://webkitgtk.org"
 source = f"{url}/releases/webkitgtk-{pkgver}.tar.xz"
-sha256 = "0a1a4630045628b3a6fe95da72dc47852cff20d66be1ac6fd0d669c88c13d8e2"
+sha256 = "52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86"
 debug_level = 1  # otherwise LTO link runs out of memory + fat debuginfo
 tool_flags = {
     "CFLAGS": ["-DNDEBUG"],

--- a/main/xdg-desktop-portal-gnome/template.py
+++ b/main/xdg-desktop-portal-gnome/template.py
@@ -1,5 +1,5 @@
 pkgname = "xdg-desktop-portal-gnome"
-pkgver = "45.0"
+pkgver = "45.1"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dsystemduserunitdir=/tmp/delete_me"]
@@ -16,7 +16,7 @@ maintainer = "eater <=@eater.me>"
 license = "LGPL-2.1-or-later"
 url = "https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome"
 source = f"https://download.gnome.org/sources/xdg-desktop-portal-gnome/{pkgver.split('.')[0]}/xdg-desktop-portal-gnome-{pkgver}.tar.xz"
-sha256 = "949598861c80000febf18cc12b3721c95c1bb1d19371fc2156dc4f33def5aff0"
+sha256 = "3e9ca821044005fb37bd68ebe4ad196fc3d072835581467a22a4879dac7b5fdd"
 
 
 def post_install(self):


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gnome-bluetooth/-/blob/97ce880be9da545477162db10984d93989c39d25/NEWS  
https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/blob/66e2fa40a9f23fb1f653fac917c72e37e546289c/NEWS  
https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/88b0ab9204f30b78fbe9e15bfc3651d5842ca986/NEWS  
https://gitlab.gnome.org/GNOME/gnome-disk-utility/-/blob/5208914fa4f6deebfd502353b51eef3aee65d3ba/NEWS  
https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/9c4a5897ab1a2d374e3e3de7fb195d47d4c422a6/NEWS  
https://gitlab.gnome.org/GNOME/gnome-shell-extensions/-/blob/b02e43d84cf7a1956d2d8cc77079a64cddef4d40/NEWS  
https://gitlab.gnome.org/GNOME/gnome-software/-/blob/7b9593d79958bcf0f1323f44fe72d11f6f4bdd06/NEWS  
https://gitlab.gnome.org/GNOME/mutter/-/blob/bedf8df88f41c34c9824dccba507c8e333dd9ba6/NEWS  
https://gitlab.gnome.org/GNOME/evolution-data-server/-/blob/0bba9c550476433a4220fffc5ba614c52684d06c/NEWS  
https://gitlab.gnome.org/GNOME/nautilus/-/blob/038885de47293a3fd2a15410d7cf3e0d36406a0d/NEWS  
https://webkitgtk.org/2023/12/15/webkitgtk2.42.4-released.html  


also runs gnome-control-center tests