### PR TITLE
contrib/regreet: new package (1.1.1)

### DIFF
--- a/contrib/regreet/files/regreet.conf
+++ b/contrib/regreet/files/regreet.conf
@@ -1,0 +1,4 @@
+# Create regreet state directories
+
+d /var/log/regreet 0755 _greetd _greetd -
+d /var/cache/regreet 0755 _greetd _greetd -

--- a/contrib/regreet/files/regreet.toml
+++ b/contrib/regreet/files/regreet.toml
@@ -1,0 +1,3 @@
+[commands]
+reboot = [ "loginctl", "reboot" ]
+poweroff = [ "loginctl", "poweroff" ]

--- a/contrib/regreet/template.py
+++ b/contrib/regreet/template.py
@@ -1,0 +1,27 @@
+pkgname = "regreet"
+pkgver = "0.1.1"
+pkgrel = 0
+build_style = "cargo"
+make_build_args = [
+    "--features=gtk4_8",
+]
+hostmakedepends = [
+    "cargo",
+    "pkgconf",
+]
+makedepends = [
+    "gtk4-devel",
+    "rust-std",
+]
+depends = ["greetd"]
+pkgdesc = "Clean and customizable greeter for greetd"
+maintainer = "natthias <natthias@proton.me>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/rharish101/ReGreet"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "a658c91cdf242dfea814f0bfd0c4d877bd39e3af498d36e5024061e3d07ea76b"
+
+
+def post_install(self):
+    self.install_file(self.files_path / "regreet.toml", "etc/greetd")
+    self.install_file(self.files_path / "regreet.conf", "usr/lib/tmpfiles.d")


### PR DESCRIPTION
Adds an actual graphical greeter for greetd. Upstream provides a systemd-tmpfiles config, but it requires patching, so using our own seems more sane. regreet.toml is for elogind.

This would require wlroots compositor as well as some manual config. I didn't provide any of the upstream example configs nor did I add a compositor to depends. Should I?