### PR TITLE
contrib/spice-vdagent: disable cfi

### DIFF
--- a/contrib/spice-vdagent/template.py
+++ b/contrib/spice-vdagent/template.py
@@ -1,6 +1,6 @@
 pkgname = "spice-vdagent"
 pkgver = "0.22.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = ["--with-session-info=none"]
 hostmakedepends = ["automake", "pkgconf"]
@@ -22,7 +22,8 @@ license = "GPL-3.0-or-later"
 url = "https://www.spice-space.org"
 source = f"https://www.spice-space.org/download/releases/spice-vdagent-{pkgver}.tar.bz2"
 sha256 = "93b0d15aca4762cc7d379b179a7101149dbaed62b72112fffb2b3e90b11687a0"
-hardening = ["vis", "cfi"]
+# FIXME: with CFI both daemon and client can upon exit crash each other
+hardening = ["vis", "!cfi"]
 
 
 def post_install(self):


### PR DESCRIPTION
Both the daemon and client can crash each other upon exit when built with CFI: https://paste.c-net.org/519lq1pmlhda