### PR TITLE
main/iputils: update to 20231222

### DIFF
--- a/main/iputils/iputils.post-install
+++ b/main/iputils/iputils.post-install
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-setcap cap_net_raw+p /usr/bin/ping 2>/dev/null || :
-setcap cap_net_raw+p /usr/bin/clockdiff 2>/dev/null || :

--- a/main/iputils/iputils.post-upgrade
+++ b/main/iputils/iputils.post-upgrade
@@ -1,1 +1,0 @@
-iputils.post-install

--- a/main/iputils/template.py
+++ b/main/iputils/template.py
@@ -1,5 +1,5 @@
 pkgname = "iputils"
-pkgver = "20221126"
+pkgver = "20231222"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -15,13 +15,18 @@ hostmakedepends = [
     "iproute2",
 ]
 makedepends = ["libcap-devel"]
-depends = ["libcap-progs"]
 pkgdesc = "Useful utilities for Linux networking"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-3-Clause AND GPL-2.0-or-later"
 url = "https://github.com/iputils/iputils"
 source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "745ea711fe06d5c57d470d21acce3c3ab866eb6afb69379a16c6d60b89bd4311"
+sha256 = "18d51e7b416da0ecbc0ae18a2cba76407ca0b5b3f32c356034f258a0cb56793f"
+file_xattrs = {
+    "usr/bin/clockdiff": {
+        "security.capability": "cap_net_raw,cap_sys_nice+ep",
+    },
+    "usr/bin/ping": {"security.capability": "cap_net_raw+p"},
+}
 hardening = ["vis", "cfi"]
 # operation not permitted (sandbox, unshared network)
 options = ["!check"]


### PR DESCRIPTION
https://github.com/iputils/iputils/releases/tag/20231222  

this also fixes EPERM on clockdiff because it needs +ep and not just +p (same as upstream script). the sys_nice isn't required it seems (works regardless) but it's what the upstream script does, so eh