### PR TITLE
contrib/seogi: new package (1.1.4)

### DIFF
--- a/contrib/libhangul-devel
+++ b/contrib/libhangul-devel
@@ -1,0 +1,1 @@
+libhangul

--- a/contrib/libhangul-progs
+++ b/contrib/libhangul-progs
@@ -1,0 +1,1 @@
+libhangul

--- a/contrib/libhangul/patches/0001-Update-gettext-version.patch
+++ b/contrib/libhangul/patches/0001-Update-gettext-version.patch
@@ -1,0 +1,25 @@
+From b9af867ef5590eb78aeb8e47c9e5f0dc60750886 Mon Sep 17 00:00:00 2001
+From: Isaac Freund <mail@isaacfreund.com>
+Date: Sat, 30 Dec 2023 14:17:36 -0600
+Subject: [PATCH] Update gettext version
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8b389be..16a44d8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -49,7 +49,7 @@ GETTEXT_PACKAGE="$PACKAGE"
+ AC_SUBST(GETTEXT_PACKAGE)
+ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", gettext package name)
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION(0.18)
++AM_GNU_GETTEXT_VERSION(0.20)
+ AM_ICONV
+ 
+ # Checks for unit test framework
+-- 
+2.43.0
+

--- a/contrib/libhangul/template.py
+++ b/contrib/libhangul/template.py
@@ -1,0 +1,23 @@
+pkgname = "libhangul"
+pkgver = "0.1.0"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_gen = ["./autogen.sh"]
+hostmakedepends = ["automake", "gettext-devel", "libtool", "pkgconf"]
+pkgdesc = "Library to support hangul input and character classification"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "LGPL-2.1-or-later"
+url = "https://github.com/libhangul/libhangul"
+source = f"{url}/archive/{pkgname}-{pkgver}.tar.gz"
+sha256 = "e2a81ef159ed098d3cc1a20377dba6204821b7ce2bc24cfb2f2543adf3bc5830"
+# FIXME enable vis and cfi, build currently fails with vis
+
+
+@subpackage("libhangul-devel")
+def _devel(self):
+    return self.default_devel()
+
+
+@subpackage("libhangul-progs")
+def _progs(self):
+    return self.default_progs()

--- a/contrib/seogi/template.py
+++ b/contrib/seogi/template.py
@@ -1,0 +1,25 @@
+pkgname = "seogi"
+pkgver = "1.1.4"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = ["meson", "pkgconf"]
+makedepends = [
+    "argp-standalone",
+    "elogind-devel",
+    "libhangul-devel",
+    "libxkbcommon-devel",
+    "wayland-devel",
+    "wayland-protocols",
+]
+pkgdesc = "Hangul IME for Wayland"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "MIT"
+url = "https://github.com/mswiger/seogi"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "243d28d54e448e98d2c910dd868c86fe83924c67309136898760d81deceb59a3"
+tool_flags = {"LDFLAGS": ["-largp"]}
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
I need a wayland IME to test my compositor and this seemed like the easiest one to build/package :)