### PR TITLE
contrib/swww: install needed binary

### DIFF
--- a/contrib/swww/template.py
+++ b/contrib/swww/template.py
@@ -1,6 +1,6 @@
 pkgname = "swww"
 pkgver = "0.8.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 hostmakedepends = ["cargo"]
 makedepends = ["rust-std"]
@@ -10,3 +10,7 @@ license = "GPL-3.0-only"
 url = "https://github.com/Horus645/swww"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "7612ae780d0aa86b772d1e224346137d490eba48e158033185d52649ff01b757"
+
+
+def post_install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/swww-daemon")


### PR DESCRIPTION
The `swww-daemon` binary wasn't being installed when it needed to be