### PR TITLE
contrib/zzz: new package (20231124)

### DIFF
--- a/contrib/zzz/template.py
+++ b/contrib/zzz/template.py
@@ -1,0 +1,14 @@
+pkgname = "zzz"
+pkgver = "20231124"
+pkgrel = 0
+pkgdesc = "Simple script to suspend or hibernate your computer"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "custom:none"
+url = "https://github.com/void-linux/void-runit"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "2bdb86a08ee0ee70d1a189ebbf9e60157f847e8c8f75caedc009536ca794a77c"
+
+
+def do_install(self):
+    self.install_bin("zzz")
+    self.install_man("zzz.8")


### PR DESCRIPTION
I realize that this is just a shell script and therefore perhaps not worth packaging. However, I wanted to allow running `doas zzz` with no password for use in scripts and realized that I shouldn't do that without having the zzz script in a root owned system directory. Therefore I made this package for my personal usage and thought it at the very least worth sharing as there is afaik currently no other user friendly option to suspend the system without logind installed.

Note that https://github.com/jirutka/zzz also exists but I personally would rather use a small shell script written by someone who really knows what they are doing rather than a significantly longer C program of middling quality.