### PR TITLE
cbuild: don't pass release to cargo test

### DIFF
--- a/contrib/git-branchless/template.py
+++ b/contrib/git-branchless/template.py
@@ -2,8 +2,6 @@ pkgname = "git-branchless"
 pkgver = "0.8.0"
 pkgrel = 1
 build_style = "cargo"
-# skip because CARGO_PROFILE_RELEASE_PANIC="abort"
-make_check_args = ["--", "--skip=test_main_branch_not_found_error_message"]
 hostmakedepends = ["cargo"]
 makedepends = ["rust-std", "sqlite-devel"]
 checkdepends = ["git"]

--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -197,7 +197,7 @@ class Cargo:
         tmpl = self.template
         return self._invoke(
             "test",
-            ["--release"] + tmpl.make_check_args + args,
+            tmpl.make_check_args + args,
             jobs,
             True,
             tmpl.make_check_env,


### PR DESCRIPTION
--release removes debug assertions (making tests overall worse), and makes the test binaries built with lto, which takes longer even though --release can reuse ~some build artifacts instead of rebuilding the full graph