### PR TITLE
contrib/frawk: new package (0.4.7)

### DIFF
--- a/contrib/frawk/patches/update-ahash.patch
+++ b/contrib/frawk/patches/update-ahash.patch
@@ -1,0 +1,40 @@
+From 06f71b098db8eab9dbefe6c11f786f0556f9a915 Mon Sep 17 00:00:00 2001
+From: "Paul A. Patience" <paul@apatience.com>
+Date: Sat, 6 Jan 2024 05:22:03 -0500
+Subject: [PATCH] Update yanked ahash dependency
+
+---
+ Cargo.lock | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 377543d..60b64a8 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4,9 +4,9 @@ version = 3
+ 
+ [[package]]
+ name = "ahash"
+-version = "0.7.6"
++version = "0.7.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
++checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+ dependencies = [
+  "getrandom",
+  "once_cell",
+@@ -734,9 +734,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "once_cell"
+-version = "1.10.0"
++version = "1.19.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
++checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+ 
+ [[package]]
+ name = "os_str_bytes"
+-- 
+2.41.0
+

--- a/contrib/frawk/patches/update-crossbeam-channel.patch
+++ b/contrib/frawk/patches/update-crossbeam-channel.patch
@@ -1,0 +1,28 @@
+From 714ce68e8ea0afdaf3728247b208d8d5a8bc2dad Mon Sep 17 00:00:00 2001
+From: "Paul A. Patience" <paul@apatience.com>
+Date: Sat, 6 Jan 2024 05:48:41 -0500
+Subject: [PATCH] Update yanked crossbeam-channel dependency
+
+---
+ Cargo.lock | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 60b64a8..0b29a60 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -294,9 +294,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.4"
++version = "0.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
++checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+ dependencies = [
+  "cfg-if",
+  "crossbeam-utils",
+-- 
+2.41.0
+

--- a/contrib/frawk/patches/update-libc.patch
+++ b/contrib/frawk/patches/update-libc.patch
@@ -1,0 +1,29 @@
+From 5d0a4ae87f156baca41891ed765ba192ef741811 Mon Sep 17 00:00:00 2001
+From: "Paul A. Patience" <paul@apatience.com>
+Date: Sat, 6 Jan 2024 04:26:21 -0500
+Subject: [PATCH] Update libc to fix missing open64
+
+See <https://github.com/rust-lang/libc/pull/2935>.
+---
+ Cargo.lock | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index da5786a..377543d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -656,9 +656,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.122"
++version = "0.2.146"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
++checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+ 
+ [[package]]
+ name = "llvm-sys"
+-- 
+2.41.0
+

--- a/contrib/frawk/template.py
+++ b/contrib/frawk/template.py
@@ -1,0 +1,31 @@
+pkgname = "frawk"
+pkgver = "0.4.7"
+pkgrel = 0
+build_style = "cargo"
+# disable llvm_backend (needs LLVM 12), unstable and use-jemalloc features
+make_build_args = ["--no-default-features", "--features=allow_avx2"]
+make_install_args = list(make_build_args)
+make_check_args = list(make_build_args)
+hostmakedepends = ["cargo"]
+makedepends = ["rust-std"]
+pkgdesc = "Awk-like language"
+maintainer = "Paul A. Patience <paul@apatience.com>"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/ezrosent/frawk"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "7ec5d93f3a9ee3c4bafc7db790ea471a568e94de657fbb74d7a3b641bf3e68e6"
+
+
+def do_prepare(self):
+    pass
+
+
+def post_patch(self):
+    from cbuild.util import cargo
+
+    self.cargo.vendor()
+    cargo.setup_vendor(self)
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")


### PR DESCRIPTION
Although the package conditionally enables architecture-specific code, it always has a generic fallback, so I did not add the `archs` line.