### PR TITLE
contrib/gnome-shell-extension-gsconnect: new package (56)

### DIFF
--- a/contrib/gnome-shell-extension-gsconnect/template.py
+++ b/contrib/gnome-shell-extension-gsconnect/template.py
@@ -1,0 +1,27 @@
+pkgname = "gnome-shell-extension-gsconnect"
+pkgver = "56"
+pkgrel = 0
+build_style = "meson"
+configure_args = ["-Dinstalled_tests=false"]
+# Would've used weston-headless-run here instead of xvfb-run, but that runs
+# into a gtk3 bug in one of the tests:
+# https://github.com/chimera-linux/cports/pull/1223#issue-2079623168
+make_check_wrapper = ["dbus-run-session", "xvfb-run"]
+hostmakedepends = [
+    "bash",
+    "desktop-file-utils",
+    "gettext",
+    "glib-devel",
+    "gtk-update-icon-cache",
+    "libxml2-progs",
+    "meson",
+    "pkgconf",
+]
+depends = ["evolution-data-server", "gnome-shell", "gsound", "openssl"]
+checkdepends = ["dbus", "gnome-shell", "xserver-xorg-xvfb"]
+pkgdesc = "KDE Connect implementation for GNOME"
+maintainer = "triallax <triallax@tutanota.com>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/GSConnect/gnome-shell-extension-gsconnect"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "283e977b7739fe67d61cc5650fee2bb24bc59fb1f905258f3a4547398464c8e5"


### PR DESCRIPTION
`gsconnect:components / ClipboardComponent` test fails with this error:

```
  stderr:

(gjs:55): Gdk-CRITICAL **: 20:04:04.485: gdk_seat_get_keyboard: assertion 'GDK_IS_SEAT (seat)' failed

(test program exited with status code -5)

TAP parsing error: Too few tests run (expected 2, got 0)
```

Not quite sure how to fix it.