### PR TITLE
Orphan packages

### DIFF
--- a/contrib/cliphist/template.py
+++ b/contrib/cliphist/template.py
@@ -1,11 +1,11 @@
 pkgname = "cliphist"
 pkgver = "0.4.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
 depends = ["wl-clipboard", "xdg-utils"]
 pkgdesc = "Wayland clipboard manager"
-maintainer = "Callum Andrew <contact@candrew.net>"
+maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "GPL-3.0-only"
 url = "https://github.com/sentriz/cliphist"
 source = f"{url}/archive/v{pkgver}.tar.gz"

--- a/contrib/gopass/template.py
+++ b/contrib/gopass/template.py
@@ -1,10 +1,10 @@
 pkgname = "gopass"
 pkgver = "1.15.11"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "Pass-compatible password manager with more features"
-maintainer = "Callum Andrew <contact@candrew.net>"
+maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "MIT"
 url = "https://www.gopass.pw"
 source = (


### PR DESCRIPTION
I have stopped using Chimera Linux as I'm not very comfortable with the project relying on Github for code hosting (especially given the recent sourcehut outage), and Github being proprietary and all.
No hard feelings though and I hope Chimera Linux keeps going well.
So this just orphans my packages.