### PR TITLE
contrib/senpai: backport 1ad07b59 from upstream

### DIFF
--- a/contrib/senpai/patches/0001-Handle-empty-message-properly.patch
+++ b/contrib/senpai/patches/0001-Handle-empty-message-properly.patch
@@ -1,0 +1,34 @@
+From 9152bd40436207686d840d196b481331d8ad0c87 Mon Sep 17 00:00:00 2001
+From: sewn <sewn@disroot.org>
+Date: Thu, 14 Dec 2023 20:07:01 +0300
+Subject: [PATCH] Handle empty message properly
+
+Sending nothing in senpai makes the if check to work properly, however
+if sent nothing but a space, senpai will panic, as parseCommand assumes
+it is alphanumerical and not just a space.
+
+This commit fixes it by making parseCommand return false instead of
+panic when a message is empty.
+
+Co-authored-by: delthas <delthas@dille.cc>
+Co-authored-by: sewn <sewn@disroot.org>
+---
+ commands.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/commands.go b/commands.go
+index 64e66b8..d94c1fa 100644
+--- a/commands.go
++++ b/commands.go
+@@ -876,7 +876,7 @@ func fieldsN(s string, n int) []string {
+ }
+ 
+ func parseCommand(s string) (command, args string, isCommand bool) {
+-	if s[0] != '/' {
++	if len(s) == 0 || s[0] != '/' {
+ 		return "", s, false
+ 	}
+ 	if len(s) > 1 && s[1] == '/' {
+-- 
+2.43.0
+

--- a/contrib/senpai/template.py
+++ b/contrib/senpai/template.py
@@ -1,6 +1,6 @@
 pkgname = "senpai"
 pkgver = "0.3.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["./cmd/senpai"]
 hostmakedepends = ["gmake", "go", "scdoc"]


### PR DESCRIPTION
this fixes a crash caused by a user attempting to send a message only containing a single space