### PR TITLE
contrib/chromium: update to 120.0.6099.224

### DIFF
--- a/contrib/chromium/patches/disable-dns_config_service.patch
+++ b/contrib/chromium/patches/disable-dns_config_service.patch
@@ -1,0 +1,19 @@
+the linux one sometimes crashes, and this is optional/not required, so use the
+stub fuschia one
+https://gitlab.alpinelinux.org/alpine/aports/-/issues/15660
+--
+diff --git a/net/dns/BUILD.gn b/net/dns/BUILD.gn
+index f36bf68..805d9a6 100644
+--- a/net/dns/BUILD.gn
++++ b/net/dns/BUILD.gn
+@@ -130,8 +130,8 @@ source_set("dns") {
+     ]
+   } else if (is_linux) {
+     sources += [
+-      "dns_config_service_linux.cc",
+-      "dns_config_service_linux.h",
++      "dns_config_service_fuchsia.cc",
++      "dns_config_service_fuchsia.h",
+     ]
+   } else if (is_posix) {
+     sources += [

--- a/contrib/chromium/template.py
+++ b/contrib/chromium/template.py
@@ -1,6 +1,6 @@
 pkgname = "chromium"
 # https://chromiumdash.appspot.com/releases?platform=Linux
-pkgver = "120.0.6099.216"
+pkgver = "120.0.6099.224"
 pkgrel = 0
 archs = ["aarch64", "ppc64le", "x86_64"]
 configure_args = [
@@ -133,7 +133,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-3-Clause"
 url = "https://www.chromium.org"
 source = f"https://commondatastorage.googleapis.com/chromium-browser-official/chromium-{pkgver}.tar.xz"
-sha256 = "7e7bea15bf56f3cc920bb015fed1a1b1368267299e132e795935c5cc604adfc0"
+sha256 = "850a85c8d8a01041a07dfaaea8289fa5f8294b4e375e6b77997b61434e0a2f1a"
 debug_level = 0
 tool_flags = {
     "CFLAGS": [


### PR DESCRIPTION
[ci skip]

https://chromereleases.googleblog.com/2024/01/stable-channel-update-for-desktop_16.html