### PR TITLE
contrib/htop: update to 3.3.0

### DIFF
--- a/contrib/htop/template.py
+++ b/contrib/htop/template.py
@@ -1,14 +1,15 @@
 pkgname = "htop"
-pkgver = "3.2.2"
+pkgver = "3.3.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--enable-unicode", "--enable-sensors"]
+configure_gen = []
 makedepends = ["ncurses-devel", "libsensors-devel"]
 pkgdesc = "Interactive process viewer"
 maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
 license = "GPL-2.0-only"
 url = "https://htop.dev"
 source = f"https://github.com/htop-dev/htop/releases/download/{pkgver}/htop-{pkgver}.tar.xz"
-sha256 = "bac9e9ab7198256b8802d2e3b327a54804dc2a19b77a5f103645b11c12473dc8"
-
-configure_gen = []
+sha256 = "a69acf9b42ff592c4861010fce7d8006805f0d6ef0e8ee647a6ee6e59b743d5c"
+# CFI cannot work with libsensors dlsym() stuff
+hardening = ["vis", "!cfi"]


### PR DESCRIPTION
Also enable hardening. Didn't drop `configure_gen = []` as I couldn't figure out what caused:
```
/builddir/htop-3.3.0/configure: 11567: Syntax error: end of file unexpected (expecting "fi")
```