### PR TITLE
Protobuf 25.2

### DIFF
--- a/contrib/android-tools/template.py
+++ b/contrib/android-tools/template.py
@@ -1,6 +1,6 @@
 pkgname = "android-tools"
 pkgver = "34.0.4"
-pkgrel = 1
+pkgrel = 2
 # only supports specific little-endian archs, particularly in boringssl
 archs = ["x86_64", "aarch64", "ppc64le", "riscv64"]
 build_style = "cmake"

--- a/contrib/mosh/template.py
+++ b/contrib/mosh/template.py
@@ -1,8 +1,16 @@
 pkgname = "mosh"
 pkgver = "1.4.0"
-pkgrel = 3
+pkgrel = 4
 build_style = "gnu_configure"
-hostmakedepends = ["pkgconf", "protobuf", "automake", "libtool", "perl"]
+make_cmd = "gmake"
+hostmakedepends = [
+    "automake",
+    "gmake",
+    "libtool",
+    "perl",
+    "pkgconf",
+    "protobuf",
+]
 makedepends = ["protobuf-devel", "ncurses-devel", "openssl-devel", "zlib-devel"]
 depends = ["perl"]
 pkgdesc = "Mobile shell"

--- a/contrib/protobuf-c/template.py
+++ b/contrib/protobuf-c/template.py
@@ -1,6 +1,6 @@
 pkgname = "protobuf-c"
 pkgver = "1.5.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
     "--enable-protoc",

--- a/contrib/protobuf/template.py
+++ b/contrib/protobuf/template.py
@@ -1,5 +1,5 @@
 pkgname = "protobuf"
-pkgver = "25.0"
+pkgver = "25.2"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -14,7 +14,7 @@ maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
 license = "BSD-3-Clause"
 url = "https://protobuf.dev"
 source = f"https://github.com/protocolbuffers/protobuf/archive/v{pkgver}.tar.gz"
-sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a"
+sha256 = "8ff511a64fc46ee792d3fe49a5a1bcad6f7dc50dfbba5a28b0e5b979c17f9871"
 # FIXME vis breaks linking lite-test, cfi makes protoc not compile any tests
 hardening = ["!vis", "!cfi"]
 


### PR DESCRIPTION
Also make `mosh` use `gmake` due to strange build errors even on current `master` of cports without any of this, not sure if it's a `bmake` bug or what as it used to build previously.