### PR TITLE
contrib/fish-shell: use correct check target

### DIFF
--- a/contrib/fish-shell/patches/0001-fix-mktemp-in-tests.patch
+++ b/contrib/fish-shell/patches/0001-fix-mktemp-in-tests.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/test_functions/mktemp.fish b/tests/test_functions/mktemp.fish
+index c0b073aa5..af84d20c7 100644
+--- a/tests/test_functions/mktemp.fish
++++ b/tests/test_functions/mktemp.fish
+@@ -49,16 +49,9 @@ function mktemp
+ 
+     # GNU mktemp treats the final occurrence of a sequence of X's as the template token.
+     # BSD mktemp only treats X's as the template token if they suffix the string.
+-    # So let's outlaw them anywhere besides the end.
++    # So let's require them in the end.
+     # Similarly GNU mktemp requires at least 3 X's, BSD mktemp requires none. Let's require 3.
+     begin
+-        # Look for at least three Xs that are not the end of the template
+-        if string match -rq -- 'XXX[^X].*$' "$template"
+-            echo "mktemp: X's may only occur at the end of the template '$template'" >&2
+-            _mktemp_help >&2
+-            exit 1
+-        end
+-
+         # Look for too few X incidences at the end of the template
+         if ! string match -rq -- 'XXX$' "$template"
+             echo "mktemp: too few trailing X's in template '$template'" >&2

--- a/contrib/fish-shell/template.py
+++ b/contrib/fish-shell/template.py
@@ -1,8 +1,8 @@
 pkgname = "fish-shell"
 pkgver = "3.7.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
-make_build_args = ["--target", "all", "fish_tests"]
+make_check_target = "fish_run_tests"
 hostmakedepends = ["cmake", "ninja", "pkgconf", "gettext"]
 makedepends = ["ncurses-devel", "pcre2-devel"]
 checkdepends = ["python", "procps"]
@@ -12,14 +12,7 @@ license = "GPL-2.0-only"
 url = "https://fishshell.com"
 source = f"https://github.com/fish-shell/fish-shell/releases/download/{pkgver}/fish-{pkgver}.tar.xz"
 sha256 = "df1b7378b714f0690b285ed9e4e58afe270ac98dbc9ca5839589c1afcca33ab1"
-# FIXME int: test fail
-hardening = ["vis", "cfi", "!int"]
-
-
-def do_check(self):
-    # fails to find test script via ctest in out-of-tree builddir
-    with self.pushd(self.make_dir):
-        self.do("./fish_tests")
+hardening = ["vis", "cfi"]
 
 
 def post_install(self):


### PR DESCRIPTION
fish has its own test target that should be used instead of just using ctest alone (see https://github.com/fish-shell/fish-shell/blob/3.7.0/cmake/Tests.cmake#L18)

Also removed `!int` hardening option as I wasn't able to reproduce the mentioned test failure.