### PR TITLE
main/abseil-cpp: update to 20240116.0

### DIFF
--- a/contrib/mosh/template.py
+++ b/contrib/mosh/template.py
@@ -1,6 +1,6 @@
 pkgname = "mosh"
 pkgver = "1.4.0"
-pkgrel = 4
+pkgrel = 5
 build_style = "gnu_configure"
 make_cmd = "gmake"
 hostmakedepends = [
@@ -11,7 +11,13 @@ hostmakedepends = [
     "pkgconf",
     "protobuf",
 ]
-makedepends = ["protobuf-devel", "ncurses-devel", "openssl-devel", "zlib-devel"]
+makedepends = [
+    "abseil-cpp-devel",
+    "protobuf-devel",
+    "ncurses-devel",
+    "openssl-devel",
+    "zlib-devel",
+]
 depends = ["perl"]
 pkgdesc = "Mobile shell"
 maintainer = "q66 <q66@chimera-linux.org>"

--- a/contrib/protobuf/template.py
+++ b/contrib/protobuf/template.py
@@ -1,6 +1,6 @@
 pkgname = "protobuf"
 pkgver = "25.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DBUILD_SHARED_LIBS=ON",

--- a/main/abseil-cpp/template.py
+++ b/main/abseil-cpp/template.py
@@ -1,5 +1,5 @@
 pkgname = "abseil-cpp"
-pkgver = "20230802.1"
+pkgver = "20240116.0"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -18,7 +18,7 @@ url = "https://abseil.io"
 source = (
     f"https://github.com/abseil/abseil-cpp/archive/refs/tags/{pkgver}.tar.gz"
 )
-sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed"
+sha256 = "338420448b140f0dfd1a1ea3c3ce71b3bc172071f24f4d9a57d59b45037da440"
 
 
 @subpackage("abseil-cpp-testing")

--- a/main/webrtc-audio-processing/template.py
+++ b/main/webrtc-audio-processing/template.py
@@ -1,6 +1,6 @@
 pkgname = "webrtc-audio-processing"
 pkgver = "1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = ["-Dcpp_std=c++17"]
 hostmakedepends = ["meson", "pkgconf", "cmake"]


### PR DESCRIPTION
weirdly, both webrtc-audio-processing and libreoffice don't actually get a needed on libabsl anywhere (probably header-only use?). i skipped the libreoffice rebuild for that reason