### PR TITLE
contrib/fractal: new package (6)

### DIFF
--- a/contrib/fractal/patches/manual-cargo-build.patch
+++ b/contrib/fractal/patches/manual-cargo-build.patch
@@ -1,0 +1,29 @@
+build it ourselves to keep all the envs
+ + it doesn't work anyway and tries redownloading something
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -41,24 +41,6 @@
+ 
+ cargo_env = [ 'CARGO_HOME=' + meson.project_build_root() / 'cargo-home' ]
+ 
+-custom_target(
+-  'cargo-build',
+-  build_by_default: true,
+-  build_always_stale: true,
+-  output: meson.project_name(),
+-  console: true,
+-  install: true,
+-  install_dir: bindir,
+-  depends: [resources, ui_resources],
+-  command: [
+-    'env',
+-    cargo_env,
+-    cargo, 'build',
+-    cargo_options,
+-    '&&',
+-    'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@',
+-  ]
+-)
+ 
+ rustdoc_flags = ' '.join([
+   '-Zunstable-options',

--- a/contrib/fractal/template.py
+++ b/contrib/fractal/template.py
@@ -1,0 +1,53 @@
+pkgname = "fractal"
+pkgver = "6"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = [
+    "cargo",
+    "desktop-file-utils",
+    "gettext",
+    "meson",
+    "pkgconf",
+]
+makedepends = [
+    "gst-plugins-bad-devel",
+    "gst-plugins-base-devel",
+    "gtk4-devel",
+    "gtksourceview-devel",
+    "libadwaita-devel",
+    "libshumate-devel",
+    "pipewire-devel",
+    "rust-std",
+    "xdg-desktop-portal-devel",
+]
+pkgdesc = "GTK Matrix client"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-3.0-or-later"
+url = "https://gitlab.gnome.org/World/fractal"
+source = f"{url}/-/archive/{pkgver}/fractal-{pkgver}.tar.gz"
+sha256 = "a730dffe5fd4859c16e0d84244a82f6ea843d4e464ee04e08fcb5bea61c248f2"
+# no actual tests just formatting/etc
+options = ["!check"]
+
+
+def post_patch(self):
+    from cbuild.util import cargo
+
+    self.cargo = cargo.Cargo(self, wrksrc=".")
+    self.cargo.vendor()
+    cargo.setup_vendor(self)
+
+
+def post_build(self):
+    from cbuild.util import cargo
+
+    # reduce 600MB debuginfo
+    cargo.Cargo(self).build(
+        env={"CARGO_PROFILE_RELEASE_DEBUG": "line-tables-only"}
+    )
+
+
+def post_install(self):
+    self.install_bin(
+        self.cwd / "target" / self.profile().triplet / "release" / "fractal"
+    )

--- a/contrib/libshumate-devel
+++ b/contrib/libshumate-devel
@@ -1,0 +1,1 @@
+libshumate

--- a/contrib/libshumate/template.py
+++ b/contrib/libshumate/template.py
@@ -1,0 +1,31 @@
+pkgname = "libshumate"
+pkgver = "1.1.2"
+pkgrel = 0
+build_style = "meson"
+configure_args = ["-Dgtk_doc=false"]
+make_check_wrapper = ["weston-headless-run", "dbus-run-session"]
+hostmakedepends = [
+    "meson",
+    "pkgconf",
+]
+makedepends = [
+    "gtk4-devel",
+    "libsoup-devel",
+]
+checkdepends = [
+    "dbus",
+    "weston",
+]
+pkgdesc = "GTK4 widgets for maps"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "LGPL-2.1-or-later"
+url = "https://gitlab.gnome.org/GNOME/libshumate"
+source = f"$(GNOME_SITE)/libshumate/{pkgver[:pkgver.rfind('.')]}/libshumate-{pkgver}.tar.xz"
+sha256 = "8f094f6e7e256ab192800516ff96617abeec2363b054aad6aeb17e0088c1fb2c"
+# vis breaks symbols
+hardening = ["!vis"]
+
+
+@subpackage("libshumate-devel")
+def _devel(self):
+    return self.default_devel()


### PR DESCRIPTION
the meson+rust handling is a bit of a mess. should probably update helvum to do the same (currently it does not pass the envs and hence also not the lto env). i can't think of a better solution than just skipping the build and manually doing it i guess

