### PR TITLE
main/cryptsetup: update to 2.7.0

### DIFF
--- a/main/cryptsetup/template.py
+++ b/main/cryptsetup/template.py
@@ -1,16 +1,21 @@
 pkgname = "cryptsetup"
-pkgver = "2.6.1"
+pkgver = "2.7.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--with-crypto_backend=openssl",
-    "--enable-cryptsetup-reencrypt",
     "--enable-libargon2",
     "--enable-static-cryptsetup",
     "--disable-ssh-token",
     "--disable-asciidoc",
 ]
-hostmakedepends = ["pkgconf", "bash"]
+hostmakedepends = [
+    "automake",
+    "bash",
+    "gettext-devel",
+    "libtool",
+    "pkgconf",
+]
 makedepends = [
     "device-mapper-devel-static",
     "openssl-devel-static",
@@ -29,7 +34,7 @@ url = "https://gitlab.com/cryptsetup/cryptsetup"
 source = (
     f"$(KERNEL_SITE)/utils/{pkgname}/v{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
 )
-sha256 = "410ded65a1072ab9c8e41added37b9729c087fef4d2db02bb4ef529ad6da4693"
+sha256 = "94003a00cd5a81944f45e8dc529e0cfd2a6ff629bd2cd21cf5e574e465daf795"
 
 if self.profile().arch == "riscv64":
     # udev static library weirdness
@@ -54,6 +59,3 @@ def _lib(self):
 @subpackage("cryptsetup-devel")
 def _devel(self):
     return self.default_devel()
-
-
-configure_gen = []


### PR DESCRIPTION
https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.7/v2.7.0-ReleaseNotes  

notably we don't have `CONFIG_BLK_SED_OPAL` enabled