### PR TITLE
 contrib/networkmanager-openconnect: new package (1.2.10)

### DIFF
--- a/contrib/networkmanager-openconnect/files/sysusers.conf
+++ b/contrib/networkmanager-openconnect/files/sysusers.conf
@@ -1,0 +1,3 @@
+# Create nm-openconnect system user
+
+u _nm-openconnect - "nm-openconnect user" /var/lib/NetworkManager /usr/bin/nologin

--- a/contrib/networkmanager-openconnect/patches/rename_system_user.patch
+++ b/contrib/networkmanager-openconnect/patches/rename_system_user.patch
@@ -1,0 +1,22 @@
+--- a/src/nm-openconnect-service.h	2023-05-17 18:19:17.000000000 +0200
++++ b/src/nm-openconnect-service.h	2024-06-07 22:45:54.708618016 +0200
+@@ -44,6 +44,6 @@
+ 
+ NMOpenconnectPlugin *nm_openconnect_plugin_new (const char *bus_name);
+ 
+-#define NM_OPENCONNECT_USER "nm-openconnect"
++#define NM_OPENCONNECT_USER "_nm-openconnect"
+ 
+ #endif /* NM_OPENCONNECT_PLUGIN_H */
+
+--- a/nm-openconnect-service.conf	2023-05-17 18:19:17.000000000 +0200
++++ b/nm-openconnect-service.conf	2024-06-07 22:48:37.051564228 +0200
+@@ -6,7 +6,7 @@
+ 		<allow own_prefix="org.freedesktop.NetworkManager.openconnect"/>
+ 		<allow send_destination="org.freedesktop.NetworkManager.openconnect"/>
+ 	</policy>
+-	<policy user="nm-openconnect">
++	<policy user="_nm-openconnect">
+ 		<allow own_prefix="org.freedesktop.NetworkManager.openconnect"/>
+ 		<allow send_destination="org.freedesktop.NetworkManager.openconnect"/>
+ 		<allow send_interface="org.freedesktop.NetworkManager.VPN.Plugin"/>

--- a/contrib/networkmanager-openconnect/template.py
+++ b/contrib/networkmanager-openconnect/template.py
@@ -1,0 +1,39 @@
+pkgname = "networkmanager-openconnect"
+pkgver = "1.2.10"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--with-gtk4=yes", "--disable-static"]
+make_cmd = "gmake"
+make_dir = "."
+hostmakedepends = [
+    "automake",
+    "file",
+    "gcr-progs",
+    "gettext-devel",
+    "glib-devel",
+    "gmake",
+    "intltool",
+    "libtool",
+    "pkgconf",
+]
+makedepends = [
+    "gcr3-devel",
+    "gtk+3-devel",
+    "gtk4-devel",
+    "libnma-devel",
+    "libsecret-devel",
+    "libxml2-devel",
+    "networkmanager-devel",
+    "openconnect-devel",
+    "webkitgtk-devel",
+]
+pkgdesc = "OpenConnect support for NetworkManager"
+maintainer = "Erica Z <zerica@callcc.eu>"
+license = "GPL-2.0-or-later"
+url = "https://gitlab.gnome.org/GNOME/NetworkManager-openconnect"
+source = f"{url}/-/archive/{pkgver}/NetworkManager-openconnect-{pkgver}.tar.bz2"
+sha256 = "df21a8730438b1614de390ecf1f73d379536d388a8e464c9a802dab14dd23c8f"
+
+
+def post_install(self):
+    self.install_sysusers(self.files_path / "sysusers.conf")

--- a/contrib/networkmanager-openconnect/update.py
+++ b/contrib/networkmanager-openconnect/update.py
@@ -1,0 +1,1 @@
+pattern = r"\"/GNOME/NetworkManager-openconnect/-/tags/([0-9.]+)\""

--- a/contrib/openconnect-devel
+++ b/contrib/openconnect-devel
@@ -1,0 +1,1 @@
+openconnect

--- a/contrib/openconnect/template.py
+++ b/contrib/openconnect/template.py
@@ -1,0 +1,40 @@
+pkgname = "openconnect"
+pkgver = "9.12"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--with-vpnc-script=/usr/libexec/vpnc-script"]
+make_cmd = "gmake"
+hostmakedepends = [
+    "automake",
+    "gettext",
+    "gmake",
+    "libtool",
+    "pkgconf",
+]
+makedepends = [
+    "gnutls-devel",
+    "heimdal-devel",
+    "libproxy-devel",
+    "libtasn1-devel",
+    "libxml2-devel",
+    "linux-headers",
+    "lz4-devel",
+    "p11-kit-devel",
+    "pcsc-lite-devel",
+    "tpm2-tss-devel",
+    "trousers-devel",
+    "zlib-devel",
+]
+checkdepends = ["bash"]
+depends = ["vpnc-scripts"]
+pkgdesc = "Multi-protocol SSL VPN client"
+maintainer = "Erica Z <zerica@callcc.eu>"
+license = "LGPL-2.1-only"
+url = "https://www.infradead.org/openconnect"
+source = f"{url}/download/openconnect-{pkgver}.tar.gz"
+sha256 = "a2bedce3aa4dfe75e36e407e48e8e8bc91d46def5335ac9564fbf91bd4b2413e"
+
+
+@subpackage("openconnect-devel")
+def _devel(self):
+    return self.default_devel()

--- a/contrib/vpnc-scripts/template.py
+++ b/contrib/vpnc-scripts/template.py
@@ -1,0 +1,16 @@
+pkgname = "vpnc-scripts"
+_commit = "4ed41c21e3857f96ab935b45092bbb07c3ccd5be"
+pkgver = "0_git20240308"
+pkgrel = 0
+pkgdesc = "OpenConnect network routing script"
+maintainer = "Erica Z <zerica@callcc.eu>"
+license = "GPL-2.0-or-later"
+url = "https://www.infradead.org/openconnect/vpnc-script.html"
+source = f"https://gitlab.com/openconnect/vpnc-scripts/-/archive/{_commit}/vpnc-scripts-{_commit}.tar.bz2"
+sha256 = "82eb6b28236988bf7b64863ed8698e9204ff99610c73775aa3d67b1a63aab33e"
+
+
+def do_install(self):
+    self.install_file("vpnc-script", "usr/libexec", 0o755)
+    self.install_file("vpnc-script-ptrtd", "usr/libexec", 0o755)
+    self.install_file("vpnc-script-sshd", "usr/libexec", 0o755)

--- a/contrib/vpnc-scripts/update.py
+++ b/contrib/vpnc-scripts/update.py
@@ -1,0 +1,1 @@
+ignore = True


### PR DESCRIPTION
patching the gcr 3 dep to 4 requires yanking a widget that was entirely removed, as far as i can tell with no replacement. i assume its fine because its just displaying a cert with no interactivity. some tests are also completely broken, i may investigate later