### PR TITLE
main/lynx: enable CFI

### DIFF
--- a/main/lynx/template.py
+++ b/main/lynx/template.py
@@ -1,6 +1,6 @@
 pkgname = "lynx"
 pkgver = "2.9.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
     "--enable-widec",
@@ -27,5 +27,5 @@ source = f"https://invisible-mirror.net/archives/{pkgname}/tarballs/{pkgname}{pk
 sha256 = "5bcae5e2e6043ca7b220963a97763c49c13218d849ffda6be7739bfd5a2d36ff"
 # FIXME cfi: crashes in UCPutUtf8_charstring via magic function pointer stuff
 # when -display_charset utf-8 on any website
-hardening = ["vis", "cfi-genptr"]
+hardening = ["vis", "cfi", "cfi-genptr"]
 options = ["!cross"]


### PR DESCRIPTION
`cfi-genptr` on its own without `cfi` is the same as no `cfi` at all, which seems to have been missed in bc086bc37c1fe196a2ec7869ee2d5264862805b7.

cc @nekopsykose
