### PR TITLE
Prototype zig package manager integration

### DIFF
--- a/src/cbuild/build_style/zig_build.py
+++ b/src/cbuild/build_style/zig_build.py
@@ -1,0 +1,14 @@
+from cbuild.util import zig_build
+
+
+def do_build(self):
+    zig_build.build(self, self.zig_build_args)
+
+
+def do_install(self):
+    zig_build.install(self)
+
+
+def use(tmpl):
+    tmpl.do_build = do_build
+    tmpl.do_install = do_install

--- a/src/cbuild/build_style/zig_package.py
+++ b/src/cbuild/build_style/zig_package.py
@@ -1,0 +1,5 @@
+from cbuild.util import zig_package
+
+
+def use(tmpl):
+    tmpl.do_install = zig_package.install

--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -487,6 +487,8 @@ core_fields = [
     ("go_mod_dl", None, str, False, False, False),
     ("go_build_tags", [], list, False, False, False),
     ("go_check_tags", [], list, False, False, False),
+    # zig
+    ("zig_build_args", [], list, False, False, False),
 ]
 
 # a field priority list, the second element indicates whether
@@ -521,6 +523,7 @@ core_fields_priority = [
     ("make_check_env", True),
     ("make_check_wrapper", True),
     ("make_use_env", True),
+    ("zig_build_args", True),
     ("cmake_dir", False),
     ("meson_dir", False),
     ("hostmakedepends", True),

--- a/src/cbuild/util/zig_build.py
+++ b/src/cbuild/util/zig_build.py
@@ -1,0 +1,54 @@
+def build(pkg, extra_args=[]):
+    profile = pkg.profile()
+    sysroot = profile.sysroot
+    with open(pkg.cwd / "cbuild_zig_libc.txt", mode="w") as f:
+        f.write(
+            f"""include_dir={sysroot}/usr/include
+sys_include_dir={sysroot}/usr/include
+crt_dir={sysroot}/lib
+msvc_lib_dir=
+kernel32_lib_dir=
+gcc_dir=
+
+"""
+        )
+
+    zig_arch = None
+    zig_cpu = None
+    match profile.arch:
+        # TODO other architectures
+        case "x86_64" | "aarch64":
+            zig_arch = profile.arch
+            zig_cpu = "baseline"
+
+    # The Zig build system only has a single install step, there is no
+    # way to build artifacts for a given prefix and then install those artifacts
+    # to that prefix at some later time. Therefore, we build and install to the zig-out
+    # directory and later copy the artifacts to the destdir in do_install().
+    # We use zig-out to avoid path conflicts as it is the default install
+    # prefix used by the zig build system.
+    pkg.do(
+        "zig",
+        "build",
+        "-j" + str(pkg.make_jobs),
+        "--sysroot",
+        sysroot,
+        "--libc",
+        "cbuild_zig_libc.txt",
+        "--search-prefix",
+        "/usr",
+        "--prefix",
+        "/usr",
+        "--system",
+        sysroot / "usr/src/zig/packages",
+        "--release=safe",
+        f"-Dtarget={zig_arch}-linux-musl",
+        f"-Dcpu={zig_cpu}",
+        *extra_args,
+        env={"DESTDIR": "zig-out"},
+    )
+
+
+def install(pkg):
+    for x in (pkg.cwd / "zig-out").iterdir():
+        pkg.install_files(x, ".")

--- a/src/cbuild/util/zig_package.py
+++ b/src/cbuild/util/zig_package.py
@@ -1,0 +1,18 @@
+def install(pkg):
+    zig_pkg_hash = (
+        pkg.do(
+            "zig",
+            "fetch",
+            "--global-cache-dir",
+            ".zig-cache",
+            ".",
+            capture_output=True,
+        )
+        .stdout.strip()
+        .decode("utf-8")
+    )
+    
+    pkg.install_files(
+        ".zig-cache/p/" + zig_pkg_hash,
+        "usr/src/zig/packages/",
+    )

--- a/user/waylock/template.py
+++ b/user/waylock/template.py
@@ -1,0 +1,30 @@
+pkgname = "waylock"
+pkgver = "1.2.0"
+pkgrel = 0
+build_style = "zig_build"
+zig_build_args = ["-Dpie", "-Dstrip"]
+hostmakedepends = [
+    "zig",
+    "pkgconf",
+    # TODO this should be wayland-progs, not wayland-devel but the
+    # wayland-scanner.pc file is in the wrong package
+    "wayland-devel",
+    "wayland-protocols",
+]
+makedepends = [
+    "libxkbcommon-devel",
+    "linux-pam-devel",
+    "wayland-devel",
+    "zig-wayland",
+    "zig-xkbcommon",
+]
+pkgdesc = "Small screenlocker for Wayland compositors"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "ISC"
+url = "https://codeberg.org/ifreund/waylock"
+source = f"https://codeberg.org/ifreund/waylock/releases/download/v{pkgver}/waylock-{pkgver}.tar.gz"
+sha256 = "343fbb043bea54f5fd93e9fdb3ef441e6bfada60e8bf754d840a20e985689582"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/zig-wayland/template.py
+++ b/user/zig-wayland/template.py
@@ -1,0 +1,21 @@
+pkgname = "zig-wayland"
+pkgver = "0.2.0"
+pkgrel = 0
+pkgdesc = "Zig bindings for libwayland"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "MIT"
+url = "https://codeberg.org/ifreund/zig-wayland"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "831ce41cb0aad8da97de5e27125cbdd80454e5da8fd52aa78e918c0e0c784d70"
+
+
+def do_install(self):
+    self.install_files(
+        ".",
+        "usr/src/zig/packages/",
+        name="122062beeb6fd2bb21c91e81acb3ea6cbba69d3c00a31b62732254e190b5fc7a934e",
+    )
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/zig-wayland/template.py
+++ b/user/zig-wayland/template.py
@@ -1,20 +1,14 @@
 pkgname = "zig-wayland"
 pkgver = "0.2.0"
 pkgrel = 0
+build_style = "zig_package"
+hostmakedepends = ["zig"]
 pkgdesc = "Zig bindings for libwayland"
 maintainer = "Isaac Freund <mail@isaacfreund.com>"
 license = "MIT"
 url = "https://codeberg.org/ifreund/zig-wayland"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "831ce41cb0aad8da97de5e27125cbdd80454e5da8fd52aa78e918c0e0c784d70"
-
-
-def do_install(self):
-    self.install_files(
-        ".",
-        "usr/src/zig/packages/",
-        name="122062beeb6fd2bb21c91e81acb3ea6cbba69d3c00a31b62732254e190b5fc7a934e",
-    )
 
 
 def post_install(self):

--- a/user/zig-xkbcommon/template.py
+++ b/user/zig-xkbcommon/template.py
@@ -1,0 +1,21 @@
+pkgname = "zig-xkbcommon"
+pkgver = "0.2.0"
+pkgrel = 0
+pkgdesc = "Zig bindings for xkbcommon"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "MIT"
+url = "https://codeberg.org/ifreund/zig-xkbcommon"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "7f9a04254e62daa795377181ae741cab31090a2393ee5e1a93b190ea0c39707d"
+
+
+def do_install(self):
+    self.install_files(
+        ".",
+        "usr/src/zig/packages/",
+        name="1220ed0ec8a6cb1990c2f95bfd71fe7f8bcb6b8e4778573f03b3c755ea81fbf74ee8",
+    )
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/zig-xkbcommon/template.py
+++ b/user/zig-xkbcommon/template.py
@@ -1,20 +1,14 @@
 pkgname = "zig-xkbcommon"
 pkgver = "0.2.0"
 pkgrel = 0
+build_style = "zig_package"
+hostmakedepends = ["zig"]
 pkgdesc = "Zig bindings for xkbcommon"
 maintainer = "Isaac Freund <mail@isaacfreund.com>"
 license = "MIT"
 url = "https://codeberg.org/ifreund/zig-xkbcommon"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "7f9a04254e62daa795377181ae741cab31090a2393ee5e1a93b190ea0c39707d"
-
-
-def do_install(self):
-    self.install_files(
-        ".",
-        "usr/src/zig/packages/",
-        name="1220ed0ec8a6cb1990c2f95bfd71fe7f8bcb6b8e4778573f03b3c755ea81fbf74ee8",
-    )
 
 
 def post_install(self):


### PR DESCRIPTION
Upstream zig recently added support for a "system package mode" intended to integrate the package management with distro packaging. This PR uses these new features to implement a proof of concept for packaging/distributing zig packages using chimera's cbuild toolchain.

This MR successfully packages waylock's 1.2.0 release and its dependencies. Native compilation on x86_64 and cross compilation to aarch64 both work.

I've opened this MR to encourage collaboration between chimera's maintainers and upstream zig maintainers with the goal of finding how we can work together to ensure our respective end-users are best served. I personally have a foot in both camps being both a zig core team member and chimera user/contributor.

Here are the main issues I see with the current state of the zig package manager from a distro packaging point of view:

1. Since zig identifies packages by their hash, there is no way for a distro to bump a zig package from e.g version 1.0.0 to 1.0.1 without patching the build.zig.zon of all consumers of that package.
2. There is no easy way to obtain the hash of a zig package using the cli without copying into the global cache. It should be trivial to add an option to `zig fetch` for this purpose which would allow full automation of the `install` step of the `zig-wayland` and `zig-xkbcommon` templates for example. Possibly this would be made irrelevant to a solution to 1. however.
3. ~~There is no easy way to delete the files in a zig package that are not referenced by the build.zig.zon and included in the package hash. There is no reason for distros to include these files in the packages they redistribute. A more generally useful solution might be to add a CLI command to list files included in the package, which the distro packaging tooling could use as a whitelist for what to include without needing to semantically parse the build.zig.zon.~~ Edit: `zig fetch` does this, I just misunderstood how to use it.
4. While `--host-target`, `--host-cpu`, and `--host-dynamic-linker` were added, what toolchains like cbuild which support cross-compilation really need are `--target`, `--cpu`, and `--dynamic-linker` which describe the target system, not the host. This PR currently uses the `-Dtarget` and `-Dcpu` flags defined by waylock's build.zig instead but this is technically not portable.