### PR TITLE
cbuild: pass the right pkg-config path to waf

### DIFF
--- a/src/cbuild/build_style/waf.py
+++ b/src/cbuild/build_style/waf.py
@@ -2,6 +2,9 @@
 
 
 def do_configure(self):
+    env = {"PKGCONFIG": self.get_tool("PKG_CONFIG")}
+    env.update(self.configure_env)
+
     self.do(
         "python3",
         self.configure_script,
@@ -9,7 +12,7 @@ def do_configure(self):
         "--prefix=/usr",
         "--libdir=/usr/lib",
         *self.configure_args,
-        env=self.configure_env,
+        env=env,
     )
 
 


### PR DESCRIPTION
as seen [here](https://gitlab.com/ita1024/waf/-/blob/master/waflib/Tools/c_config.py#L211-214), waf reads `PKGCONFIG` from the environment instead of what cbuild sets, which is `PKG_CONFIG`