### PR TITLE
contrib/megatools: new package (1.11.1)

### DIFF
--- a/contrib/megatools/template.py
+++ b/contrib/megatools/template.py
@@ -1,0 +1,27 @@
+pkgname = "megatools"
+pkgver = "1.11.1"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = [
+    "asciidoc",
+    "meson",
+    "pkgconf",
+    # TODO package docbook2x to allow man page compliation
+    # "docbook2x",
+]
+makedepends = [
+    "fuse-devel",
+    "glib-devel",
+    "glib-networking",
+    "gobject-introspection",
+    "libcurl-devel",
+    "libsodium-devel",
+    "openssl-devel",
+]
+pkgdesc = "Command line client for mega.nz"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "GPL-2.0-or-later"
+url = "https://megatools.megous.com"
+source = f"{url}/builds/megatools-{pkgver}.20230212.tar.gz"
+sha256 = "ecfa2ee4b277c601ebae648287311030aa4ca73ea61ee730bc66bef24ef19a34"
+hardening = ["vis", "cfi"]

--- a/contrib/megatools/update.py
+++ b/contrib/megatools/update.py
@@ -1,0 +1,1 @@
+pattern = r"megatools-(\d+.\d+.\d+)."


### PR DESCRIPTION
Man pages aren't currently built as docbook2x is required and looks like a lot of work to package. I don't have plans to package it myself at the moment but thought I'd open this PR anyways in case it's acceptable to merge without man pages and to avoid duplicated effort if anyone else looks into packaging this software.