### PR TITLE
contrib/yggdrasil: new package (0.5.5)

### DIFF
--- a/contrib/yggdrasil/files/yggdrasil
+++ b/contrib/yggdrasil/files/yggdrasil
@@ -1,0 +1,6 @@
+# yggdrasil system service
+
+type       = process
+command    = /usr/libexec/yggdrasil.wrapper
+depends-on = network.target
+logfile    = /var/log/yggdrasil.log

--- a/contrib/yggdrasil/files/yggdrasil.wrapper
+++ b/contrib/yggdrasil/files/yggdrasil.wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+/usr/bin/modprobe -q tun
+
+conf="-autoconf"
+if [ -f /etc/yggdrasil.conf ]; then
+    conf="-useconffile /etc/yggdrasil.conf"
+fi
+
+exec /usr/bin/yggdrasil ${conf}

--- a/contrib/yggdrasil/template.py
+++ b/contrib/yggdrasil/template.py
@@ -1,0 +1,32 @@
+pkgname = "yggdrasil"
+pkgver = "0.5.5"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    "-ldflags="
+    f" -X github.com/yggdrasil-network/yggdrasil-go/src/version.buildName={pkgname}"
+    f" -X github.com/yggdrasil-network/yggdrasil-go/src/version.buildVersion={pkgver}",
+    "./cmd/yggdrasil/",
+    "./cmd/yggdrasilctl/",
+]
+make_check_args = ["./src/..."]
+hostmakedepends = ["go"]
+pkgdesc = "Experiment in scalable routing as an encrypted IPv6 overlay network"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "LGPL-3.0-only"
+url = "https://yggdrasil-network.github.io"
+source = f"https://github.com/yggdrasil-network/yggdrasil-go/archive/v{pkgver}.tar.gz"
+sha256 = "cdbb56b19b91b828afa282554862efb2a79dd4ada26dfb5a7bf3b0c5220f6c17"
+
+
+def pre_build(self):
+    self.do("rm", "build")
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+    self.install_service(self.files_path / "yggdrasil")
+    self.install_file(
+        self.files_path / "yggdrasil.wrapper", "usr/libexec", mode=0o755
+    )


### PR DESCRIPTION
### Things that are working
 - building and running this natively on aarch64
 - building this natively on x86_64
 - logs are stored by dinit properly
 - detection whether config file exists and falling back to `-autoconf` works
### Things that aren't working
 - cross compiling from x86_64 to aarch64
 ```
 => yggdrasil-0.5.5-r0: running post_install hook: 007_strip_debug...
objcopy: error: SHT_STRTAB string table section [index 11] is non-null terminated
=> yggdrasil-0.5.5-r0: ERROR: failed to attach debug link to usr/bin/yggdrasilctl
```