### PR TITLE
cbuild: default to running some tests for golang

### DIFF
--- a/src/cbuild/util/golang.py
+++ b/src/cbuild/util/golang.py
@@ -115,6 +115,8 @@ class Golang:
 
         if self.template.make_check_args:
             myargs += self.template.make_check_args
+        else:
+            myargs += ["./..."]
 
         return self._invoke("test", myargs)
 


### PR DESCRIPTION
without specifying make_check_args, the cmdline looks like:
 go test -p {jobs}

the go documentation states that:
 The first, called local directory mode, occurs when go test is
 invoked with no package arguments (for example, 'go test' or 'go
 test -v'). In this mode, go test compiles the package sources and
 tests found in the current directory and then runs the resulting
 test binary. In this mode, caching (discussed below) is disabled.
 After the package test finishes, go test prints a summary line
 showing the test status ('ok' or 'FAIL'), package name, and elapsed
 time.

so, by default we actually skipped all the tests unless they are in cwd. ./... runs all tests found recursively under the current directory- we can exclude some that aren't meant to be run/fail/.. later.