### PR TITLE
contrib/gopls: fix update-check

### DIFF
--- a/contrib/gopls/update.py
+++ b/contrib/gopls/update.py
@@ -1,1 +1,3 @@
-pattern = r"/tags/gopls/v([\d.]+)\.tar\.gz"
+url = "https://api.github.com/repos/golang/tools/git/refs/tags"
+pattern = r"refs/tags/gopls/v([\d.\w-]+)"
+ignore = "*pre*"


### PR DESCRIPTION
The latest release stopped being on the first page of the tags page on
GitHub, causing the update-check to fail. The GitHub API returns way more
tags than the website's first page, so use that.