### PR TITLE
contrib/swaync: new package (0.10.0)

### DIFF
--- a/contrib/granite/template.py
+++ b/contrib/granite/template.py
@@ -1,5 +1,5 @@
 pkgname = "granite"
-pkgver = "7.4.0"
+pkgver = "6.2.0"
 pkgrel = 0
 build_style = "meson"
 # missing dep on meson-generated_Application.c.o somewhere for granite .a
@@ -13,7 +13,7 @@ hostmakedepends = [
     "vala",
 ]
 makedepends = [
-    "gtk4-devel",
+    "gtk+3-devel",
     "libgee-devel",
 ]
 pkgdesc = "GTK widget extension library"
@@ -21,7 +21,7 @@ maintainer = "psykose <alice@ayaya.dev>"
 license = "LGPL-3.0-or-later"
 url = "https://github.com/elementary/granite"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "594fe6670940bf2e5d094c73071025d77efab9c5b147a6f64134fe10d370e40e"
+sha256 = "067d31445da9808a802fca523630c3e4b84d2d7c78ae547ced017cb7f3b9c6b5"
 
 
 @subpackage("granite-devel")

--- a/contrib/granite/update.py
+++ b/contrib/granite/update.py
@@ -1,0 +1,2 @@
+# intentionally ignore gtk4 version for now since this is for swaync
+ignore = ["7*"]

--- a/contrib/swaync/files/swaync.user
+++ b/contrib/swaync/files/swaync.user
@@ -1,0 +1,5 @@
+# swaync user service
+
+type       = process
+command    = /usr/bin/swaync
+depends-on = dbus

--- a/contrib/swaync/template.py
+++ b/contrib/swaync/template.py
@@ -1,0 +1,31 @@
+pkgname = "swaync"
+pkgver = "0.10.1"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = [
+    "gobject-introspection",
+    "meson",
+    "pkgconf",
+    "sassc",
+    "scdoc",
+    "vala",
+]
+makedepends = [
+    "granite-devel",
+    "gtk+3-devel",
+    "gtk-layer-shell-devel",
+    "json-glib-devel",
+    "libhandy-devel",
+    "libpulse-devel",
+]
+pkgdesc = "Notification daemon for sway"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/ErikReider/SwayNotificationCenter"
+source = f"https://github.com/ErikReider/SwayNotificationCenter/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "5586d8a679dde5e530cb8b6f0c86abdd0d5e41362fc1c4e56e2211edea0f7a13"
+
+
+def post_install(self):
+    self.rm(self.destdir / "usr/lib/systemd", recursive=True)
+    self.install_service(self.files_path / "swaync.user")


### PR DESCRIPTION
the full name is huge so every distro names this swaync usually

also has the user service that doesn't work by default because of the display thing, but works to manually start after like fnott, kanshi etc