### PR TITLE
Fix adding printers in GNOME control center

### DIFF
--- a/main/gnome-control-center/template.py
+++ b/main/gnome-control-center/template.py
@@ -1,6 +1,6 @@
 pkgname = "gnome-control-center"
 pkgver = "45.3"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 make_check_wrapper = ["weston-headless-run"]
 hostmakedepends = [
@@ -56,6 +56,7 @@ depends = [
     "gsettings-desktop-schemas",
     "power-profiles-daemon-meta",
     "sound-theme-freedesktop",
+    "system-config-printer",
     "tecla",
     "udisks",
 ]

--- a/main/python-pycups/template.py
+++ b/main/python-pycups/template.py
@@ -1,0 +1,20 @@
+pkgname = "python-pycups"
+pkgver = "2.0.1"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+]
+makedepends = ["cups-devel", "python-devel"]
+depends = ["python"]
+pkgdesc = "Python bindings for CUPS"
+maintainer = "triallax <triallax@tutanota.com>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/OpenPrinting/pycups"
+source = f"$(PYPI_SITE)/p/pycups/pycups-{pkgver}.tar.gz"
+sha256 = "57434ce5f62548eb12949ca8217f066f4eeb21a5d6ab8b13471dce350e380c90"
+# No test suite
+options = ["!check"]

--- a/main/system-config-printer/patches/Makefile-python.patch
+++ b/main/system-config-printer/patches/Makefile-python.patch
@@ -1,0 +1,16 @@
+--- a/Makefile.am	2022-08-30 16:20:07.000000000 +0100
++++ b/Makefile.am	2024-02-28 23:56:38.523125518 +0000
+@@ -59,11 +59,11 @@
+ 
+ # Use distutils to build the module.
+ all-local: .stamp-distutils-in-builddir config.py cupshelpers/config.py
+-	$(PYTHON) setup.py build
++	$(PYTHON) -m build --wheel --no-isolation .
+ 
+ # Use distutils to install the module.
+ install-exec-local: .stamp-distutils-in-builddir
+-	$(PYTHON) setup.py install --prefix=$(DESTDIR)$(prefix)
++	$(PYTHON) -m installer --compile-bytecode 0 --destdir "$(DESTDIR)" $(top_srcdir)/build/dist/cupshelpers-1.0-py3-none-any.whl
+ 
+ # Uninstall the module, crossing our fingers that we know enough
+ # about how distutils works to do this.  Unfortunately, distutils

--- a/main/system-config-printer/template.py
+++ b/main/system-config-printer/template.py
@@ -1,0 +1,46 @@
+pkgname = "system-config-printer"
+pkgver = "1.5.18"
+pkgrel = 0
+build_style = "gnu_configure"
+make_cmd = "gmake"
+hostmakedepends = [
+    "autoconf-archive",
+    "automake",
+    "desktop-file-utils",
+    "gettext-devel",
+    "gmake",
+    "libxml2-progs",
+    "pkgconf",
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-wheel",
+    "xmlto",
+]
+makedepends = ["cups-devel", "glib-devel", "libusb-devel", "udev-devel"]
+depends = [
+    "gdk-pixbuf",
+    "gtk+3",
+    "libhandy",
+    "libnotify",
+    "libsecret",
+    "python-cairo",
+    "python-dbus",
+    "python-gobject",
+    "python-pycups",
+]
+pkgdesc = "Graphical user interface for CUPS administration"
+maintainer = "triallax <triallax@tutanota.com>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/OpenPrinting/system-config-printer"
+source = (
+    f"{url}/releases/download/v{pkgver}/system-config-printer-{pkgver}.tar.xz"
+)
+sha256 = "b1a69e1b4ec2add569a87aeca811a37c5361ee6ae327ec852b79e64223e34bee"
+
+
+def post_install(self):
+    self.mv(
+        self.destdir / "etc/dbus-1/system.d",
+        self.destdir / "usr/share/dbus-1/system.d",
+    )


### PR DESCRIPTION
- **main/python-pycups: new package (2.0.1)**
- **main/system-config-printer: new package (1.5.18)**
- **main/gnome-control-center: add depenency on system-config-printer**
