### PR TITLE
main/docbook-xsl: depend on libxml2-progs 

### DIFF
--- a/main/docbook-xsl/template.py
+++ b/main/docbook-xsl/template.py
@@ -1,7 +1,7 @@
 pkgname = "docbook-xsl"
 pkgver = "1.79.2"
-pkgrel = 1
-depends = ["xmlcatmgr", "docbook-xml"]
+pkgrel = 2
+depends = ["xmlcatmgr", "docbook-xml", "libxml2-progs"]
 pkgdesc = "Docbook XSL modular stylesheet"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"


### PR DESCRIPTION
some things use `xmlcatalog` to look up if the xsl exists seemingly, so just pull it in