### PR TITLE
`main/musl` `main/musl-mallocng` `main/musl-cross`: use https instead of http for musl source

### DIFF
--- a/main/musl-cross/template.py
+++ b/main/musl-cross/template.py
@@ -15,7 +15,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "http://www.musl-libc.org"
 source = [
-    f"http://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz",
+    f"https://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz",
     f"https://github.com/llvm/llvm-project/releases/download/llvmorg-{_scudo_ver}/compiler-rt-{_scudo_ver}.src.tar.xz",
 ]
 sha256 = [

--- a/main/musl-mallocng/template.py
+++ b/main/musl-mallocng/template.py
@@ -23,7 +23,7 @@ pkgdesc = "Musl C library (with mallocng allocator)"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "http://www.musl-libc.org"
-source = f"http://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz"
+source = f"https://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz"
 sha256 = "5829457efb2247c1e39920b14721b75e9c488a06149736c8317536ec4aa3764b"
 # scp makes it segfault
 hardening = ["!scp"]

--- a/main/musl/template.py
+++ b/main/musl/template.py
@@ -17,7 +17,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "http://www.musl-libc.org"
 source = [
-    f"http://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz",
+    f"https://git.musl-libc.org/cgit/musl/snapshot/musl-{_commit}.tar.gz",
     f"https://github.com/llvm/llvm-project/releases/download/llvmorg-{_scudo_ver}/compiler-rt-{_scudo_ver}.src.tar.xz",
 ]
 source_paths = [".", "compiler-rt"]


### PR DESCRIPTION
main/musl main/musl-mallocng main/musl-cross: use https instead of http for musl source