### PR TITLE
contrib/kitty: update to 0.33.0

### DIFF
--- a/contrib/kitty/patches/simden.patch
+++ b/contrib/kitty/patches/simden.patch
@@ -1,0 +1,14 @@
+--- a/kitty/simd-string.c
++++ b/kitty/simd-string.c
+@@ -195,7 +195,11 @@
+     PyObject *module = (PyObject*)x;
+     if (PyModule_AddFunctions(module, module_methods) != 0) return false;
+ #define A(x, val) { Py_INCREF(Py_##val); if (0 != PyModule_AddObject(module, #x, Py_##val)) return false; }
++#if __has_builtin(__builtin_cpu_supports)
+ #define do_check() { has_sse4_2 = __builtin_cpu_supports("sse4.2") != 0; has_avx2 = __builtin_cpu_supports("avx2") != 0; }
++#else
++#define do_check() { has_sse4_2 = false; has_avx2 = false; }
++#endif
+ 
+ #ifdef __APPLE__
+ #ifdef __arm64__

--- a/contrib/kitty/template.py
+++ b/contrib/kitty/template.py
@@ -1,6 +1,6 @@
 pkgname = "kitty"
-pkgver = "0.32.2"
-pkgrel = 2
+pkgver = "0.33.0"
+pkgrel = 0
 hostmakedepends = [
     "go",
     "pkgconf",
@@ -25,6 +25,7 @@ makedepends = [
     "libxrandr-devel",
     "openssl-devel",
     "python-devel",
+    "simde",
     "xxhash-devel",
 ]
 depends = [
@@ -36,7 +37,7 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-3.0-only"
 url = "https://sw.kovidgoyal.net/kitty"
 source = f"https://github.com/kovidgoyal/kitty/releases/download/v{pkgver}/kitty-{pkgver}.tar.xz"
-sha256 = "d4bb54f7bfc16e274d60326323555b63733915c3e32d2ef711fd9860404bd6f2"
+sha256 = "5b11b4edddba41269824df9049d60e22ffc35551446161018dfaf5cd22f77297"
 # nah
 options = ["!cross"]
 

--- a/contrib/simde/template.py
+++ b/contrib/simde/template.py
@@ -1,0 +1,17 @@
+pkgname = "simde"
+pkgver = "0.7.6"
+pkgrel = 0
+build_style = "meson"
+# fail to build by missing roundeven symbol
+configure_args = ["-Dtests=false"]
+hostmakedepends = ["meson", "pkgconf"]
+pkgdesc = "SIMD wrapper implementation with non-native fallbacks"
+maintainer = "psykose <alice@ayaya.dev>"
+license = "MIT"
+url = "https://github.com/simd-everywhere/simde"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "c63e6c61392e324728da1c7e5de308cb31410908993a769594f5e21ff8de962b"
+
+
+def post_install(self):
+    self.install_license("COPYING")


### PR DESCRIPTION
broken for now on ppc64le:   

```
ImportError: Error relocating /builddir/kitty-0.33.0/linux-package/bin/../lib/kitty/kitty/fast_data_types.so: xor_data64_256: symbol not found
```