### PR TITLE
contrib/thermald: enable cfi

### DIFF
--- a/contrib/thermald/patches/0001-parse_new_cdev-disable-cfi-icall.patch
+++ b/contrib/thermald/patches/0001-parse_new_cdev-disable-cfi-icall.patch
@@ -1,0 +1,24 @@
+From 148b455010c8bae8cc43bd21653b7f3805668ad4 Mon Sep 17 00:00:00 2001
+From: miko <mikoxyzzz@gmail.com>
+Date: Wed, 13 Mar 2024 11:35:14 +0100
+Subject: [PATCH] parse_new_cdev: disable cfi-icall
+
+---
+ src/thd_cdev_order_parser.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/thd_cdev_order_parser.cpp b/src/thd_cdev_order_parser.cpp
+index 477b3d7..a194878 100644
+--- a/src/thd_cdev_order_parser.cpp
++++ b/src/thd_cdev_order_parser.cpp
+@@ -62,6 +62,7 @@ void cthd_cdev_order_parse::parser_deinit() {
+ 	xmlFreeDoc(doc);
+ }
+ 
++__attribute__((no_sanitize("cfi-icall")))
+ int cthd_cdev_order_parse::parse_new_cdev(xmlNode * a_node, xmlDoc *doc) {
+ 	xmlNode *cur_node = NULL;
+ 	char *tmp_value;
+-- 
+2.44.0
+

--- a/contrib/thermald/template.py
+++ b/contrib/thermald/template.py
@@ -1,6 +1,6 @@
 pkgname = "thermald"
 pkgver = "2.5.6"
-pkgrel = 0
+pkgrel = 1
 archs = ["x86_64"]
 # don't use autogen.sh, it generates files that force reconf in do_build
 build_style = "gnu_configure"
@@ -32,8 +32,7 @@ license = "GPL-2.0-or-later"
 url = "https://github.com/intel/thermal_daemon"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "e5a452624f133d71f4aff0bd0c8f8258399a5ae1a7d5aea177fa6a6e33dad1fd"
-# TODO: cfi
-hardening = ["vis"]
+hardening = ["cfi", "vis"]
 
 
 # autoreconf fails otherwise


### PR DESCRIPTION
cfi-icall is disabled for parse_new_cdev due to some fuckery with xmlFree. everything else seems fine, though