### PR TITLE
OpenPGP card tooling

### DIFF
--- a/contrib/ccid/template.py
+++ b/contrib/ccid/template.py
@@ -1,0 +1,20 @@
+pkgname = "ccid"
+pkgver = "1.5.5"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--enable-twinserial"]
+configure_gen = []
+hostmakedepends = ["automake", "libtool", "pkgconf", "flex", "perl"]
+makedepends = ["zlib-devel", "pcsc-lite-devel", "udev-devel", "libusb-devel"]
+pkgdesc = "PC/SC driver to support CCID compliant readers"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "LGPL-2.1-or-later"
+url = "https://ccid.apdu.fr"
+source = f"{url}/files/ccid-{pkgver}.tar.bz2"
+sha256 = "194708f75fe369d45dd7c15e8b3e8a7db8b49cfc5557574ca2a2e76ef12ca0ca"
+
+
+def post_install(self):
+    self.install_file(
+        "src/92_pcscd_ccid.rules", "usr/lib/udev/rules.d", mode=0o644
+    )

--- a/contrib/ccid/update.py
+++ b/contrib/ccid/update.py
@@ -1,0 +1,1 @@
+pattern = r"ccid-([0-9.]+).tar"

--- a/contrib/openpgp-card-ssh-agent/files/openpgp-card-ssh-agent.user
+++ b/contrib/openpgp-card-ssh-agent/files/openpgp-card-ssh-agent.user
@@ -1,0 +1,5 @@
+# openpgp-card-ssh-agent user service
+
+type     = process
+command  = /usr/bin/openpgp-card-ssh-agent --host unix://$XDG_RUNTIME_DIR/ocsa.sock
+log-type = buffer

--- a/contrib/openpgp-card-ssh-agent/template.py
+++ b/contrib/openpgp-card-ssh-agent/template.py
@@ -1,0 +1,18 @@
+pkgname = "openpgp-card-ssh-agent"
+pkgver = "0.2.3"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo", "pkgconf"]
+makedepends = ["rust-std", "pcsc-lite-devel"]
+depends = ["ccid"]
+pkgdesc = "SSH-agent backed by OpenPGP card authentication keys"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "Apache-2.0 OR MIT"
+url = "https://codeberg.org/openpgp-card/ssh-agent"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "afbb3620a361eb541d0a289ee9789f68c04db2dc07135f42ac989b92a4f149b0"
+
+
+def post_install(self):
+    self.install_license("LICENSES/MIT.txt")
+    self.install_service(self.files_path / "openpgp-card-ssh-agent.user")

--- a/contrib/openpgp-card-ssh-agent/update.py
+++ b/contrib/openpgp-card-ssh-agent/update.py
@@ -1,0 +1,2 @@
+url = "https://codeberg.org/openpgp-card/ssh-agent/tags"
+pattern = r">v([0-9.]+)</a>"

--- a/contrib/openpgp-card-tools/template.py
+++ b/contrib/openpgp-card-tools/template.py
@@ -1,0 +1,17 @@
+pkgname = "openpgp-card-tools"
+pkgver = "0.10.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo", "pkgconf"]
+makedepends = ["rust-std", "pcsc-lite-devel", "nettle-devel", "bzip2-devel"]
+depends = ["ccid"]
+pkgdesc = "CLI tool for inspecting, configuring and using OpenPGP cards"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "Apache-2.0 OR MIT"
+url = "https://codeberg.org/openpgp-card/openpgp-card-tools"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "2bea380d0038208d5b6bd93cb7580e6522d4f43bc1e429cc977cb678adb061fb"
+
+
+def post_install(self):
+    self.install_license("LICENSES/MIT.txt")

--- a/contrib/openpgp-card-tools/update.py
+++ b/contrib/openpgp-card-tools/update.py
@@ -1,0 +1,2 @@
+url = "https://codeberg.org/openpgp-card/openpgp-card-tools/tags"
+pattern = r">v([0-9.]+)</a>"


### PR DESCRIPTION
- **contrib/pcsc-ccid: new package (1.5.5)**: Needed for using the two tools below
- **contrib/openpgp-card-tools: new package (0.10.0)**: Tool for managing openpgp smart cards
- **contrib/openpgp-card-ssh-agent: new package (0.2.3)**: SSH agent for OpenPGP authentication subkeys on OpenPGP smart cards.
