### PR TITLE
main/pipewire,wireplumber: add log-type buffer for user services

### DIFF
--- a/main/pipewire/files/pipewire-pulse.user
+++ b/main/pipewire/files/pipewire-pulse.user
@@ -2,6 +2,7 @@
 
 type            = process
 command         = /usr/bin/pipewire-pulse
+log-type        = buffer
 depends-on      = pipewire
 restart         = true
 smooth-recovery = true

--- a/main/pipewire/files/pipewire.user
+++ b/main/pipewire/files/pipewire.user
@@ -2,6 +2,7 @@
 
 type               = process
 command            = /usr/bin/pipewire
+log-type           = buffer
 depends-on         = dbus
 restart            = true
 ready-notification = pipevar:PIPEWIRE_READY_FD

--- a/main/pipewire/template.py
+++ b/main/pipewire/template.py
@@ -1,6 +1,6 @@
 pkgname = "pipewire"
 pkgver = "1.0.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "--auto-features=enabled",

--- a/main/wireplumber/files/wireplumber.user
+++ b/main/wireplumber/files/wireplumber.user
@@ -2,6 +2,7 @@
 
 type            = process
 command         = /usr/bin/wireplumber
+log-type        = buffer
 depends-on      = pipewire
 restart         = true
 smooth-recovery = true

--- a/main/wireplumber/template.py
+++ b/main/wireplumber/template.py
@@ -1,6 +1,6 @@
 pkgname = "wireplumber"
 pkgver = "0.4.17"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "-Dsystem-lua=true",
@@ -8,12 +8,12 @@ configure_args = [
     "-Dintrospection=enabled",
 ]
 hostmakedepends = [
+    "doxygen",
+    "glib-devel",
+    "gobject-introspection",
     "meson",
     "pkgconf",
-    "gobject-introspection",
     "python-lxml",
-    "glib-devel",
-    "doxygen",
 ]
 makedepends = ["pipewire-devel", "glib-devel", "lua5.4-devel"]
 checkdepends = ["pipewire", "dbus"]


### PR DESCRIPTION
i've had log-file = /home/me/whatever locally for a while to look at these logs, but this is probably a bit better. a small scrollback is usually enough to see if something weird was happenening