### PR TITLE
contrib/wlroots0.17: add xcb-util-errors dep

### DIFF
--- a/contrib/wlroots0.16/template.py
+++ b/contrib/wlroots0.16/template.py
@@ -1,6 +1,6 @@
 pkgname = "wlroots0.16"
 pkgver = "0.16.2"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 configure_args = ["-Dexamples=false", "--includedir=/usr/include/wlroots-0.16"]
 hostmakedepends = [
@@ -24,6 +24,7 @@ makedepends = [
     "vulkan-loader-devel",
     "wayland-devel",
     "wayland-protocols",
+    "xcb-util-errors-devel",
     "xcb-util-renderutil-devel",
     "xcb-util-wm-devel",
 ]

--- a/contrib/wlroots0.17/template.py
+++ b/contrib/wlroots0.17/template.py
@@ -1,14 +1,13 @@
 pkgname = "wlroots0.17"
 pkgver = "0.17.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
-    # all except xcb-errors are needed,
+    # all auto features are needed,
     # don't accidentally end up with them disabled
     "--auto-features=enabled",
     "--includedir=/usr/include/wlroots-0.17",
     "-Dexamples=false",
-    "-Dxcb-errors=disabled",
 ]
 hostmakedepends = [
     "glslang-progs",
@@ -33,6 +32,7 @@ makedepends = [
     "vulkan-loader-devel",
     "wayland-devel",
     "wayland-protocols",
+    "xcb-util-errors-devel",
     "xcb-util-renderutil-devel",
     "xcb-util-wm-devel",
 ]

--- a/main/xcb-util-errors-devel
+++ b/main/xcb-util-errors-devel
@@ -1,0 +1,1 @@
+xcb-util-errors

--- a/main/xcb-util-errors/template.py
+++ b/main/xcb-util-errors/template.py
@@ -1,0 +1,26 @@
+pkgname = "xcb-util-errors"
+pkgver = "1.0.1"
+pkgrel = 0
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+    "libtool",
+    "pkgconf",
+    "xorg-util-macros",
+]
+makedepends = ["libxcb-devel"]
+pkgdesc = "XCB errors library"
+maintainer = "Isaac Freund <mail@isaacfreund.com>"
+license = "MIT"
+url = "https://xcb.freedesktop.org"
+source = f"{url}/dist/{pkgname}-{pkgver}.tar.gz"
+sha256 = "cfbd3b022bdb27a6921a4abd6b41f4071b4e4960447598abd30955d3454f4d99"
+
+
+def post_install(self):
+    self.install_license("COPYING")
+
+
+@subpackage("xcb-util-errors-devel")
+def _devel(self):
+    return self.default_devel()


### PR DESCRIPTION
I needed this package for my own wayland compositor development purposes so I thought I might as well enable it for the packaged wlroots versions as well to give developers better error messages in possible bug reports.