### PR TITLE
ci: use ruff format instead of black

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install python3-pip
 
       - name: Install dependencies
-        run: sudo pip3 install black flake8
+        run: sudo pip3 install flake8 ruff
 
       - name: Checkout
         uses: classabbyamp/treeless-checkout-action@v1
@@ -37,4 +37,4 @@ jobs:
         run: flake8 main contrib user src
 
       - name: Check format
-        run: black --check main contrib user src
+        run: ruff format --check main contrib user src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 80
 target-version = ['py311']
+
+[tool.ruff]
+line-length = 80
+target-version = "py311"

--- a/src/cbuild/core/scanelf.py
+++ b/src/cbuild/core/scanelf.py
@@ -115,7 +115,7 @@ def _scan_one(fpath):
     inf = open(fpath, "rb")
     mm = mmap.mmap(inf.fileno(), 0, prot=mmap.PROT_READ)
 
-    if mm[0:4] != b"\x7FELF":
+    if mm[0:4] != b"\x7fELF":
         mm.close()
         inf.close()
         return None


### PR DESCRIPTION
black takes 50+ seconds. ruff takes less than one :)

also fix the single source of difference from black (which black doesn't fix back into)  

---

see https://docs.astral.sh/ruff/formatter/#black-compatibility for limitations. tl;dr not really anything  

we could also use it as a flake8 drop in, but  

- flake8 is not anywhere near as slow for now (though i would still like to change to this)
- have to fix a million things like:  
  ```
  main/zimg/template.py:22:2: F821 Undefined name `subpackage`
  main/zix/template.py:23:2: F821 Undefined name `subpackage`
  main/zlib/template.py:20:2: F821 Undefined name `subpackage`
  ```

i kept the black entry in pyproject.toml too so that still works
