### PR TITLE
cbuild: fix a bunch of linter warnings

### DIFF
--- a/src/cbuild/core/chroot.py
+++ b/src/cbuild/core/chroot.py
@@ -5,6 +5,7 @@ import time
 import shutil
 import pathlib
 import binascii
+import stat
 from tempfile import mkstemp, mkdtemp
 
 from cbuild.core import logger, paths, errors

--- a/src/cbuild/core/pkg.py
+++ b/src/cbuild/core/pkg.py
@@ -1,6 +1,7 @@
 from cbuild.core import template
 import os
 import shutil
+import stat
 
 
 def _remove_ro(f, path, _):

--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -16,6 +16,7 @@ import pathlib
 import contextlib
 import subprocess
 import builtins
+import stat
 
 from cbuild.core import logger, chroot, paths, profile, spdx, errors
 from cbuild.util import compiler, flock

--- a/src/cbuild/hooks/post_install/006_protected_paths.py
+++ b/src/cbuild/hooks/post_install/006_protected_paths.py
@@ -19,8 +19,8 @@ def invoke(pkg):
 
     with open(ppath / f"apk-{pkg.pkgname}.list", "w") as outf:
         for pp in pkg.protected_paths:
-            if not pp[0:1] in _valid_pfx:
-                pkg.error(f"protected path '{path}' has an invalid prefix")
+            if pp[0:1] not in _valid_pfx:
+                pkg.error(f"protected path '{pp}' has an invalid prefix")
             if pathlib.Path(pp[1:]).is_absolute():
-                pkg.error(f"protected path '{path}' is not relative")
+                pkg.error(f"protected path '{pp}' is not relative")
             outf.write(f"{pp}\n")

--- a/src/cbuild/hooks/pre_pkg/003_pc_provides.py
+++ b/src/cbuild/hooks/pre_pkg/003_pc_provides.py
@@ -17,7 +17,7 @@ def invoke(pkg):
         pcname = p[3:]
         eq = pcname.find("=")
         if eq < 0:
-            pkg.error(f"invalid explicit .pc file: {soname}")
+            pkg.error(f"invalid explicit .pc file: {pcname}")
         pcname = pcname[:eq]
         sfx = pcname[eq + 1 :]
         pcset[pcname] = True

--- a/src/cbuild/step/install.py
+++ b/src/cbuild/step/install.py
@@ -1,6 +1,8 @@
 from cbuild.core import template, scanelf
 
+import os
 import shutil
+import stat
 
 
 def _remove_ro(f, path, _):

--- a/src/cbuild/util/patch.py
+++ b/src/cbuild/util/patch.py
@@ -1,5 +1,6 @@
 from cbuild.core import chroot
 
+import shlex
 import shutil
 import pathlib
 import subprocess

--- a/src/runner.py
+++ b/src/runner.py
@@ -1825,6 +1825,7 @@ def _repo_check():
     global _repo_checked
     if _repo_checked:
         return
+    import errors
     import subprocess
 
     if (
@@ -1838,6 +1839,7 @@ def _repo_check():
 
 
 def _collect_git(expr):
+    import errors
     import subprocess
     import pathlib
 
@@ -1920,6 +1922,8 @@ def _collect_status(inf):
 
 
 def _collect_blist(pkgs):
+    import sys
+
     rpkgs = []
     for pkg in pkgs:
         # empty args


### PR DESCRIPTION
```
$ ruff check src
src/cbuild/core/chroot.py:65:20: F821 Undefined name `stat`
src/cbuild/core/pkg.py:7:20: F821 Undefined name `stat`
src/cbuild/core/template.py:310:33: F821 Undefined name `stat`
src/cbuild/hooks/post_install/006_protected_paths.py:22:20: E713 [*] Test for membership should be `not in`
src/cbuild/hooks/post_install/006_protected_paths.py:23:46: F821 Undefined name `path`
src/cbuild/hooks/post_install/006_protected_paths.py:25:46: F821 Undefined name `path`
src/cbuild/hooks/pre_pkg/003_pc_provides.py:20:53: F821 Undefined name `soname`
src/cbuild/step/install.py:7:5: F821 Undefined name `os`
src/cbuild/step/install.py:7:20: F821 Undefined name `stat`
src/cbuild/util/patch.py:50:18: F821 Undefined name `shlex`
src/runner.py:1836:15: F821 Undefined name `errors`
src/runner.py:1879:15: F821 Undefined name `errors`
src/runner.py:1888:19: F821 Undefined name `errors`
src/runner.py:1952:23: F821 Undefined name `sys`
```

the undefined non-imported names (soname/path) look weird, was flake8 missing this and was this just broken?