### PR TITLE
cbuild: fix gitlab update check regex

### DIFF
--- a/src/cbuild/core/update_check.py
+++ b/src/cbuild/core/update_check.py
@@ -286,7 +286,7 @@ class UpdateCheck:
                 rx = rf"""
                     /archive/[^/]+/
                     {re.escape(pname)}-v?
-                    ([\d.]+)(?=\.tar\.gz") # match
+                    ([\d.]+)(?=\.tar\.gz) # match
                 """
             elif "bitbucket.org" in url:
                 pn = "/".join(url.split("/")[3:5])


### PR DESCRIPTION
What used to be a literal double quote is now `&quot;`, but the `.tar.gz`
alone should be enough for the regex's purposes anyway so there's no need
to match the double quote.
