### PR TITLE
contrib/xwayland-run: add missing xwayland dep

### DIFF
--- a/contrib/xwayland-run/template.py
+++ b/contrib/xwayland-run/template.py
@@ -1,6 +1,6 @@
 pkgname = "xwayland-run"
 pkgver = "0.0.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = ["-Dcompositor=weston"]
 hostmakedepends = ["meson"]
@@ -8,6 +8,7 @@ depends = [
     "python",
     "weston",
     "xauth",
+    "xwayland",
 ]
 pkgdesc = "Utilities around xwayland for running headless applications"
 maintainer = "psykose <alice@ayaya.dev>"


### PR DESCRIPTION
```
root@cbuild: /builddir/kwindowsystem-6.0.0/build$ QT_QPA_PLATFORM=xcb xwfb-run -e /dev/stdout -- ctest -E 'kwindowinfox11test|threadtest|kwindowsystem(x11test|-kwindoweffectstest)' --output-on-failure
Date: 2024-03-25 UTC
[10:46:22.570] weston 13.0.0
               https://wayland.freedesktop.org
               Bug reports to: https://gitlab.freedesktop.org/wayland/weston/issues/
               Build: 13.0.0
[10:46:22.570] Command line: weston --no-config --backend headless --socket wayland-1276
[10:46:22.570] OS: Linux, 6.7.10_1, #1 SMP PREEMPT_DYNAMIC Fri Mar 15 23:56:15 UTC 2024, x86_64
[10:46:22.570] Flight recorder: enabled
[10:46:22.570] Starting with no config file.
[10:46:22.570] Output repaint window is 7 ms maximum.
[10:46:22.570] Loading module '/usr/lib/libweston-13/headless-backend.so'
[10:46:22.571] Registered plugin API 'weston_windowed_output_api_v2' of size 16
[10:46:22.571] Color manager: no-op
[10:46:22.571] Output 'headless' attempts EOTF mode: SDR
[10:46:22.571] Output 'headless' using color profile: stock sRGB color profile
[10:46:22.572] Output 'headless' enabled with head(s) headless
[10:46:22.572] Compositor capabilities:
               arbitrary surface rotation: no
               screen capture uses y-flip: no
               cursor planes: no
               arbitrary resolutions: no
               view mask clipping: no
               explicit sync: no
               color operations: no
               presentation clock: CLOCK_MONOTONIC_RAW, id 4
               presentation clock resolution: 0.000000001 s
[10:46:22.572] Loading module '/usr/lib/weston/desktop-shell.so'
[10:46:22.572] launching '/usr/libexec/weston-keyboard'
[10:46:22.572] launching '/usr/libexec/weston-desktop-shell'
could not load cursor 'dnd-move'
could not load cursor 'dnd-copy'
could not load cursor 'dnd-none'
could not load cursor 'dnd-move'
could not load cursor 'dnd-copy'
could not load cursor 'dnd-none'
Traceback (most recent call last):
  File "/usr/bin/xwfb-run", line 128, in <module>
    if wlheadless.spawn_xwayland(xserver_args) < 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/wlheadless/weston.py", line 58, in spawn_xwayland
    return self.xwayland.spawn_xwayland(xserver_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/wlheadless/xwayland.py", line 66, in spawn_xwayland
    proc = subprocess.Popen(command, stdout = subprocess.PIPE)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1953, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'Xwayland'
```