### PR TITLE
main/gnome-font-viewer: update to 46.0

### DIFF
--- a/main/gnome-font-viewer/template.py
+++ b/main/gnome-font-viewer/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnome-font-viewer"
-pkgver = "45.0"
+pkgver = "46.0"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -22,8 +22,6 @@ maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/gnome-font-viewer"
 source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "97cb6b68dda60de0ab3038383586f1e4bc1da5a48f44025bd6bbe74ea05c2b08"
-# FIXME cfi
-hardening = ["vis", "!cfi"]
+sha256 = "592f401e485d02cc044d487bb5c8e04c961da6856216768a59f1ff98bd2d537c"
 
 tool_flags = {"CFLAGS": ["-Wno-incompatible-function-pointer-types"]}


### PR DESCRIPTION
Remove vis and cfi TODO because cfi probably isn't happening with glib.
