### PR TITLE
cbuild: enable keeping frame pointers by default

### DIFF
--- a/Packaging.md
+++ b/Packaging.md
@@ -1697,6 +1697,8 @@ the template including for subpackages:
   disable linker and LTO threads.
 * `linkundefver` *(false)* Pass `--undefined-version` to `ld.lld` to
   bypass version errors in affected packages.
+* `framepointer` *(true)* If enabled, frame pointers will be turned
+  on to make profiling of resultant binaries easier.
 
 The following options apply to a single package and need to be specified
 for subpackages separately if needed:

--- a/main/python/template.py
+++ b/main/python/template.py
@@ -63,6 +63,7 @@ sha256 = "be28112dac813d2053545c14bf13a16401a21877f1a69eb6ea5d84c4a0f3d870"
 # we cannot enable ubsan stuff because there is known UB where tests
 # are just skipped and so on, so be on the safe side for the time being
 hardening = ["vis", "!cfi", "!int"]
+options = ["!framepointer"]
 
 env = {
     # emulate python's configure stuff but with -O2

--- a/src/cbuild/core/profile.py
+++ b/src/cbuild/core/profile.py
@@ -81,6 +81,9 @@ def _get_archflags(prof, tmpl, hard):
     if not hard["ssp"]:
         sflags.append("-fno-stack-protector")
 
+    if opts["framepointer"]:
+        sflags.append("-fno-omit-frame-pointer")
+
     if hard["sst"]:
         sflags.append("-fsanitize=safe-stack")
 
@@ -234,6 +237,9 @@ def _get_rustflags(self, tmpl, name, extra_flags, debug, hardening, shell):
             "--sysroot",
             self.sysroot / "usr",
         ]
+
+    if opts["framepointer"]:
+        bflags += ["-Cforce-frame-pointers=true"]
 
     if tmpl.options["relr"] and self._has_relr(tmpl.stage):
         bflags += ["-Clink-arg=-Wl,-z,pack-relative-relocs"]

--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -392,6 +392,7 @@ default_options = {
     "ltostrip": (False, False),
     "linkparallel": (True, True),
     "linkundefver": (False, False),
+    "framepointer": (True, True),
 }
 
 core_fields = [


### PR DESCRIPTION
[ci skip]

closes #1604  

---

this is the most naive implementation:  

- does this matter only for stage>0? (shouldn't make a meaningful difference)
- do we want the `-m` arg on every arch? (clang accepts it everywhere, but i don't know outside-of-x86_64 caveats)

after this, and rebuilding musl with it for a test on a simple program, `perf record -F100 -g ...` (`-g` implicit `--call-graph=fp`) works normally.