### PR TITLE
contrib/perf: don't split doc

### DIFF
--- a/contrib/perf/template.py
+++ b/contrib/perf/template.py
@@ -1,5 +1,5 @@
 pkgname = "perf"
-pkgver = "6.8.1"
+pkgver = "6.8.2"
 pkgrel = 0
 build_wrksrc = "tools/perf"
 build_style = "makefile"
@@ -52,9 +52,10 @@ maintainer = "psykose <alice@ayaya.dev>"
 license = "GPL-2.0-only"
 url = "https://perf.wiki.kernel.org/index.php/Main_Page"
 source = f"https://cdn.kernel.org/pub/linux/kernel/v{pkgver[:pkgver.find('.')]}.x/linux-{pkgver}.tar.xz"
-sha256 = "8d0c8936e3140a0fbdf511ad7a9f21121598f3656743898f47bb9052d37cff68"
+sha256 = "9ac322d85bcf98a04667d929f5c2666b15bd58c6c2d68dd512c72acbced07d04"
 # nope
-options = ["!check"]
+# docs are a single tips file that gets displayed in the TUI
+options = ["!check", "!splitdoc"]
 # MAKE is ignored in some places
 exec_wrappers = [("/usr/bin/gmake", "make")]
 


### PR DESCRIPTION
this is a single usr/share/doc/perf-tip/tips.txt file that perf displays tips from in `perf report` (or tells you to please install perf otherwise lol), there's no point to separating it