### PR TITLE
main/libspelling: update repo url

### DIFF
--- a/main/libspelling/template.py
+++ b/main/libspelling/template.py
@@ -20,7 +20,7 @@ makedepends = [
 pkgdesc = "Spellcheck library for GTK 4"
 maintainer = "GeopJr <evan@geopjr.dev>"
 license = "LGPL-2.1-or-later"
-url = "https://gitlab.gnome.org/chergert/libspelling"
+url = "https://gitlab.gnome.org/GNOME/libspelling"
 source = f"{url}/-/archive/{pkgver}/{pkgname}-{pkgver}.tar.gz"
 sha256 = "413b22a358e77f2302d15a8fbd3ed4ad8fdecea38dfd5c687af4c567c6b3e15a"
 

--- a/main/libspelling/update.py
+++ b/main/libspelling/update.py
@@ -1,3 +1,3 @@
-url = "https://gitlab.gnome.org/chergert/libspelling/-/tags"
+url = "https://gitlab.gnome.org/GNOME/libspelling/-/tags"
 pattern = r"/tags/([\d.]+)\">"
 ignore = ["*.99*"]


### PR DESCRIPTION
libspelling moved to the GNOME namespace