### PR TITLE
fix drobilla.net update checks

### DIFF
--- a/contrib/suil/update.py
+++ b/contrib/suil/update.py
@@ -1,0 +1,2 @@
+url = "https://drobilla.net/category/suil/"
+pattern = r"suil-([\d.]+)\.tar\.xz"

--- a/main/lilv/update.py
+++ b/main/lilv/update.py
@@ -1,0 +1,2 @@
+url = "https://drobilla.net/category/lilv/"
+pattern = r"lilv-([\d.]+)\.tar\.xz"

--- a/main/serd/update.py
+++ b/main/serd/update.py
@@ -1,0 +1,2 @@
+url = "https://drobilla.net/category/serd/"
+pattern = r"serd-([\d.]+)\.tar\.xz"

--- a/main/sord/update.py
+++ b/main/sord/update.py
@@ -1,0 +1,2 @@
+url = "https://drobilla.net/category/sord/"
+pattern = r"sord-([\d.]+)\.tar\.xz"

--- a/main/sratom/update.py
+++ b/main/sratom/update.py
@@ -1,0 +1,2 @@
+url = "https://drobilla.net/category/sratom/"
+pattern = r"sratom-([\d.]+)\.tar\.xz"


### PR DESCRIPTION
I've checked https://repo.chimera-linux.org/cports-updates/cports-updates.txt to see what packages I need to update and decided to fix a bunch of the `CAUTION: no version found for '<package>'` warnings in there.

The only thing we're still missing is libreoffice, but I really couldn't find a good url for fetching that.
