### PR TITLE
contrib/ddcutil: add trigger to load i2c-dev

### DIFF
--- a/contrib/ddcutil/ddcutil.trigger
+++ b/contrib/ddcutil/ddcutil.trigger
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/modprobe -b -q i2c-dev || :

--- a/contrib/ddcutil/template.py
+++ b/contrib/ddcutil/template.py
@@ -1,6 +1,6 @@
 pkgname = "ddcutil"
 pkgver = "2.1.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = ["--disable-x11"]
 make_cmd = "gmake"
@@ -20,6 +20,7 @@ makedepends = [
     "linux-headers",
     "udev-devel",
 ]
+triggers = ["/usr/lib/modules-load.d"]
 pkgdesc = "Control monitor settings using DDC/CI and USB"
 maintainer = "psykose <alice@ayaya.dev>"
 license = "GPL-2.0-or-later"


### PR DESCRIPTION
This is required to use ddcutil (via DDC/CI) and would already get loaded upon rebooting.
```
# ddcutil getvcp 1 10
   Unexpected error. Unable to open sysfs directory /sys/class/drm/card0-HDMI-A-1/ddc/i2c-dev: No such file or directory
No /dev/i2c devices exist.
ddcutil requires module i2c-dev.
```