### PR TITLE
main/cargo-auditable: new package (0.6.2)

### DIFF
--- a/main/cargo-auditable/patches/fix-tests.patch
+++ b/main/cargo-auditable/patches/fix-tests.patch
@@ -1,0 +1,18 @@
+revert of https://github.com/rust-secure-code/cargo-auditable/pull/138
+
+rust 1.77 means cargo 0.78; but our cargo is 0.77 because of ppc64le
+regressions, so it doesn't have the change that needs this test update.
+--
+--- a/cargo-auditable/tests/it.rs
++++ b/cargo-auditable/tests/it.rs
+@@ -113,9 +113,7 @@
+             binaries
+         })
+         .for_each(|(package, binary)| {
+-            bins.entry(pkgid_to_bin_name(&package))
+-                .or_insert(Vec::new())
+-                .push(binary);
++            bins.entry(package).or_insert(Vec::new()).push(binary);
+         });
+     bins
+ }

--- a/main/cargo-auditable/template.py
+++ b/main/cargo-auditable/template.py
@@ -1,0 +1,27 @@
+pkgname = "cargo-auditable"
+pkgver = "0.6.4"
+pkgrel = 0
+build_style = "cargo"
+make_build_args = ["-p", "cargo-auditable"]
+make_check_args = make_build_args + [
+    "--",
+    "--skip",
+    # probably fails because we have slightly older cargo
+    "test_wasm",
+]
+hostmakedepends = ["cargo"]
+makedepends = ["rust-std"]
+depends = ["cargo"]
+pkgdesc = "Tool for embedding dependency information in rust binaries"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "Apache-2.0 OR MIT"
+url = "https://github.com/rust-secure-code/cargo-auditable"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "3e3f4134d81b47277d34c44bc1169c9b0356612977651f8e98e2ba1a470b69a2"
+
+
+def do_install(self):
+    self.install_bin(
+        f"./target/{self.profile().triplet}/release/cargo-auditable"
+    )
+    self.install_license("LICENSE-MIT")


### PR DESCRIPTION
Split out of #1598 