### PR TITLE
main/poppler: update and run tests; contrib/libreoffice: update

### DIFF
--- a/contrib/inkscape/template.py
+++ b/contrib/inkscape/template.py
@@ -1,6 +1,6 @@
 pkgname = "inkscape"
 pkgver = "1.3.2"
-pkgrel = 3
+pkgrel = 4
 build_style = "cmake"
 configure_args = [
     "-D2GEOM_BUILD_SHARED=OFF",

--- a/contrib/libreoffice-lang_hy
+++ b/contrib/libreoffice-lang_hy
@@ -1,0 +1,1 @@
+libreoffice

--- a/contrib/libreoffice/patches/fsword_t.patch
+++ b/contrib/libreoffice/patches/fsword_t.patch
@@ -1,0 +1,15 @@
+--- a/sal/osl/unx/file.cxx	2024-03-22 19:34:51.000000000 +0000
++++ b/sal/osl/unx/file.cxx	2024-04-01 21:24:54.452961768 +0100
+@@ -67,9 +67,9 @@
+ #ifdef LINUX
+ #include <sys/vfs.h>
+ // As documented by the kernel
+-#define SMB_SUPER_MAGIC  static_cast<__fsword_t>(0x517B)
+-#define CIFS_SUPER_MAGIC static_cast<__fsword_t>(0xFF534D42)
+-#define SMB2_SUPER_MAGIC static_cast<__fsword_t>(0xFE534D42)
++#define SMB_SUPER_MAGIC  static_cast<unsigned long>(0x517B)
++#define CIFS_SUPER_MAGIC static_cast<unsigned long>(0xFF534D42)
++#define SMB2_SUPER_MAGIC static_cast<unsigned long>(0xFE534D42)
+ #endif
+ 
+ namespace {

--- a/contrib/libreoffice/template.py
+++ b/contrib/libreoffice/template.py
@@ -1,5 +1,5 @@
 pkgname = "libreoffice"
-pkgver = "24.2.1.2"
+pkgver = "24.2.2.2"
 pkgrel = 0
 # riscv64: no handling of libcxxabi + likely too slow
 archs = ["x86_64", "ppc64le", "ppc64", "aarch64"]
@@ -129,7 +129,6 @@ makedepends = [
     "librevenge-devel",
     "librsvg-devel",
     "libtiff-devel",
-    "libtommath-devel",
     "libvisio-devel",
     "libwebp-devel",
     "libwpg-devel",
@@ -202,10 +201,10 @@ source = [
     f"{_aurl}/zxcvbn-c-2.5.tar.gz",
 ]
 sha256 = [
-    "3ccf577e8f665059ed5a06577b3b37278080be9f29cc4ad3352857a8f2549fa8",
-    "db010c781e85b401e87aa2030902565d5dfceb2c5ff4483c7172484d0f645eab",
-    "6f8b03b1af94e72c8301164fbcb84c0af57ba6416be8ff02f7b7dd06ff4c2f74",
-    "bf5b164b5e8ac9f796dbc2cf1e9d30e345341d367f634852c47e4572a94f58e9",
+    "c205a65042f65c94b54ea310344b851043633c3eb5259f4e567d9341aae5e45e",
+    "a4606997cbb04d5aa0043ccdc55abad802d8fe6aab78b1166ef562fb678f130d",
+    "e4ca31ec501c3c59e6c7aa4cc1279185675b088b2d042f17a7e6b0a8304ce025",
+    "925016b4172c1dcfb2774cdb0376df949241e369375399b9875b154e65f319b2",
     "1fb458d6aab06932693cc8a9b6e4e70944ee1ff052fa63606e3131df34e21753",
     "75823776fb51a9c526af904f1503a7afaaab900fba83eda64f8a41073724c870",
     "7d2797fe9f79a77009721e3f14fa4a1dec17a6d706bdc93f85f1f01d124fab66",
@@ -284,12 +283,6 @@ def do_install(self):
     )
     # move stuff out
     self.mv(self.destdir / "all/usr", self.destdir)
-    # qt6 is not installed for some reason?
-    self.install_file(
-        "instdir/program/libvclplug_qt6lo.so",
-        "usr/lib/libreoffice/program",
-        mode=0o755,
-    )
 
 
 def _take_list(self, listn):
@@ -369,6 +362,7 @@ for _langc, _langd in [
     ("hr", "Croatian"),
     ("hsb", "Upper Sorbian"),
     ("hu", "Hungarian"),
+    ("hy", "Armenian"),
     ("id", "Indonesian"),
     ("is", "Icelandic"),
     ("it", "Italian"),

--- a/main/poppler/template.py
+++ b/main/poppler/template.py
@@ -1,5 +1,6 @@
 pkgname = "poppler"
-pkgver = "24.03.0"
+pkgver = "24.04.0"
+_test_commit = "400f3ff05b2b1c0ae17797a0bd50e75e35c1f1b1"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -35,10 +36,21 @@ pkgdesc = "PDF rendering library"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-only OR GPL-3.0-only"
 url = "https://poppler.freedesktop.org"
-source = f"{url}/{pkgname}-{pkgver}.tar.xz"
-sha256 = "bafbf0db5713dec25b5d16eb2cd87e4a62351cdc40f050c3937cd8dd6882d446"
-# needs unshipped sample files
-options = ["!check"]
+source = [
+    f"{url}/{pkgname}-{pkgver}.tar.xz",
+    f"https://gitlab.freedesktop.org/poppler/test/-/archive/{_test_commit}/test-{_test_commit}.tar.gz",
+]
+source_paths = [".", "testdata"]
+sha256 = [
+    "1e804ec565acf7126eb2e9bb3b56422ab2039f7e05863a5dfabdd1ffd1bb77a7",
+    "0d850a1d06944671c991be6822b7146ade401b06aad560ff39b254a028074525",
+]
+
+
+def init_configure(self):
+    self.configure_args.append(
+        f"-DTESTDATADIR=/builddir/{self.wrksrc}/testdata"
+    )
 
 
 @subpackage("libpoppler")


### PR DESCRIPTION
`libtommath-devel` is only needed when embedded firebird is used, but we pass `--disable-firebird-sdbc` to configure and so firebird is disabled altogether.

[ci skip]
