### PR TITLE
main/klibc-kinit-standalone: fix build

### DIFF
--- a/main/klibc-kinit-standalone/patches/drop-linear.patch
+++ b/main/klibc-kinit-standalone/patches/drop-linear.patch
@@ -1,0 +1,25 @@
+diff -ruN ../klibc-kinit-standalone-0.0.1.orig/do_mounts_md.c ./do_mounts_md.c
+--- ../klibc-kinit-standalone-0.0.1.orig/do_mounts_md.c	2022-07-17 11:08:11.000000000 -0500
++++ ./do_mounts_md.c	2024-04-02 12:47:09.967466096 -0500
+@@ -189,7 +189,7 @@
+ 		md_setup_ents++;
+ 	switch (get_option(&str, &level)) {	/* RAID level */
+ 	case 2:		/* could be 0 or -1.. */
+-		if (level == 0 || level == LEVEL_LINEAR) {
++		if (level == 0) {
+ 			if (get_option(&str, &factor) != 2 ||	/* Chunk Size */
+ 			    get_option(&str, &fault) != 2) {
+ 				fprintf(stderr,
+@@ -198,11 +198,7 @@
+ 			}
+ 			md_setup_args[ent].level = level;
+ 			md_setup_args[ent].chunk = 1 << (factor + 12);
+-			if (level == LEVEL_LINEAR)
+-				pername = "linear";
+-			else
+-				pername = "raid0";
+-			break;
++			pername = "raid0";
+ 		}
+ 		/* FALL THROUGH */
+ 	case 1:		/* the first device is numeric */

--- a/main/klibc-kinit-standalone/template.py
+++ b/main/klibc-kinit-standalone/template.py
@@ -1,7 +1,7 @@
 pkgname = "klibc-kinit-standalone"
 _commit = "f2f5cb9f87598b27ee0a68bc3e5bbe470e6b8827"
 pkgver = "0.0.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = ["meson", "pkgconf"]
 makedepends = ["zlib-devel", "libcap-devel", "linux-headers"]
@@ -12,3 +12,7 @@ url = "https://github.com/chimera-linux/klibc-kinit-standalone"
 source = f"{url}/archive/{_commit}.tar.gz"
 sha256 = "b15bb14e33b222299685eb0818274268ea32b4133db834fb038cd0ede08bd926"
 hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("COPYING.md")


### PR DESCRIPTION
Fix build after md-linear was dropped from kernel and also install proper license file