### PR TITLE
main/libbs2b: fix -Werror=format-security

### DIFF
--- a/main/libbs2b/patches/fix-build.patch
+++ b/main/libbs2b/patches/fix-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bs2bconvert.c b/src/bs2bconvert.c
+index 24531b2..5e8c992 100644
+--- a/src/bs2bconvert.c
++++ b/src/bs2bconvert.c
+@@ -153,7 +153,7 @@ int main( int argc, char *argv[] )
+ 	if( ( infile = sf_open( infilename, SFM_READ, &sfinfo ) ) == NULL )
+ 	{
+ 		printf( "Not able to open input file %s.\n", infilename );
+-		printf( sf_strerror( NULL ) );
++		printf( "%s", sf_strerror( NULL ) );
+ 		return 1;
+ 	}
+ 

--- a/main/libbs2b/template.py
+++ b/main/libbs2b/template.py
@@ -1,6 +1,6 @@
 pkgname = "libbs2b"
 pkgver = "3.1.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 hostmakedepends = ["pkgconf"]
 makedepends = ["libsndfile-devel"]


### PR DESCRIPTION
Without this change it fails like:

```/builddir/libbs2b-3.1.0/src/bs2bconvert.c:156:11: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
  156 |                 printf( sf_strerror( NULL ) );
      |                         ^~~~~~~~~~~~~~~~~~~
/builddir/libbs2b-3.1.0/src/bs2bconvert.c:156:11: note: treat the string as an argument to avoid this
  156 |                 printf( sf_strerror( NULL ) );
      |                         ^
      |                         "%s",```