### PR TITLE
main/base-files: add network group

### DIFF
--- a/main/base-files/files/sysusers.conf
+++ b/main/base-files/files/sysusers.conf
@@ -26,6 +26,7 @@ g sgx 16
 g tape 17
 g tty 18
 g video 19
+g network 20
 
 # non-device groups
 g mail 64

--- a/main/base-files/template.py
+++ b/main/base-files/template.py
@@ -1,7 +1,7 @@
 pkgname = "base-files"
 _iana_ver = "20240305"
 pkgver = f"0.1.{_iana_ver}"
-pkgrel = 0
+pkgrel = 1
 # highest priority dir owner
 replaces_priority = 65535
 pkgdesc = "Chimera Linux base system files"


### PR DESCRIPTION
base-files was missing the network group needed for some packages, like non root iwctl access. Didn't know if I should bump version, so I just bumped pkgrel.