### PR TITLE
contrib/intel-undervolt: new package

### DIFF
--- a/contrib/intel-undervolt/files/intel-undervolt
+++ b/contrib/intel-undervolt/files/intel-undervolt
@@ -1,0 +1,5 @@
+# intel-undervolt service
+
+type = scripted
+command = /usr/bin/intel-undervolt apply
+depends-on = local.target

--- a/contrib/intel-undervolt/files/intel-undervolt-loop
+++ b/contrib/intel-undervolt/files/intel-undervolt-loop
@@ -1,0 +1,5 @@
+# intel-undervolt daemon service
+
+type = process
+command = /usr/bin/intel-undervolt daemon
+depends-on = local.target

--- a/contrib/intel-undervolt/patches/configure-gsed.patch
+++ b/contrib/intel-undervolt/patches/configure-gsed.patch
@@ -1,0 +1,20 @@
+--- a/configure
++++ b/configure
+@@ -65,7 +65,7 @@ sedarg() {
+   printf '%s' "s,^\($1 =\).*$,\1 $2,"
+ }
+ 
+-sed Makefile.in \
++sed \
+ -e "`sedcond SYSTEMD "$enable_systemd"`" \
+ -e "`sedcond ELOGIND "$enable_elogind"`" \
+ -e "`sedcond OPENRC "$enable_openrc"`" \
+@@ -74,7 +74,7 @@ sed Makefile.in \
+ -e "`sedarg RUNSTATEDIR "$runstatedir"`" \
+ -e "`sedarg UNITDIR "$unitdir"`" \
+ -e "`sedarg ELOGINDDIR "$eloginddir"`" \
+-> Makefile || exit 1
++Makefile.in > Makefile || exit 1
+ 
+ echo "Enable systemd: $enable_systemd"
+ echo "Enable elogind: $enable_elogind"

--- a/contrib/intel-undervolt/patches/fix_include.patch
+++ b/contrib/intel-undervolt/patches/fix_include.patch
@@ -1,0 +1,12 @@
+diff --git a/measure.c b/measure.c
+index 075db94..63dd655 100644
+--- a/measure.c
++++ b/measure.c
+@@ -13,6 +13,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/time.h>
+ #include <time.h>
+ #include <unistd.h>
+ 

--- a/contrib/intel-undervolt/patches/fix_install.patch
+++ b/contrib/intel-undervolt/patches/fix_install.patch
@@ -1,0 +1,28 @@
+diff --git a/Makefile.in b/Makefile.in
+index 8c44a7c..f7df7d9 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -74,9 +74,11 @@ intel-undervolt: $(intel_undervolt_objects)
+ 	$(CC) $(LDFLAGS) -o $@ $^ -lm
+ 
+ install: all
+-	install -Dm755 'intel-undervolt' \
++	install -dm 755 $(DESTDIR)$(BINDIR)
++	install -dm 755 $(DESTDIR)$(SYSCONFDIR)
++	install -m755 'intel-undervolt' \
+ 	"$(DESTDIR)$(BINDIR)/intel-undervolt"
+-	install -Dm644 'intel-undervolt.conf' \
++	install -m644 'intel-undervolt.conf' \
+ 	"$(DESTDIR)$(SYSCONFDIR)/intel-undervolt.conf"
+ ifeq ($(ENABLE_SYSTEMD), 1)
+ 	install -Dm644 'intel-undervolt.service' \
+@@ -85,7 +87,8 @@ ifeq ($(ENABLE_SYSTEMD), 1)
+ 	"$(DESTDIR)$(UNITDIR)/intel-undervolt-loop.service"
+ endif
+ ifeq ($(ENABLE_ELOGIND), 1)
+-	install -Dm755 'intel-undervolt.elogind' \
++	install -dm 755 $(DESTDIR)$(ELOGINDDIR)/system-sleep
++	install -m755 'intel-undervolt.elogind' \
+ 	"$(DESTDIR)$(ELOGINDDIR)/system-sleep/50-intel-undervolt"
+ endif
+ ifeq ($(ENABLE_OPENRC), 1)

--- a/contrib/intel-undervolt/template.py
+++ b/contrib/intel-undervolt/template.py
@@ -1,0 +1,26 @@
+pkgname = "intel-undervolt"
+pkgver = "1.7"
+pkgrel = 0
+archs = ["x86_64"]
+build_style = "makefile"
+make_cmd = "gmake"
+hostmakedepends = ["gmake", "pkgconf"]
+makedepends = ["elogind-devel"]
+pkgdesc = "Intel CPU undervolting tool"
+maintainer = "Sid Pranjale <mail@sidonthe.net>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/kitsunyan/intel-undervolt"
+source = f"{url}/archive/{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "29a7ebaee4830d65d0b5cefa6d497887d4f23f34659876dfe944f3a020cf33ff"
+hardening = ["vis", "cfi"]
+# no tests
+options = ["!check"]
+
+
+def do_configure(self):
+    self.do("./configure", "--enable-elogind")
+
+
+def post_install(self):
+    self.install_service(self.files_path / "intel-undervolt")
+    self.install_service(self.files_path / "intel-undervolt-loop")


### PR DESCRIPTION
Confirmed tested and working as on arch linux. Did not test the -loop service but it should work the same. Tested by the following means:

- set a large compile with make -j9
- apply undervolt config
- notice thermal throttling to be reduced
- revert config
- throttling is back
- apply config again and reboot, then use `intel-undervolt read` to check if config is applied on boot