### PR TITLE
contrib/nbfc-linux fixup: fix typo in service

### DIFF
--- a/contrib/nbfc-linux/files/nbfc
+++ b/contrib/nbfc-linux/files/nbfc
@@ -4,4 +4,4 @@ type = process
 command = /usr/bin/nbfc_service
 depends-on = local.target
 logfile = /var/log/nbfc.log
-logile-permissions = 644
+logfile-permissions = 644


### PR DESCRIPTION
...yeah
typo prevents boot and requires manual intervention