### PR TITLE
main/mesa: update to 24.1.0

### DIFF
--- a/main/cbindgen/template.py
+++ b/main/cbindgen/template.py
@@ -1,6 +1,6 @@
 pkgname = "cbindgen"
 pkgver = "0.26.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable"]
 makedepends = ["rust-std"]


### PR DESCRIPTION
not released obviously, for whoever wants to test it early  

new in this:  

- xe is default enabled for intel
- nvk (vulkan-drivers=nouveau), needs rust
- nouveau (gallium) needs rust now too