### PR TITLE
main/linux-stable-zfs-bin: remove broken on riscv64

### DIFF
--- a/main/linux-stable-zfs-bin/template.py
+++ b/main/linux-stable-zfs-bin/template.py
@@ -14,10 +14,6 @@ url = "https://openzfs.github.io/openzfs-docs"
 options = ["!cross"]
 
 
-if self.profile().arch == "riscv64":
-    broken = "https://github.com/openzfs/zfs/issues/14974"
-
-
 def init_configure(self):
     from cbuild.util import linux
 


### PR DESCRIPTION
The linked ticket was resolved in zfs 2.2.3.
