### PR TITLE
contrib/prismlauncher: add qt6-qtsvg as runtime depend

### DIFF
--- a/contrib/prismlauncher/template.py
+++ b/contrib/prismlauncher/template.py
@@ -18,6 +18,10 @@ makedepends = [
     "quazip-devel",
     "zlib-devel",
 ]
+depends = [
+    # prismlauncher does not directly link to qt6-qtsvg
+    "qt6-qtsvg",
+]
 pkgdesc = "Minecraft launcher with multiple instances support"
 maintainer = "aurelia <git@elia.garden>"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
qt6-qtsvg is not listed as a dependency as prismlauncher does not directly link to qt6-qtsvg. This causes the svg icons to be missing.