### PR TITLE
main/cryptsetup: remove argon2 dep and configure arg

### DIFF
--- a/main/cryptsetup/template.py
+++ b/main/cryptsetup/template.py
@@ -4,7 +4,6 @@ pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--with-crypto_backend=openssl",
-    "--enable-libargon2",
     "--enable-static-cryptsetup",
     "--disable-ssh-token",
     "--disable-asciidoc",
@@ -18,13 +17,12 @@ hostmakedepends = [
 ]
 makedepends = [
     "device-mapper-devel-static",
+    "json-c-devel-static",
+    "libatomic-chimera-devel-static",
+    "libuuid-devel-static",
+    "linux-headers",
     "openssl-devel-static",
     "popt-devel-static",
-    "json-c-devel-static",
-    "libuuid-devel-static",
-    "argon2-devel-static",
-    "libatomic-chimera-devel-static",
-    "linux-headers",
 ]
 checkdepends = ["procps", "xz"]
 pkgdesc = "Open source Linux disk encryption setup"


### PR DESCRIPTION
The configure script is ignoring those and using openssl's argon2 anyway.
