### PR TITLE
cbuild: remove redundant sort

### DIFF
--- a/src/cbuild/hooks/do_pkg/000_gen_apk.py
+++ b/src/cbuild/hooks/do_pkg/000_gen_apk.py
@@ -75,7 +75,6 @@ def genpkg(pkg, repo, arch, binpkg):
 
     # shlib requires
     if hasattr(pkg, "so_requires"):
-        pkg.so_requires.sort()
         deps += map(lambda v: f"so:{v}", sorted(pkg.so_requires))
 
     # .pc file requires


### PR DESCRIPTION
`pkg.so_requires` isn't used anywhere else anyway.
