### PR TITLE
contrib/aria2: new package

### DIFF
--- a/contrib/aria2/template.py
+++ b/contrib/aria2/template.py
@@ -1,0 +1,57 @@
+pkgname = "aria2"
+pkgver = "1.37.0"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = [
+    "--disable-libaria2",
+    "--disable-werror",
+    "--enable-bittorrent",
+    "--enable-metalink",
+    "--enable-ssl",
+    "--enable-websocket",
+    "--enable-year2038",
+    "--enable-epoll",
+    "--enable-largefile",
+    "--enable-nls",
+    "--enable-rpath",
+    "--without-appletls",
+    "--without-wintls",
+    "--without-libnettle",
+    "--without-libgmp",
+    "--without-libgcrypt",
+    "--without-libexpat",
+    "--without-gnutls",
+    "--with-libxml2",
+    "--with-openssl",
+    "--with-libz",
+    "--with-libcares",
+    "--with-libuv",
+    "--with-libssh2",
+    "--with-sqlite3",
+]
+hostmakedepends = [
+    "autoconf",
+    "automake",
+    "gettext-devel",
+    "libtool",
+    "pkgconf",
+]
+makedepends = [
+    "c-ares-devel",
+    "cppunit-devel",
+    "libssh2-devel",
+    "libuv-devel",
+    "libxml2-devel",
+    "openssl-devel",
+    "sqlite-devel",
+    "zlib-devel",
+]
+pkgdesc = "Multi-protocol download utility"
+maintainer = "nullobsi <nullobsi@unix.dog>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/aria2/aria2"
+source = f"{url}/releases/download/release-{pkgver}/aria2-{pkgver}.tar.xz"
+sha256 = "60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b"
+hardening = ["vis", "cfi"]
+# Check is broken
+options = ["!check"]

--- a/contrib/aria2/update.py
+++ b/contrib/aria2/update.py
@@ -1,0 +1,2 @@
+url = "https://github.com/aria2/aria2/tags"
+pkgname = "release"


### PR DESCRIPTION
I believe aria2 has a library that could be built too, but I haven't figured out how to achieve this with a subpackage yet or if it should be -devel or -libs.