### PR TITLE
main/*: fix git.kernel.org update-check

### DIFF
--- a/main/dtc/update.py
+++ b/main/dtc/update.py
@@ -1,0 +1,2 @@
+url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/refs/tags"
+pattern = r"\?h=v(\d.+)(?='>v\d)"

--- a/main/f2fs-tools/update.py
+++ b/main/f2fs-tools/update.py
@@ -1,0 +1,2 @@
+url = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/refs/tags"
+pattern = r"\?h=v(\d.+)(?='>v\d)"

--- a/main/firmware-linux/update.py
+++ b/main/firmware-linux/update.py
@@ -1,3 +1,2 @@
-pkgname = "linux-firmware"
 url = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/refs/tags"
-pattern = rf"{pkgname}-(\d+).tar.gz"
+pattern = r"\?h=(\d+)(?='>\d)"

--- a/main/libtraceevent/update.py
+++ b/main/libtraceevent/update.py
@@ -1,0 +1,2 @@
+url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/refs/tags"
+pattern = r"\?h=libtraceevent-(\d.+)(?='>libtraceevent-\d)"

--- a/main/libtracefs/update.py
+++ b/main/libtracefs/update.py
@@ -1,1 +1,2 @@
-url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/refs"
+url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/refs/tags"
+pattern = r"\?h=libtracefs-(\d.+)(?='>libtracefs-\d)"

--- a/main/pahole/update.py
+++ b/main/pahole/update.py
@@ -1,0 +1,2 @@
+url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/refs/tags"
+pattern = r"\?h=v(\d.+)(?='>v\d)"


### PR DESCRIPTION
All of these had `no version` found in https://repo.chimera-linux.org/cports-updates/cports-updates.txt