### PR TITLE
cbuild: take fish completion dirs with `take_progs`/`default_progs`

### DIFF
--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -1832,6 +1832,8 @@ class Subpackage(Package):
         self.take("usr/bin/*")
         self.take("usr/share/bash-completion", missing_ok=True)
         self.take("usr/share/zsh", missing_ok=True)
+        self.take("usr/share/fish/completions", missing_ok=True)
+        self.take("usr/share/fish/vendor_completions.d", missing_ok=True)
         if man:
             self.take(f"usr/share/man/man[{man}]", missing_ok=True)
 


### PR DESCRIPTION
bash and zsh completions are already included so there's no reason not to include fish ones as well

doesn't actually affect anything at the moment so no relbumps required
