### PR TITLE
cbuild: disambiguate unknown architecture error between cmake and meson

### DIFF
--- a/src/cbuild/util/cmake.py
+++ b/src/cbuild/util/cmake.py
@@ -42,7 +42,7 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
             case "aarch64" | "ppc64le" | "ppc64" | "ppc" | "x86_64" | "riscv64":
                 cmake_cpu = pkg.profile().arch
             case _:
-                pkg.error(f"unknown architecture: {pkg.profile().arch}")
+                pkg.error(f"unknown cmake architecture: {pkg.profile().arch}")
 
         sroot = pkg.profile().sysroot
 

--- a/src/cbuild/util/meson.py
+++ b/src/cbuild/util/meson.py
@@ -15,7 +15,7 @@ def _make_crossfile(pkg, build_dir):
         case "ppc":
             meson_cpu = "ppc"
         case _:
-            pkg.error(f"unknown architecture: {pkg.profile().arch}")
+            pkg.error(f"unknown meson architecture: {pkg.profile().arch}")
 
     with open(cfpath, "w") as outf:
         outf.write(


### PR DESCRIPTION
this bit me when setting up armhf