### PR TITLE
contrib/corrosion: update to 0.5.0

### DIFF
--- a/contrib/corrosion/template.py
+++ b/contrib/corrosion/template.py
@@ -1,14 +1,14 @@
 pkgname = "corrosion"
-pkgver = "0.4.9"
+pkgver = "0.5.0"
 pkgrel = 0
 build_style = "cmake"
-hostmakedepends = ["cmake", "ninja", "cargo"]
+hostmakedepends = ["cmake", "ninja", "cargo-auditable"]
 pkgdesc = "Tool for integrating Rust into an existing CMake project"
 maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license = "MIT"
 url = "https://github.com/corrosion-rs/corrosion"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "3346b21c4986c077988e10a19b8737a7b56f6f84ef8e800058b58d1f138e8fa9"
+sha256 = "bbe0d4a31cef91b890134af82789fb6e8ecc33270472beea9cecb8f2b7b7ed65"
 # Checks require rustup, because they support specifying specific toolchains
 options = ["!check"]
 

--- a/user/taskwarrior/patches/new-corrosion.patch
+++ b/user/taskwarrior/patches/new-corrosion.patch
@@ -1,0 +1,10 @@
+diff --git a/src/tc/CMakeLists.txt b/src/tc/CMakeLists.txt
+index 8009dae04..b81c51c49 100644
+--- a/src/tc/CMakeLists.txt
++++ b/src/tc/CMakeLists.txt
+@@ -24,4 +24,4 @@ set (tc_SRCS
+   Task.cpp Task.h)
+ 
+ add_library (tc STATIC ${tc_SRCS})
+-target_link_libraries(tc taskchampion-lib)
++target_link_libraries(tc taskchampion_lib)


### PR DESCRIPTION
Is it okay to put the taskwarrior patch in here?

See https://github.com/corrosion-rs/corrosion/blob/master/RELEASES.md#breaking-changes-1
