### PR TITLE
main/mandoc: move apropos stuff to main pkg, enable int+lto+vis+cfi

### DIFF
--- a/main/mandoc/patches/signed-overflow.patch
+++ b/main/mandoc/patches/signed-overflow.patch
@@ -1,0 +1,21 @@
+--- a/roff.c	2021-09-23 19:03:23.000000000 +0100
++++ b/roff.c	2024-05-15 19:25:45.375186003 +0100
+@@ -2480,7 +2480,8 @@
+ 			p++;
+ 
+ 	for (*res = 0; isdigit((unsigned char)v[p]); p++)
+-		*res = 10 * *res + v[p] - '0';
++		*res = (int) ((unsigned int) 10 * *res + v[p] - '0');
++
+ 	if (p == *pos + n)
+ 		return 0;
+ 
+@@ -3062,7 +3063,7 @@
+ 	}
+ 
+ 	if ('+' == sign)
+-		reg->val += val;
++		reg->val = (int) ((unsigned int) val + reg->val);
+ 	else if ('-' == sign)
+ 		reg->val -= val;
+ 	else

--- a/main/mandoc/template.py
+++ b/main/mandoc/template.py
@@ -1,23 +1,20 @@
 pkgname = "mandoc"
 pkgver = "1.14.6"
-pkgrel = 2
+pkgrel = 3
 build_style = "configure"
 make_cmd = "gmake"
 make_check_target = "regress"
 hostmakedepends = ["gmake"]
-makedepends = ["less", "zlib-devel"]
+makedepends = ["zlib-devel"]
 checkdepends = ["perl"]
 depends = ["less"]
 pkgdesc = "UNIX manpage compiler toolset"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "ISC"
-url = "http://mandoc.bsd.lv"
+url = "https://mandoc.bsd.lv"
 source = f"{url}/snapshots/{pkgname}-{pkgver}.tar.gz"
 sha256 = "8bf0d570f01e70a6e124884088870cbed7537f36328d512909eb10cd53179d9c"
-# FIXME int
-hardening = ["!int"]
-# ld: error: undefined symbol: mchars_alloc
-options = ["!lto"]
+hardening = ["vis", "cfi"]
 
 
 def pre_configure(self):
@@ -78,9 +75,6 @@ def _apropos(self):
     self.pkgdesc = f"{pkgdesc} (apropos trigger)"
     self.install_if = [f"{pkgname}={pkgver}-r{pkgrel}"]
     self.triggers = ["/usr/share/man"]
+    self.options = ["empty"]
 
-    return [
-        "usr/bin/apropos",
-        "usr/bin/makewhatis",
-        "usr/bin/whatis",
-    ]
+    return []


### PR DESCRIPTION
The motivation for moving `mandoc-apropos`'s contents (save the trigger) to the main package is to allow people to do `apk add !mandoc-apropos` but still be able to run `makewhatis`, e.g. in a cron job, instead of using the apk trigger (because the command can take quite a bit).
