### PR TITLE
contrib/xfce4-settings: default to `Papirus-Light` instead of `Papirus`

### DIFF
--- a/contrib/xfce4-settings/patches/defaults.patch
+++ b/contrib/xfce4-settings/patches/defaults.patch
@@ -9,7 +9,7 @@ index d8fe2ac4..ed04cdf5 100644
 -    <property name="ThemeName" type="empty"/>
 -    <property name="IconThemeName" type="empty"/>
 +    <property name="ThemeName" type="string" value="adw-gtk3"/>
-+    <property name="IconThemeName" type="string" value="Papirus"/>
++    <property name="IconThemeName" type="string" value="Papirus-Light"/>
      <property name="DoubleClickTime" type="int" value="400"/>
      <property name="DoubleClickDistance" type="int" value="5"/>
      <property name="DndDragThreshold" type="int" value="8"/>

--- a/contrib/xfce4-settings/template.py
+++ b/contrib/xfce4-settings/template.py
@@ -1,6 +1,6 @@
 pkgname = "xfce4-settings"
 pkgver = "4.18.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--enable-pluggable-dialogs",


### PR DESCRIPTION
The latter has weird icon colors sometimes, e.g. the speaker icon shown on the volume notification when changing audio volume.
