### PR TITLE
cbuild: make maintainer global to cports clone

### DIFF
--- a/etc/config.ini.example
+++ b/etc/config.ini.example
@@ -52,6 +52,8 @@ remote = yes
 categories = main contrib user
 # whether restricted packages can be considered for building
 allow_restricted = no
+# maintainer field to use for packages, you can set it for personal repos
+maintainer = unknown <cports@local>
 
 # flags passed to tools
 [flags]

--- a/src/cbuild/core/build.py
+++ b/src/cbuild/core/build.py
@@ -17,6 +17,7 @@ def build(
     no_update=False,
     update_check=False,
     accept_checksums=False,
+    maintainer=None,
 ):
     if chost:
         depn = "host-" + pkg.pkgname
@@ -56,6 +57,8 @@ def build(
 
     pkg.cwd = pkg.builddir / pkg.wrksrc
     pkg.chroot_cwd = pkg.chroot_builddir / pkg.wrksrc
+
+    pkg._maintainer = maintainer
 
     prof = pkg.profile()
     hard = profile.get_hardening(prof, pkg)

--- a/src/cbuild/core/dependencies.py
+++ b/src/cbuild/core/dependencies.py
@@ -457,6 +457,7 @@ def install(pkg, origpkg, step, depmap, hostdep, update_check):
                 chost=hostdep or not not pprof.cross,
                 no_update=not missing,
                 update_check=update_check,
+                maintainer=pkg._maintainer,
             )
             missing = True
         except template.SkipPackage:
@@ -488,6 +489,7 @@ def install(pkg, origpkg, step, depmap, hostdep, update_check):
                 chost=hostdep,
                 no_update=not missing,
                 update_check=update_check,
+                maintainer=pkg._maintainer,
             )
             missing = True
         except template.SkipPackage:
@@ -528,6 +530,7 @@ def install(pkg, origpkg, step, depmap, hostdep, update_check):
                 chost=hostdep,
                 no_update=not missing,
                 update_check=update_check,
+                maintainer=pkg._maintainer,
             )
             missing = True
         except template.SkipPackage:

--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -745,7 +745,6 @@ class Template(Package):
             "pkgrel": self.pkgrel,
             "pkgdesc": self.pkgdesc,
             "license": self.license,
-            "maintainer": self.maintainer,
             "url": self.url,
             "broken": self.broken,
             "restricted": self.restricted,
@@ -876,7 +875,6 @@ class Template(Package):
 
         # validate other stuff
         self.validate_pkgdesc()
-        self.validate_maintainer()
         self.validate_url()
         self.validate_order()
         self.validate_spdx()
@@ -960,25 +958,6 @@ class Template(Package):
             self.error("pkgdesc should start with an uppercase letter")
         if len(dstr) > 72:
             self.error("pkgdesc should be no longer than 72 characters")
-
-    def validate_maintainer(self):
-        # do not validate if not linting
-        if not self.options["lint"]:
-            return
-
-        m = re.fullmatch(r"^(.+) <([^>]+)>$", self.maintainer)
-        if not m:
-            self.error("maintainer has an invalid format")
-
-        grp = m.groups()
-
-        if grp[0] != " ".join(grp[0].split()):
-            self.error("maintainer name has an invalid format")
-
-        addrp = r"^[A-Za-z0-9._%+=-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}$"
-
-        if not re.fullmatch(addrp, grp[1]):
-            self.error("maintainer email has an invalid format")
 
     def validate_order(self):
         global core_fields_map

--- a/src/cbuild/hooks/do_pkg/000_gen_apk.py
+++ b/src/cbuild/hooks/do_pkg/000_gen_apk.py
@@ -44,7 +44,7 @@ def genpkg(pkg, repo, arch, binpkg):
         "--info",
         f"origin:{origin}",
         "--info",
-        f"maintainer:{pkg.rparent.maintainer}",
+        f"maintainer:{pkg.rparent._maintainer}",
         "--info",
         f"url:{pkg.rparent.url}",
         "--info",

--- a/src/runner.py
+++ b/src/runner.py
@@ -46,6 +46,7 @@ opt_allowcat = "main contrib user"
 opt_restricted = False
 opt_updatecheck = False
 opt_acceptsum = False
+opt_maint = "unknown <cports@local>"
 
 #
 # INITIALIZATION ROUTINES
@@ -104,7 +105,7 @@ def handle_options():
     global opt_nonet, opt_dirty, opt_statusfd, opt_keeptemp, opt_forcecheck
     global opt_checkfail, opt_stage, opt_altrepo, opt_stagepath, opt_bldroot
     global opt_blddir, opt_pkgpath, opt_srcpath, opt_cchpath, opt_updatecheck
-    global opt_acceptsum, opt_comp
+    global opt_acceptsum, opt_comp, opt_maint
 
     # respect NO_COLOR
     opt_nocolor = ("NO_COLOR" in os.environ) or not sys.stdout.isatty()
@@ -317,6 +318,7 @@ def handle_options():
         opt_srcpath = bcfg.get("sources", fallback=opt_srcpath)
         opt_cchpath = bcfg.get("cbuild_cache_path", fallback=opt_cchpath)
         opt_allowcat = bcfg.get("categories", fallback=opt_allowcat)
+        opt_maint = bcfg.get("maintainer", fallback=opt_maint)
         opt_restricted = bcfg.getboolean(
             "allow_restricted", fallback=opt_restricted
         )
@@ -625,7 +627,7 @@ def bootstrap(tgt):
         chroot.initdb()
         chroot.repo_init()
         if rp:
-            build.build(tgt, rp, {})
+            build.build(tgt, rp, {}, maintainer=opt_maint)
         do_unstage(tgt, True)
         shutil.rmtree(paths.bldroot())
         chroot.install()
@@ -1509,46 +1511,15 @@ def do_update_check(tgt):
             _print_upd(tmpls[0].repository, tmpls[0].pkgname, pv, nv)
         return
 
-    maint = None
-    pmaint = False
-    first = True
-
-    # sorted by maintainer for convenience (and then by name)
-    # put a placeholder for no maintainer, print orphaned first
     stmpls = sorted(
         tmpls,
         key=lambda tmpl: (
-            (
-                tmpl.maintainer
-                if tmpl.maintainer != "Orphaned <orphaned@chimera-linux.org>"
-                else "!!!"
-            ),
             tmpl.repository,
             tmpl.pkgname,
         ),
     )
-
     for tmpl in stmpls:
-        if tmpl.maintainer != maint:
-            maint = tmpl.maintainer
-            pmaint = False
-        # check each package, print maintainer when we find something
-        cv = update_check.update_check(tmpl, verbose)
-        if cv and not pmaint:
-            if first:
-                first = False
-            else:
-                # put an empty line inbetween different maintainers' stuff
-                print()
-            if maint:
-                print(maint)
-                print("-" * len(maint))
-            else:
-                print("ORPHANED PACKAGES")
-                print("-----------------")
-            pmaint = True
-        # now we can actually print the versions
-        for pv, nv in cv:
+        for pv, nv in update_check.update_check(tmpl, verbose):
             _print_upd(tmpl.repository, tmpl.pkgname, pv, nv)
 
 
@@ -1634,6 +1605,7 @@ def do_pkg(tgt, pkgn=None, force=None, check=None, stage=None):
         check_fail=opt_checkfail,
         update_check=opt_updatecheck,
         accept_checksums=opt_acceptsum,
+        maintainer=opt_maint,
     )
     if tgt == "pkg" and (not opt_stage or bstage < 3):
         do_unstage(tgt, bstage < 3)
@@ -1863,6 +1835,7 @@ def _bulkpkg(pkgs, statusf, do_build, do_raw):
                         check_fail=opt_checkfail,
                         update_check=opt_updatecheck,
                         accept_checksums=opt_acceptsum,
+                        maintainer=opt_maint,
                     )
                 ):
                     statusf.write(f"{pn} ok\n")


### PR DESCRIPTION
The maintainer field in packages for now still exits but is ignored. All packages get a fallback name that primarily exists to identify the origin cports instance. That is, people are free to choose a name for their local repos.

Our builders will get a `Chimera Linux <cports@chimera-linux.org>` set on each builder.

This is a part of an effort to drop the concept of template ownership. Any authorship can be tracked through git already, and this deals with the issue of orphaning, especially considering in practice nobody really owns templates in cports and this has existed only because the concept exists in apk itself.