### PR TITLE
main/protobuf-c: move binaries into -devel subpkg

### DIFF
--- a/main/protobuf-c/template.py
+++ b/main/protobuf-c/template.py
@@ -1,6 +1,6 @@
 pkgname = "protobuf-c"
 pkgver = "1.5.0"
-pkgrel = 8
+pkgrel = 9
 build_style = "gnu_configure"
 configure_args = [
     "--enable-protoc",
@@ -22,4 +22,4 @@ def post_install(self):
 
 @subpackage("protobuf-c-devel")
 def _dev(self):
-    return self.default_devel()
+    return self.default_devel(extra=["usr/bin"])


### PR DESCRIPTION
These were bringing in `protoc`/`protobuf-devel` into `base-desktop` (through `libshumate`/`gnome-maps`).

I'm aware this probably isn't the right solution but I just wanted this issue to be seen. It also frees up ~23 MiB
```
(1/9) Upgrading protobuf-c (1.5.0-r8 -> 1.5.0-r9)
(2/9) Purging protoc (26.1-r1)
(3/9) Purging protobuf-devel (26.1-r1)
(4/9) Purging protobuf (26.1-r1)
(5/9) Purging protobuf-lite (26.1-r1)
(6/9) Purging abseil-cpp-devel (20240116.2-r1)
(7/9) Purging abseil-cpp-testing (20240116.2-r1)
(8/9) Purging abseil-cpp (20240116.2-r1)
(9/9) Purging gtest (1.14.0-r0)
```