### PR TITLE
contrib/kanata: new package (1.6.1)

### DIFF
--- a/contrib/kanata/template.py
+++ b/contrib/kanata/template.py
@@ -1,0 +1,12 @@
+pkgname = "kanata"
+pkgver = "1.6.1"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["rust-std"]
+pkgdesc = "Software keyboard remapper"
+maintainer = "hge <h.gersen@gmail.com>"
+license = "LGPL-3.0-only"
+url = "https://github.com/jtroo/kanata"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "c0e047197af23cf434adf20e21a871b7b12c876b58ac75852d662c004bf49f2c"


### PR DESCRIPTION
Note: currently works for root only, which does the job for my use. Adding the ability to run as user required a fix in uaccess input rules and suitable udev rule.