### PR TITLE
contrib/php8.3: fix tests with curl 8.8.0

### DIFF
--- a/contrib/php8.3/patches/ab2c69884b474a81ce26a51d6ba0deeb1a14587a.patch
+++ b/contrib/php8.3/patches/ab2c69884b474a81ce26a51d6ba0deeb1a14587a.patch
@@ -1,0 +1,23 @@
+From ab2c69884b474a81ce26a51d6ba0deeb1a14587a Mon Sep 17 00:00:00 2001
+From: Niels Dossche <7771979+nielsdos@users.noreply.github.com>
+Date: Thu, 23 May 2024 22:20:37 +0200
+Subject: [PATCH] Fix GH-14307: Test curl_basic_024 fails with curl 8.8.0
+
+---
+ ext/curl/tests/curl_basic_024.phpt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ext/curl/tests/curl_basic_024.phpt b/ext/curl/tests/curl_basic_024.phpt
+index b16bfed03835f..84216bde308eb 100644
+--- a/ext/curl/tests/curl_basic_024.phpt
++++ b/ext/curl/tests/curl_basic_024.phpt
+@@ -25,7 +25,7 @@ var_dump(0 === curl_getinfo($ch, CURLINFO_PROXY_SSL_VERIFYRESULT));
+ var_dump(curl_getinfo($ch, CURLINFO_SCHEME));
+ curl_close($ch);
+ ?>
+---EXPECT--
++--EXPECTF--
+ bool(true)
+ bool(true)
+-string(4) "HTTP"
++string(4) "%r(HTTP|http)%r"


### PR DESCRIPTION
I didn't bump `pkgrel` since this change will not affect final package so it doesn't need to rebuild and people don't need to upgrade it