### PR TITLE
contrib/qt6-qtsensors: new package (6.7.1)

### DIFF
--- a/contrib/qt6-qtsensors-devel
+++ b/contrib/qt6-qtsensors-devel
@@ -1,0 +1,1 @@
+qt6-qtsensors

--- a/contrib/qt6-qtsensors/patches/no-cmake-tests.patch
+++ b/contrib/qt6-qtsensors/patches/no-cmake-tests.patch
@@ -1,0 +1,12 @@
+fails to find Qt6_DIR due to Unknown CMake command "_qt_internal_suggest_dependency_debugging"
+
+--- a/tests/auto/CMakeLists.txt
++++ b/tests/auto/CMakeLists.txt
+@@ -2,7 +2,6 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ 
+ add_subdirectory(qsensor)
+-add_subdirectory(cmake)
+ if(TARGET Qt::Quick)
+     add_subdirectory(qml)
+ endif()

--- a/contrib/qt6-qtsensors/template.py
+++ b/contrib/qt6-qtsensors/template.py
@@ -1,0 +1,34 @@
+pkgname = "qt6-qtsensors"
+pkgver = "6.7.1"
+pkgrel = 0
+build_style = "cmake"
+make_check_env = {"QT_QPA_PLATFORM": "offscreen"}
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = ["qt6-qtdeclarative-devel", "qt6-qtsvg-devel"]
+pkgdesc = "Qt6 Sensors component"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = (
+    "LGPL-2.1-only AND LGPL-3.0-only AND GPL-3.0-only WITH Qt-GPL-exception-1.0"
+)
+url = "https://www.qt.io"
+source = f"https://download.qt.io/official_releases/qt/{pkgver[:-2]}/{pkgver}/submodules/qtsensors-everywhere-src-{pkgver}.tar.xz"
+sha256 = "d5694a17d90f71039c12daf9c1c14fd76baf447246798e7cad171038c80dfbf2"
+# TODO
+options = ["!cross"]
+
+
+def post_install(self):
+    self.rm(self.destdir / "usr/lib/cmake/Qt6BuildInternals", recursive=True)
+    self.rm(self.destdir / "usr/tests", recursive=True)
+
+
+@subpackage("qt6-qtsensors-devel")
+def _devel(self):
+    return self.default_devel(
+        extra=[
+            "usr/lib/qt6/metatypes",
+            "usr/lib/qt6/mkspecs",
+            "usr/lib/qt6/modules",
+            "usr/lib/*.prl",
+        ]
+    )

--- a/contrib/qt6-qtsensors/update.py
+++ b/contrib/qt6-qtsensors/update.py
@@ -1,0 +1,5 @@
+url = [
+    "https://download.qt.io/official_releases/qt",
+    f"https://download.qt.io/official_releases/qt/{self.template.pkgver[:-2]}",
+]
+pattern = r">([\d.]+)/<"


### PR DESCRIPTION
`kscreen` and `kwin` will build with this for future https://gitlab.freedesktop.org/hadess/iio-sensor-proxy enablement on devices with accelerometer for auto-rotation etc.