### PR TITLE
[HACK] cbuild: fix update-check defaults for KDE packages

### DIFF
--- a/src/cbuild/core/update_check.py
+++ b/src/cbuild/core/update_check.py
@@ -214,8 +214,9 @@ class UpdateCheck:
         if not m:
             return ret
 
-        urlpfx = re.match("(.+)/[^/]+", m[0])[1] + "/"
+        urlpfx = re.match("(.+)/[^/]+", m[0])[0] + "/"
         dirpfx = re.match(".+/([^/]+)", m[0])[1]
+        dirpfx = ""
         urlsfx = re.match(".+/([^/]+)", url[len(urlpfx) + 1 :])
         if urlsfx:
             urlsfx = urlsfx[1]


### PR DESCRIPTION
This probably breaks a bunch of other stuff so this shouldn't be merged as-is; makes the behavior (almost) match `xbps-src` for this particular case though as tested with various packages in #2064. It was split for visibility.

This will be needed to stop `extra-cmake-modules` reporting only 6.2.0 always as latest version after 1ad99bcf257319fec2d334c9a5579b289616e204 (and any of other new packages in the Plasma 6 PR since I'm not planning on adding an `update.py` to 100+ templates when it *can* work automagically as seen with `xbps-src`.

For some reason the `release-service` ones scan also older than `pkgver` dirs making it slow but still work for e.g. `konsole`.