### PR TITLE
Revert "contrib/xfce4-settings: default to `Papirus-Light` instead of `Papirus`"

### DIFF
--- a/contrib/xfce4-settings/patches/defaults.patch
+++ b/contrib/xfce4-settings/patches/defaults.patch
@@ -9,7 +9,7 @@ index d8fe2ac4..ed04cdf5 100644
 -    <property name="ThemeName" type="empty"/>
 -    <property name="IconThemeName" type="empty"/>
 +    <property name="ThemeName" type="string" value="adw-gtk3"/>
-+    <property name="IconThemeName" type="string" value="Papirus-Light"/>
++    <property name="IconThemeName" type="string" value="Papirus"/>
      <property name="DoubleClickTime" type="int" value="400"/>
      <property name="DoubleClickDistance" type="int" value="5"/>
      <property name="DndDragThreshold" type="int" value="8"/>

--- a/contrib/xfce4-settings/template.py
+++ b/contrib/xfce4-settings/template.py
@@ -1,6 +1,6 @@
 pkgname = "xfce4-settings"
 pkgver = "4.18.4"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
     "--enable-pluggable-dialogs",


### PR DESCRIPTION
This reverts commit 5a1300dcb12592f1741386076e3ae6a1a7680960.

See https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/issues/2896#issuecomment-985442354; since the Xfce panel is dark by default with our theme of choice, we should be defaulting to `Papirus` and not `Papirus-Light`. I'll ask upstream later about the original color issues that prompted me to erroneously switch the default to `Papirus-Light`.
