### PR TITLE
contrib/*: improve xfce templates

### DIFF
--- a/contrib/exo/template.py
+++ b/contrib/exo/template.py
@@ -4,6 +4,7 @@ pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--disable-static"]
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/garcon/template.py
+++ b/contrib/garcon/template.py
@@ -1,6 +1,6 @@
 pkgname = "garcon"
 pkgver = "4.18.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 make_dir = "."
@@ -9,6 +9,7 @@ hostmakedepends = [
     "gettext",
     "glib-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",

--- a/contrib/garcon/template.py
+++ b/contrib/garcon/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.2"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext",

--- a/contrib/garcon/template.py
+++ b/contrib/garcon/template.py
@@ -28,6 +28,7 @@ license = "LGPL-2.0-or-later"
 url = "https://docs.xfce.org/xfce/garcon/start"
 source = f"$(XFCE_SITE)/xfce/garcon/{pkgver[:-2]}/garcon-{pkgver}.tar.bz2"
 sha256 = "1b8c9292e131968fbfc8987bbc62c5ba47186dd45ef4e47c5d8c5088bb2d434d"
+options = ["!cross"]
 
 
 @subpackage("garcon-devel")

--- a/contrib/gigolo/template.py
+++ b/contrib/gigolo/template.py
@@ -3,6 +3,7 @@ pkgver = "0.5.3"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/libxfce4ui/template.py
+++ b/contrib/libxfce4ui/template.py
@@ -1,16 +1,20 @@
 pkgname = "libxfce4ui"
 pkgver = "4.18.6"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
-configure_args = ["--enable-tests", "--disable-static"]
+configure_args = [
+    "--enable-tests",
+    "--disable-static",
+    "--with-vendor-info=Chimera Linux",
+]
 make_cmd = "gmake"
-# TODO: gobject-introspection, fails to build with it for some reason
 make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",
     "glib-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",
@@ -22,7 +26,9 @@ hostmakedepends = [
 makedepends = [
     "glib-devel",
     "gtk+3-devel",
+    "libepoxy-devel",
     "libgtop-devel",
+    "libgudev-devel",
     "libsm-devel",
     "libxfce4util-devel",
     "libxml2-devel",
@@ -38,6 +44,7 @@ source = (
     f"$(XFCE_SITE)/xfce/libxfce4ui/{pkgver[:-2]}/libxfce4ui-{pkgver}.tar.bz2"
 )
 sha256 = "77dd99206cc8c6c7f69c269c83c7ee6a037bca9d4a89b1a6d9765e5a09ce30cd"
+options = ["!cross"]
 
 
 @subpackage("libxfce4ui-devel")

--- a/contrib/libxfce4ui/template.py
+++ b/contrib/libxfce4ui/template.py
@@ -5,6 +5,7 @@ build_style = "gnu_configure"
 configure_args = ["--enable-tests", "--disable-static"]
 make_cmd = "gmake"
 # TODO: gobject-introspection, fails to build with it for some reason
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/libxfce4util/template.py
+++ b/contrib/libxfce4util/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.2"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/libxfce4util/template.py
+++ b/contrib/libxfce4util/template.py
@@ -1,6 +1,6 @@
 pkgname = "libxfce4util"
 pkgver = "4.18.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 make_dir = "."
@@ -8,6 +8,7 @@ hostmakedepends = [
     "automake",
     "gettext-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",
@@ -22,6 +23,7 @@ license = "LGPL-2.0-or-later"
 url = "https://docs.xfce.org/xfce/libxfce4util/start"
 source = f"$(XFCE_SITE)/xfce/libxfce4util/{pkgver[:-2]}/libxfce4util-{pkgver}.tar.bz2"
 sha256 = "d9a329182b78f7e2520cd4aafcbb276bbbf162f6a89191676539ad2e3889c353"
+options = ["!cross"]
 
 
 @subpackage("libxfce4util-devel")

--- a/contrib/libxklavier/template.py
+++ b/contrib/libxklavier/template.py
@@ -1,6 +1,6 @@
 pkgname = "libxklavier"
 pkgver = "5.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--disable-static",
@@ -11,9 +11,7 @@ hostmakedepends = [
     "automake",
     "gettext-devel",
     "gmake",
-    # TODO: cause a bunch of build warnings, e.g.:
-    # ../../libxklavier/xkl_config_registry.h:132: Warning: Xkl: symbol='ConfigItemProcessFunc': Unknown namespace for identifier 'ConfigItemProcessFunc'
-    # "gobject-introspection",
+    "gobject-introspection",
     "gtk-doc-tools",
     "libtool",
     "pkgconf",
@@ -33,6 +31,7 @@ license = "LGPL-2.0-or-later"
 url = "https://www.freedesktop.org/wiki/Software/LibXklavier"
 source = f"https://people.freedesktop.org/~svu/libxklavier-{pkgver}.tar.bz2"
 sha256 = "17a34194df5cbcd3b7bfd0f561d95d1f723aa1c87fca56bc2c209514460a9320"
+options = ["!cross"]
 
 
 @subpackage("libxklavier-devel")

--- a/contrib/mousepad/template.py
+++ b/contrib/mousepad/template.py
@@ -3,6 +3,7 @@ pkgver = "0.6.2"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/orage/template.py
+++ b/contrib/orage/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.0"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/thunar-volman/template.py
+++ b/contrib/thunar-volman/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.0"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/thunar/template.py
+++ b/contrib/thunar/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.10"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/thunar/template.py
+++ b/contrib/thunar/template.py
@@ -1,6 +1,6 @@
 pkgname = "thunar"
 pkgver = "4.18.10"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 make_dir = "."
@@ -8,6 +8,7 @@ hostmakedepends = [
     "automake",
     "gettext-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",
@@ -33,6 +34,11 @@ license = "GPL-2.0-or-later AND LGPL-2.0-or-later"
 url = "https://docs.xfce.org/xfce/thunar/start"
 source = f"$(XFCE_SITE)/xfce/thunar/{'.'.join(pkgver.split('.')[:-1])}/thunar-{pkgver}.tar.bz2"
 sha256 = "e8308a1f139602d8c125f594bfcebb063b7dac1fbb6e14293bab4cdb3ecf1d08"
+options = ["!cross"]
+
+
+def post_install(self):
+    self.rm(self.destdir / "usr/lib/systemd/user", recursive=True)
 
 
 @subpackage("thunar-devel")

--- a/contrib/tumbler/template.py
+++ b/contrib/tumbler/template.py
@@ -1,6 +1,6 @@
 pkgname = "tumbler"
 pkgver = "4.18.2"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 make_cmd = "gmake"
 make_dir = "."
@@ -33,3 +33,7 @@ license = "GPL-2.0-or-later"
 url = "https://docs.xfce.org/xfce/tumbler/start"
 source = f"$(XFCE_SITE)/xfce/tumbler/{pkgver[:-2]}/tumbler-{pkgver}.tar.bz2"
 sha256 = "b530eec635eac7f898c0d8d3a3ff79d76a145d3bed3e786d54b1ec058132be7a"
+
+
+def post_install(self):
+    self.rm(self.destdir / "usr/lib/systemd/user", recursive=True)

--- a/contrib/tumbler/template.py
+++ b/contrib/tumbler/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.2"
 pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfburn/template.py
+++ b/contrib/xfburn/template.py
@@ -3,6 +3,7 @@ pkgver = "0.7.0"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-appfinder/template.py
+++ b/contrib/xfce4-appfinder/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.1"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-dev-tools/template.py
+++ b/contrib/xfce4-dev-tools/template.py
@@ -2,6 +2,7 @@ pkgname = "xfce4-dev-tools"
 pkgver = "4.18.1"
 pkgrel = 0
 build_style = "gnu_configure"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "libtool",

--- a/contrib/xfce4-dict/template.py
+++ b/contrib/xfce4-dict/template.py
@@ -3,6 +3,7 @@ pkgver = "0.8.6"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-mixer/template.py
+++ b/contrib/xfce4-mixer/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.1"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-notifyd/template.py
+++ b/contrib/xfce4-notifyd/template.py
@@ -1,7 +1,8 @@
 pkgname = "xfce4-notifyd"
 pkgver = "0.9.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
+configure_args = ["--disable-systemd"]
 make_cmd = "gmake"
 make_dir = "."
 hostmakedepends = [

--- a/contrib/xfce4-notifyd/template.py
+++ b/contrib/xfce4-notifyd/template.py
@@ -3,6 +3,7 @@ pkgver = "0.9.4"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-panel/template.py
+++ b/contrib/xfce4-panel/template.py
@@ -1,6 +1,6 @@
 pkgname = "xfce4-panel"
 pkgver = "4.18.6"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
 # check target fails without this
@@ -10,6 +10,7 @@ hostmakedepends = [
     "gettext-devel",
     "glib-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",
@@ -36,6 +37,7 @@ source = (
     f"$(XFCE_SITE)/xfce/xfce4-panel/{pkgver[:-2]}/xfce4-panel-{pkgver}.tar.bz2"
 )
 sha256 = "21337161f58bb9b6e42760cb6883bc79beea27882aa6272b61f0e09d750d7c62"
+options = ["!cross"]
 
 
 @subpackage("xfce4-panel-devel")

--- a/contrib/xfce4-power-manager/template.py
+++ b/contrib/xfce4-power-manager/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.3"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-screensaver/template.py
+++ b/contrib/xfce4-screensaver/template.py
@@ -38,7 +38,6 @@ makedepends = [
 pkgdesc = "Xfce screensaver"
 maintainer = "triallax <triallax@tutanota.com>"
 license = "GPL-2.0-or-later"
-url = "https://xfce.org"
 url = "https://docs.xfce.org/apps/xfce4-screensaver/start"
 source = f"$(XFCE_SITE)/apps/xfce4-screensaver/{pkgver[:-2]}/xfce4-screensaver-{pkgver}.tar.bz2"
 sha256 = "d171316136a1189dfe69ef3da7f7a7f842014129ece184cc21ffb13bc0e13a39"

--- a/contrib/xfce4-session/template.py
+++ b/contrib/xfce4-session/template.py
@@ -3,6 +3,7 @@ pkgver = "4.18.3"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-settings/template.py
+++ b/contrib/xfce4-settings/template.py
@@ -8,6 +8,7 @@ configure_args = [
     "--enable-upower-glib",
 ]
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-taskmanager/template.py
+++ b/contrib/xfce4-taskmanager/template.py
@@ -3,6 +3,7 @@ pkgver = "1.5.7"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-terminal/template.py
+++ b/contrib/xfce4-terminal/template.py
@@ -3,6 +3,7 @@ pkgver = "1.1.3"
 pkgrel = 1
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gettext-devel",

--- a/contrib/xfce4-volumed-pulse/template.py
+++ b/contrib/xfce4-volumed-pulse/template.py
@@ -3,6 +3,7 @@ pkgver = "0.2.4"
 pkgrel = 0
 build_style = "gnu_configure"
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "gmake",

--- a/contrib/xfconf/template.py
+++ b/contrib/xfconf/template.py
@@ -1,6 +1,6 @@
 pkgname = "xfconf"
 pkgver = "4.18.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = ["--enable-gsettings-backend"]
 make_cmd = "gmake"
@@ -15,6 +15,7 @@ hostmakedepends = [
     "automake",
     "glib-devel",
     "gmake",
+    "gobject-introspection",
     "gtk-doc-tools",
     "intltool",
     "libtool",
@@ -31,6 +32,7 @@ license = "GPL-2.0-only AND LGPL-2.0-or-later"
 url = "https://docs.xfce.org/xfce/xfconf/start"
 source = f"$(XFCE_SITE)/xfce/xfconf/{pkgver[:-2]}/xfconf-{pkgver}.tar.bz2"
 sha256 = "c56cc69056f6947b2c60b165ec1e4c2b0acf26a778da5f86c89ffce24d5ebd98"
+options = ["!cross"]
 
 
 @subpackage("xfconf-devel")

--- a/contrib/xfconf/template.py
+++ b/contrib/xfconf/template.py
@@ -4,6 +4,7 @@ pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--enable-gsettings-backend"]
 make_cmd = "gmake"
+make_dir = "."
 make_check_wrapper = [
     "dbus-run-session",
     "--",

--- a/contrib/xfwm4/template.py
+++ b/contrib/xfwm4/template.py
@@ -4,6 +4,7 @@ pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--enable-poswin", "--enable-xi2"]
 make_cmd = "gmake"
+make_dir = "."
 hostmakedepends = [
     "automake",
     "libtool",


### PR DESCRIPTION
- **contrib/*: use make_dir = "." for all xfce templates**
- **contrib/garcon: enable introspection**
- **contrib/xfconf: enable introspection**
- **contrib/xfce4-panel: build with introspection**
- **contrib/xfce4-screensaver: don't accidentally set url twice**
- **contrib/libxklavier: build with introspection**
- **contrib/libxfce4ui: enable introspection, build with libgudev, pass vendor info**
- **contrib/xfce4-notifyd: don't install systemd service**
- **contrib/libxfce4util: enable introspection**
- **contrib/thunar: enable introspection, don't install systemd service**
- **contrib/tumbler: don't install systemd service**
