### PR TITLE
contrib/nginx: use system user in service

### DIFF
--- a/contrib/nginx/files/nginx
+++ b/contrib/nginx/files/nginx
@@ -1,6 +1,6 @@
 # nginx service
 
-type            = process
-command         = /usr/bin/nginx -g "daemon off;"
-depends-on      = local.target
+type = process
+command = /usr/bin/nginx -g "daemon off;"
+depends-on = local.target
 smooth-recovery = true

--- a/contrib/nginx/files/sysusers.conf
+++ b/contrib/nginx/files/sysusers.conf
@@ -1,4 +1,4 @@
 # Create www system user
 
-u _nignx - "nginx www user" /var/lib/nginx /usr/bin/nologin
+u _nginx - "nginx www user" /var/lib/nginx /usr/bin/nologin
 m _nginx www-data

--- a/contrib/nginx/template.py
+++ b/contrib/nginx/template.py
@@ -1,6 +1,6 @@
 pkgname = "nginx"
 pkgver = "1.26.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "configure"
 configure_args = [
     "--prefix=/var/lib/nginx",


### PR DESCRIPTION
fixes a typo where the system user would otherwise be installed as `_nignx`
i also used that opportunity to unalign the service and run it as said user.
