### PR TITLE
contrib/dnsmasq: install config file

### DIFF
--- a/contrib/dnsmasq/patches/conf.patch
+++ b/contrib/dnsmasq/patches/conf.patch
@@ -1,0 +1,37 @@
+diff --git a/dnsmasq.conf.example b/dnsmasq.conf.example
+index f1fb2d1..ebca0e9 100644
+--- a/dnsmasq.conf.example
++++ b/dnsmasq.conf.example
+@@ -22,7 +22,7 @@
+ 
+ # Uncomment these to enable DNSSEC validation and caching:
+ # (Requires dnsmasq to be built with DNSSEC option.)
+-#conf-file=%%PREFIX%%/share/dnsmasq/trust-anchors.conf
++#conf-file=/usr/share/dnsmasq/trust-anchors.conf
+ #dnssec
+ 
+ # Replies which are not DNSSEC signed may be legitimate, because the domain
+@@ -106,8 +106,12 @@
+ 
+ # If you want dnsmasq to change uid and gid to something other
+ # than the default, edit the following lines.
+-#user=
+-#group=
++#user=_dnsmasq
++#group=_dnsmasq
++
++# Serve DNS and DHCP only to networks directly connected to this machine.
++# Any interface= line will override it.
++local-service
+ 
+ # If you want dnsmasq to listen for DHCP and DNS requests only on
+ # specified interfaces (and the loopback) give the name of the
+@@ -675,7 +679,7 @@
+ 
+ # Include another lot of configuration options.
+ #conf-file=/etc/dnsmasq.more.conf
+-#conf-dir=/etc/dnsmasq.d
++conf-dir=/etc/dnsmasq.d
+ 
+ # Include all the files in a directory except those ending in .bak
+ #conf-dir=/etc/dnsmasq.d,.bak

--- a/contrib/dnsmasq/patches/user.patch
+++ b/contrib/dnsmasq/patches/user.patch
@@ -1,0 +1,15 @@
+diff --git a/src/config.h b/src/config.h
+index e722e98..1910572 100644
+--- a/src/config.h
++++ b/src/config.h
+@@ -48,8 +48,8 @@
+ #define ETHERSFILE "/etc/ethers"
+ #define DEFLEASE 3600 /* default DHCPv4 lease time, one hour */
+ #define DEFLEASE6 (3600*24) /* default lease time for DHCPv6. One day. */
+-#define CHUSER "nobody"
+-#define CHGRP "dip"
++#define CHUSER "_dnsmasq"
++#define CHGRP "_dnsmasq"
+ #define TFTP_MAX_CONNECTIONS 50 /* max simultaneous connections */
+ #define LOG_MAX 5 /* log-queue length */
+ #define RANDFILE "/dev/urandom"

--- a/contrib/dnsmasq/template.py
+++ b/contrib/dnsmasq/template.py
@@ -1,6 +1,6 @@
 pkgname = "dnsmasq"
 pkgver = "2.90"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_install_args = ["BINDIR=/usr/bin"]
 hostmakedepends = ["pkgconf"]
@@ -23,6 +23,9 @@ options = ["!check"]
 
 
 def post_install(self):
+    self.install_file("dnsmasq.conf.example", "etc", name="dnsmasq.conf")
+    self.install_dir("etc/dnsmasq.d", empty=True)
+    self.install_file("trust-anchors.conf", "usr/share/dnsmasq")
     self.install_file("dbus/dnsmasq.conf", "usr/share/dbus-1/system.d")
     self.install_tmpfiles(self.files_path / "tmpfiles.conf")
     self.install_sysusers(self.files_path / "sysusers.conf")


### PR DESCRIPTION
noticed this file was missing when setting up libvirt