### PR TITLE
main/rtkit: _rtkit user instead of plain rtkit

### DIFF
--- a/main/rtkit/files/rtkit
+++ b/main/rtkit/files/rtkit
@@ -1,7 +1,7 @@
 # rtkit daemon service
 
 type               = process
-command            = /usr/libexec/rtkit-daemon
+command            = /usr/libexec/rtkit-daemon --user-name=_rtkit
 before             = login.target
 depends-on         = dbus
 waits-for          = polkitd

--- a/main/rtkit/files/sysusers.conf
+++ b/main/rtkit/files/sysusers.conf
@@ -1,3 +1,3 @@
 # Create rtkit system user
 
-u rtkit - "rtkit user" /proc /usr/bin/nologin
+u _rtkit - "rtkit user" /proc /usr/bin/nologin

--- a/main/rtkit/patches/0001-make-the-_rtkit-user-own-the-service-instead-of-rtki.patch
+++ b/main/rtkit/patches/0001-make-the-_rtkit-user-own-the-service-instead-of-rtki.patch
@@ -1,0 +1,25 @@
+From a859c0a3698287fbc5c559dc706654dcccc9c615 Mon Sep 17 00:00:00 2001
+From: miko <mikoxyzzz@gmail.com>
+Date: Sun, 9 Jun 2024 12:33:33 +0200
+Subject: [PATCH] make the _rtkit user own the service instead of rtkit
+
+---
+ org.freedesktop.RealtimeKit1.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/org.freedesktop.RealtimeKit1.conf b/org.freedesktop.RealtimeKit1.conf
+index 780363a..f213fbe 100644
+--- a/org.freedesktop.RealtimeKit1.conf
++++ b/org.freedesktop.RealtimeKit1.conf
+@@ -4,7 +4,7 @@
+         "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+ <busconfig>
+ 
+-        <policy user="rtkit">
++        <policy user="_rtkit">
+                 <allow own="org.freedesktop.RealtimeKit1"/>
+         </policy>
+ 
+-- 
+2.45.2
+

--- a/main/rtkit/template.py
+++ b/main/rtkit/template.py
@@ -1,6 +1,6 @@
 pkgname = "rtkit"
 pkgver = "0.13"
-pkgrel = 4
+pkgrel = 5
 build_style = "meson"
 configure_args = [
     "-Dlibsystemd=disabled",


### PR DESCRIPTION
This is done in order to stay consistent with the rest of the system.