### PR TITLE
contrib/plasma-workspace: correct system locales path

### DIFF
--- a/contrib/plasma-workspace/patches/locales.patch
+++ b/contrib/plasma-workspace/patches/locales.patch
@@ -1,0 +1,13 @@
+diff --git a/kcms/region_language/kcmregionandlang.cpp b/kcms/region_language/kcmregionandlang.cpp
+index cc486c1ca0..193de02045 100644
+--- a/kcms/region_language/kcmregionandlang.cpp
++++ b/kcms/region_language/kcmregionandlang.cpp
+@@ -128,7 +128,7 @@ QString KCMRegionAndLang::failedFindLocalesMessage()
+ 
+ QString KCMRegionAndLang::localeFileDirPath()
+ {
+-    return QStringLiteral("/usr/share/i18n/locales");
++    return QStringLiteral("/usr/share/i18n/locales/musl");
+ }
+ 
+ void KCMRegionAndLang::save()

--- a/contrib/plasma-workspace/template.py
+++ b/contrib/plasma-workspace/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma-workspace"
 pkgver = "6.0.5.1"
-pkgrel = 2
+pkgrel = 3
 build_style = "cmake"
 # TODO: -DINSTALL_SDDM_WAYLAND_SESSION=ON experiments?
 configure_args = ["-DGLIBC_LOCALE_GEN=OFF"]


### PR DESCRIPTION
fixes system settings warning "Could not find the system's available locales" when changing language

waiting on https://github.com/chimera-linux/cports/pull/2027
