### PR TITLE
contrib/glycin-loaders: build with cargo-auditable, run checks

### DIFF
--- a/contrib/glycin-loaders/patches/cargo-auditable.patch
+++ b/contrib/glycin-loaders/patches/cargo-auditable.patch
@@ -1,0 +1,13 @@
+diff --git a/loaders/meson.build b/loaders/meson.build
+index 7913b58..a763863 100644
+--- a/loaders/meson.build
++++ b/loaders/meson.build
+@@ -51,7 +51,7 @@ foreach loader : get_option('loaders')
+     console: true,
+     env: cargo_env,
+     command: [
+-      cargo_bin, 'build',
++      cargo_bin, 'auditable', 'build',
+       '--target-dir', target_dir / 'loaders',
+       [cargo_options, [ '--package', loader ]],
+     ],

--- a/contrib/glycin-loaders/patches/meson-cargo.patch
+++ b/contrib/glycin-loaders/patches/meson-cargo.patch
@@ -1,6 +1,8 @@
---- a/loaders/meson.build	2024-03-30 22:29:20.000000000 +0000
-+++ b/loaders/meson.build	2024-04-06 01:29:01.206154760 +0100
-@@ -26,17 +26,8 @@
+diff --git a/loaders/meson.build b/loaders/meson.build
+index 7913b58..7375f28 100644
+--- a/loaders/meson.build
++++ b/loaders/meson.build
+@@ -26,17 +26,8 @@ cargo_options = [
  ]
  
  cargo_env = {
@@ -18,25 +20,3 @@
  }
  
  test_args = []
-@@ -54,21 +45,6 @@
-       cargo_bin, 'build',
-       '--target-dir', target_dir / 'loaders',
-       [cargo_options, [ '--package', loader ]],
--    ],
--  )
--
--  custom_target(
--    loader + '-cp-binary',
--    depends: cargo_build,
--    build_by_default: true,
--    build_always_stale: true,
--    install: true,
--    install_dir: libexecdir,
--    output: loader,
--    command: [
--      'cp',
--      target_dir / 'loaders' / rust_target / loader,
--      '@OUTPUT@',
-     ],
-   )
- 

--- a/contrib/glycin-loaders/template.py
+++ b/contrib/glycin-loaders/template.py
@@ -1,10 +1,9 @@
 pkgname = "glycin-loaders"
 pkgver = "1.0.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
-configure_args = ["-Dtests=false"]
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "gettext",
     "meson",
     "pkgconf",
@@ -19,14 +18,17 @@ makedepends = [
     "rust-std",
 ]
 depends = ["bubblewrap"]
+checkdepends = ["bubblewrap", "gtk4-devel"]
 pkgdesc = "Sandboxed and extendable image decoding"
 maintainer = "triallax <triallax@tutanota.com>"
 license = "MPL-2.0 OR LGPL-2.1-or-later"
 url = "https://gitlab.gnome.org/sophie-h/glycin"
-source = f"$(GNOME_SITE)/{pkgname}/{pkgver[:-2]}/{pkgname}-{pkgver}.tar.xz"
+source = (
+    f"$(GNOME_SITE)/glycin-loaders/{pkgver[:-2]}/glycin-loaders-{pkgver}.tar.xz"
+)
 sha256 = "d0f022462ff555856e85ea940474470bb36b37c9ffcbcba63a03fe5e954370cf"
-# Needs loaders to be system-installed
-options = ["!check"]
+# deleting CARGO_BUILD_TARGET from env breaks cross
+options = ["!cross"]
 
 
 def init_build(self):
@@ -34,12 +36,5 @@ def init_build(self):
 
     renv = cargo.get_environment(self)
     self.make_env.update(renv)
-
-
-def post_install(self):
-    for loader in (self.cwd / "loaders").glob("glycin-*"):
-        self.install_file(
-            f"./build/cargo_target/loaders/{self.profile().triplet}/release/{loader.name}",
-            "usr/libexec/glycin-loaders/1+",
-            mode=0o755,
-        )
+    # so target/release is not triple-prefixed for buildsystem integration
+    del self.make_env["CARGO_BUILD_TARGET"]


### PR DESCRIPTION
turns out the original comment regarding tests needing system-installed loaders was not true at all; for tests, the buildsystem installs the loaders into a separate location in the build directory and then the tests use these loaders
