### PR TITLE
main/dbus: start user service in $HOME and system service in /

### DIFF
--- a/main/dbus/files/dbus
+++ b/main/dbus/files/dbus
@@ -1,7 +1,8 @@
 # dbus daemon service
 
-type               = process
-command            = /usr/bin/dbus-daemon --system --nofork --nopidfile --print-address=4
-before             = login.target
-depends-on         = local.target
+type = process
+command = /usr/bin/dbus-daemon --system --nofork --nopidfile --print-address=4
+before = login.target
+depends-on = local.target
 ready-notification = pipefd:4
+working-dir = /

--- a/main/dbus/files/dbus.user
+++ b/main/dbus/files/dbus.user
@@ -1,5 +1,6 @@
 # dbus session bus user service
 
-type               = process
-command            = /usr/libexec/dbus-session.wrapper --print-address=4
+type = process
+command = /usr/libexec/dbus-session.wrapper --print-address=4
 ready-notification = pipefd:4
+working-dir = $HOME

--- a/main/dbus/template.py
+++ b/main/dbus/template.py
@@ -1,6 +1,6 @@
 pkgname = "dbus"
 pkgver = "1.14.10"
-pkgrel = 9
+pkgrel = 10
 build_style = "gnu_configure"
 configure_args = [
     "--disable-selinux",


### PR DESCRIPTION
e.g. so that yakuake, when added to kde's autostarted apps, starts in $HOME and not in /etc/dinit.d/user
