### PR TITLE
main/elfutils: silence unaligned access warning

### DIFF
--- a/main/elfutils/template.py
+++ b/main/elfutils/template.py
@@ -45,7 +45,7 @@ source = (
 )
 sha256 = "df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"
 tool_flags = {
-    "CFLAGS": ["-D_GNU_SOURCE"],
+    "CFLAGS": ["-D_GNU_SOURCE", "-Wno-unaligned-access"],
     "LDFLAGS": ["-Wl,-z,stack-size=2097152"],
 }
 


### PR DESCRIPTION
otherwise errors for armhf with
```
In file included from ../../backends/m68k_corenote.c:72:
../../backends/linux-core-note.c:99:27: error: field pr_utime within 'struct m68k_prstatus' is less aligned than 'struct m68k_timeval' and is usually due to 'struct m68k_prstatus' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
   99 |   struct EBLHOOK(timeval) pr_utime;
      |                           ^
../../backends/linux-core-note.c:100:27: error: field pr_stime within 'struct m68k_prstatus' is less aligned than 'struct m68k_timeval' and is usually due to 'struct m68k_prstatus' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
  100 |   struct EBLHOOK(timeval) pr_stime;
      |                           ^
../../backends/linux-core-note.c:101:27: error: field pr_cutime within 'struct m68k_prstatus' is less aligned than 'struct m68k_timeval' and is usually due to 'struct m68k_prstatus' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
  101 |   struct EBLHOOK(timeval) pr_cutime;
      |                           ^
../../backends/linux-core-note.c:102:27: error: field pr_cstime within 'struct m68k_prstatus' is less aligned than 'struct m68k_timeval' and is usually due to 'struct m68k_prstatus' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
  102 |   struct EBLHOOK(timeval) pr_cstime;
      |                           ^
../../backends/linux-core-note.c:103:3: error: field  within 'struct m68k_prstatus' is less aligned than 'struct m68k_prstatus::(anonymous at ../../backends/linux-core-note.c:103:3)' and is usually due to 'struct m68k_prstatus' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
  103 |   struct
      |   ^
5 errors generated.

```