### PR TITLE
main/base-kernel: raise vm.max_map_count by default

### DIFF
--- a/main/base-kernel/files/sysctl.d/sysctl.conf
+++ b/main/base-kernel/files/sysctl.d/sysctl.conf
@@ -13,3 +13,7 @@ kernel.kptr_restrict=1
 
 # Block non-uid-0 kernel profiling
 kernel.perf_event_paranoid=2
+
+# Increase the amount of mmaps available to memory intensive applications (like
+# certain games through Wine/Proton, and musl's malloc-ng)
+vm.max_map_count=1048576

--- a/main/base-kernel/template.py
+++ b/main/base-kernel/template.py
@@ -1,6 +1,6 @@
 pkgname = "base-kernel"
 pkgver = "0.1"
-pkgrel = 10
+pkgrel = 11
 depends = [
     "kmod",
     "procps",


### PR DESCRIPTION
some discussion in https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/5GU7ZUFI25T2IRXIQ62YYERQKIPE3U6E/  

final news https://archlinux.org/news/increasing-the-default-vmmax_map_count-value/  

malloc-ng is also affected- for instance when doing a thinlto link of firefox on an altra machine with 80 cores it would get a bad alloc error at some point raised from llvm, but the cause of it is just running out of maps (since it's very map hungry). doesn't affect our default allocator though

fedora/ubuntu apparently ship this same thing too

