### PR TITLE
cbuild: make codeberg use /tags instead of /releases

### DIFF
--- a/src/cbuild/core/update_check.py
+++ b/src/cbuild/core/update_check.py
@@ -333,7 +333,7 @@ class UpdateCheck:
                 rx = rf"{mver}[\d.]+(?=\.tar\.xz)"
             elif "codeberg.org" in url:
                 pn = "/".join(url.split("/")[3:5])
-                url = f"https://codeberg.org/{pn}/releases"
+                url = f"https://codeberg.org/{pn}/tags"
                 rx = r"""
                     /archive/
                     ([\d.]+)(?=\.tar\.gz) # match


### PR DESCRIPTION
not every project has a releases page, but tags should reflect all the versions too