### PR TITLE
contrib/fossil: don't try to use system sqlite

### DIFF
--- a/contrib/fossil/template.py
+++ b/contrib/fossil/template.py
@@ -3,7 +3,6 @@ pkgver = "2.24"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
-    "--disable-internal-sqlite",
     "--json",
     "--with-th1-docs",
     "--with-th1-hooks",
@@ -12,7 +11,7 @@ configure_args = [
 ]
 configure_gen = []
 make_check_target = "test"
-makedepends = ["openssl-devel", "zlib-devel", "sqlite-devel", "tcl-devel"]
+makedepends = ["openssl-devel", "zlib-devel", "tcl-devel"]
 checkdepends = ["tcl", "tcllib"]
 pkgdesc = "Distributed software configuration management system"
 maintainer = "Erica Z <zerica@callcc.eu>"


### PR DESCRIPTION
the configure option wasnt actually doing anything since the final package never ends up depending on the sqlite3 so. also when forcibly patching the included amalgamation out, some symbols are missing:

```
ld: error: undefined symbol: sqlite3_shell
>>> referenced by sqlcmd.c:426 (../src/sqlcmd.c:426)
>>>               bld/fossil.lto.sqlcmd.o:(cmd_sqlite3)

ld: error: undefined symbol: deduceDatabaseType
>>> referenced by main.c:661 (../src/main.c:661)
>>>               bld/fossil.lto.main.o:(fossil_main)

ld: error: undefined symbol: sqlite3_shathree_init
>>> referenced by login.c:891 (../src/login.c:891)
>>>               bld/fossil.lto.login.o:(login_resetpw_suffix)

ld: error: undefined symbol: sqlite3_appendvfs_init
>>> referenced by db.c:2107 (../src/db.c:2107)
>>>               bld/fossil.lto.db.o:(db_open.llvm.13013435771961569091)
```

at least `deduceDatabaseType` is an internal sqlite method, which leads me to believe fossil cant actually use an unvendored sqlite