### PR TITLE
KInfoCenter fixes

### DIFF
--- a/contrib/kinfocenter/template.py
+++ b/contrib/kinfocenter/template.py
@@ -1,6 +1,6 @@
 pkgname = "kinfocenter"
 pkgver = "6.1.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -46,6 +46,7 @@ def _meta(self):
         # basic
         "plasma-systemmonitor",
         # devices
+        "libpulse-progs",
         "lscpu",
         "aha",
         "fwupd",
@@ -55,7 +56,7 @@ def _meta(self):
         "mesa-utils",
         "vulkan-tools",
         "wayland-utils",
-        "qt6-qttools",  # FIXME: adds ~50 MiB, clang-libs heavy? split qt6-qttools into more subpkgs? just qdbus needed here
+        "qdbus",
         "xdpyinfo",
     ]
     self.options = ["empty"]

--- a/contrib/qdbus
+++ b/contrib/qdbus
@@ -1,0 +1,1 @@
+qt6-qttools

--- a/contrib/qt6-qttools/template.py
+++ b/contrib/qt6-qttools/template.py
@@ -1,6 +1,6 @@
 pkgname = "qt6-qttools"
 pkgver = "6.7.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DQT_BUILD_TESTS=OFF",  # downloads gtest
@@ -26,6 +26,7 @@ makedepends = [
     "clang-devel",
     "clang-tools-extra",
 ]
+depends = [f"qdbus={pkgver}-r{pkgrel}"]
 pkgdesc = "Qt6 tools"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = (
@@ -57,6 +58,14 @@ def post_install(self):
         for line in f.readlines():
             a, b = line.split()
             self.install_link(b, a.replace("/usr/lib", "../lib"))
+
+
+@subpackage("qdbus")
+def _qdbus(self):
+    return [
+        "usr/bin/qdbus6",
+        "usr/lib/qt6/bin/qdbus",
+    ]
 
 
 @subpackage("qt6-qttools-libs")


### PR DESCRIPTION
Add missing `libpulse-progs` for `pactl` which the audio tab can optionally show and save ~140 MiB of on-disk space by splitting `qdbus` away separate from `qt6-qttools` since that's the only thing `kinfocenter` needs to run `/usr/lib/qt6/bin/qdbus org.kde.KWin /KWin supportInformation` for `Window Manager` tab.

Fwiw `usr/bin/qdoc6` & `usr/lib/qt6/bin/{lupdate,qdoc}` are the ones that were pulling in  `clang{,-cpp}-libs`. Funnily enough `qt6-qttools` was also bringing in Qt Designer but it doesn't have a `.desktop` entry, though that's a separate matter :p