### PR TITLE
cbuild: compress manpages

### DIFF
--- a/src/cbuild/hooks/post_install/199_recompress_manpages.py
+++ b/src/cbuild/hooks/post_install/199_recompress_manpages.py
@@ -1,0 +1,25 @@
+from cbuild.core import chroot
+
+
+def invoke(pkg):
+    for f in (pkg.destdir / "usr/share/man").rglob("*.*"):
+        # may be a symlink too
+        if not f.is_file():
+            continue
+        # if a symlink, point it to the right target
+        if f.is_symlink():
+            linktgt = f.readlink()
+            f.unlink()
+            f.symlink_to(f"{linktgt}.gz")
+        # otherwise compress
+        cf = pkg.chroot_destdir / f.relative_to(pkg.destdir)
+        chroot.enter(
+            "gzip",
+            "-9n",
+            cf,
+            check=True,
+            ro_root=True,
+            ro_build=True,
+            ro_dest=False,
+            unshare_all=True,
+        )


### PR DESCRIPTION
This is a pass right before the autosplit logic but after everything else, which compresses manpages (which are guaranteed not to be compressed as they are extracted in an earlier hook) and retargets any potential symlinks.

Fixes https://github.com/chimera-linux/cports/issues/304