### PR TITLE
contrib/python-tomli: move from main, enable tests

### DIFF
--- a/contrib/python-tomli/template.py
+++ b/contrib/python-tomli/template.py
@@ -1,17 +1,16 @@
 pkgname = "python-tomli"
 pkgver = "2.0.1"
-pkgrel = 1
+pkgrel = 2
 build_style = "python_pep517"
-hostmakedepends = ["python-flit_core", "python-build", "python-installer"]
+hostmakedepends = ["python-build", "python-flit_core", "python-installer"]
 depends = ["python"]
+checkdepends = ["python-pytest"]
 pkgdesc = "TOML parser for Python"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "MIT"
 url = "https://github.com/hukkin/tomli"
-source = f"$(PYPI_SITE)/t/tomli/tomli-{pkgver}.tar.gz"
-sha256 = "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-# no tests in archive
-options = ["!check"]
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "ad22dbc128623e0c156ffaff019f29f456eba8a5d5a05164dd34f63e560449df"
 
 
 def post_install(self):


### PR DESCRIPTION
not used by anything in main anymore
