### PR TITLE
contrib/just: update to 1.29.1

### DIFF
--- a/contrib/just/template.py
+++ b/contrib/just/template.py
@@ -1,7 +1,9 @@
 pkgname = "just"
-pkgver = "1.27.0"
+pkgver = "1.29.1"
 pkgrel = 0
 build_style = "cargo"
+# skip tests that fail when run outside of git repo
+make_check_args = ["--", "--skip", "completions::bash"]
 hostmakedepends = ["cargo-auditable"]
 makedepends = ["rust-std"]
 checkdepends = ["bash", "python"]
@@ -9,12 +11,19 @@ pkgdesc = "Save and run commands from justfile"
 maintainer = "Wesley Moore <wes@wezm.net>"
 license = "CC0-1.0"
 url = "https://github.com/casey/just"
-source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "3f7af44ce43fef5e54df2b64574930e036baadae4a66645e996c4bb2164bf2a3"
+source = [
+    f"{url}/archive/{pkgver}.tar.gz",
+    f"{url}/releases/download/{pkgver}/just-{pkgver}-x86_64-unknown-linux-musl.tar.gz",
+]
+source_paths = [".", "docs-prebuilt"]
+sha256 = [
+    "3e909245038295b6935448d48bb93418b4bc1b0b5621116d1568e12dd872512b",
+    "42c47bd34b511c43a4d51a13c425c0e0f51e59e20b9f390fbd8838b85ee8db1b",
+]
 
 
 def post_install(self):
-    self.install_man("man/just.1")
-    self.install_completion("completions/just.bash", "bash")
-    self.install_completion("completions/just.zsh", "zsh")
-    self.install_completion("completions/just.fish", "fish")
+    self.install_man("docs-prebuilt/just.1")
+    self.install_completion("docs-prebuilt/completions/just.bash", "bash")
+    self.install_completion("docs-prebuilt/completions/just.zsh", "zsh")
+    self.install_completion("docs-prebuilt/completions/just.fish", "fish")


### PR DESCRIPTION
- Project has stopped including the completions and man page in the repo, requiring running the binary to generate them. I did what I did for other packages and fish them out of one of the published binary tarballs.
- Some tests fail to run due to [assuming running from a git repo](https://github.com/casey/just/blob/ef6a813dd178f43d112cf87b2bd09b79f60e5454/tests/completions/just.bash#L24), skip these.