### PR TITLE
cbuild: actually strip bins in strip

### DIFF
--- a/src/cbuild/util/strip.py
+++ b/src/cbuild/util/strip.py
@@ -5,7 +5,13 @@ def strip(pkg, path):
     cfile = str(pkg.chroot_destdir / relp)
 
     try:
-        pkg.rparent.do(strip_path, "--strip-debug", cfile)
+        pkg.rparent.do(
+            strip_path,
+            "--strip-unneeded",
+            "--remove-section=.comment",
+            "--keep-section=.gnu_debuglink",
+            cfile,
+        )
     except Exception:
         pkg.error(f"failed to strip {relp}")
 


### PR DESCRIPTION
strip --strip-debug keeps .strtab/.symtab/.comment  


---

- maybe just `--strip-unneeded --keep-section=.gnu_debuginfo` is better?
- i'm not sure if the objcopy to itself is valid