### PR TITLE
main/python: fix build

### DIFF
--- a/main/python/template.py
+++ b/main/python/template.py
@@ -109,7 +109,6 @@ def do_install(self):
     self.uninstall(f"{lbase}/tkinter")
     self.uninstall(f"{lbase}/turtledemo")
     self.uninstall(f"{lbase}/test")
-    self.uninstall(f"{lbase}/lib2to3/tests")
     self.uninstall(f"{lbase}/turtle.py")
 
     self.rename(


### PR DESCRIPTION
Attempting to build `main/python` resulted in this error prior to this change:

```
=> python-3.12.4-r0: ERROR: path 'usr/lib/python3.12/lib2to3/tests' does not match anything
=> Stack trace:
=>   /home/wmoore/cports/src/cbuild/core/build.py:24: in function 'build'
=>   /home/wmoore/cports/src/cbuild/core/build.py:161: in function '_build'
=>   /home/wmoore/cports/src/cbuild/core/dependencies.py:445: in function 'install'
=>   /home/wmoore/cports/src/cbuild/core/build.py:24: in function 'build'
=>   /home/wmoore/cports/src/cbuild/core/build.py:225: in function '_build'
=>   /home/wmoore/cports/src/cbuild/step/install.py:46: in function 'invoke'
=>   /home/wmoore/cports/src/cbuild/core/template.py:1410: in function 'run_step'
=>   /home/wmoore/cports/src/cbuild/core/template.py:227: in function 'run_pkg_func'
=>   /home/wmoore/cports/main/python/template.py:112: in function 'do_install'
=>   /home/wmoore/cports/src/cbuild/core/template.py:1525: in function 'uninstall'
=>   /home/wmoore/cports/src/cbuild/core/template.py:276: in function 'error'
=> Raised exception:
=>   PackageException: path 'usr/lib/python3.12/lib2to3/tests' does not match anything
=> Phase 'install' failed for package 'python'.
```