### PR TITLE
main/firmware-linux-brcm-rpi: fix ln_s

### DIFF
--- a/main/firmware-linux-brcm-rpi/template.py
+++ b/main/firmware-linux-brcm-rpi/template.py
@@ -28,7 +28,8 @@ def do_install(self):
 
     # need either standard or minimal
     self.ln_s(
-        "cyfmac43455-sdio-standard.bin", f"{wfw}/cypress/cyfmac43455-sdio.bin"
+        "cyfmac43455-sdio-standard.bin",
+        f"{self.cwd}/{wfw}/cypress/cyfmac43455-sdio.bin",
     )
     # install all wifi firmware
     self.install_files(f"{wfw}/cypress", "usr/lib/firmware")


### PR DESCRIPTION
for some reason (new behavior wrt relative paths?), was failing with:

```
=>   FileNotFoundError (cyfmac43455-sdio-standard.bin): [Errno 2] No such file or directory: 'cyfmac43455-sdio-standard.bin' -> 'firmware-nonfree-88aa085bfa1a4650e1ccd88896f8343c22a24055/debian/config/brcm80211/cypress/cyfmac43455-sdio.bin'
```