### PR TITLE
main/grub: fix parsing for broken archs

### DIFF
--- a/main/grub/template.py
+++ b/main/grub/template.py
@@ -83,6 +83,7 @@ match self.profile().arch:
         # otherwise crashes llvm backend (unsupported code model for lowering)
         configure_args += ["grub_cv_cc_mcmodel=no"]
     case _:
+        _archs = []
         broken = f"Unsupported platform ({self.profile().arch})"
 
 


### PR DESCRIPTION
otherwise, when parsing the template for an unsupported arch, the subpackage flag refers to an _archs variable that was never set up

the error in question is

```
=> A failure has occurred!
=> Stack trace:
=>   /home/me/cports/src/cbuild/core/template.py:2508: in function 'read_mod'
=>   <frozen importlib._bootstrap_external>:995: in function 'exec_module'
=>   <frozen importlib._bootstrap>:488: in function '_call_with_frames_removed'
=>   /home/me/cports/main/grub/template.py:228: in function '<module>'
=>   /home/me/cports/main/grub/template.py:197: in function '_genplatform'
=> Raised exception:
=>   NameError: name '_archs' is not defined
```