### PR TITLE
main/libkcapi: fix cross

### DIFF
--- a/main/libkcapi/template.py
+++ b/main/libkcapi/template.py
@@ -7,8 +7,10 @@ configure_args = [
     "--enable-lib-asym",
     "--enable-lib-kpp",
 ]
+make_cmd = "gmake"
 hostmakedepends = [
     "automake",
+    "gmake",
     "libtool",
     "pkgconf",
 ]


### PR DESCRIPTION
failure is

```
bmake: "/builddir/libkcapi-1.5.0/build/Makefile" line 2021: warning: duplicate script for target "lib/doc/bin/docproc" ignored
bmake: "Makefile" line 995: warning: using previous script for "lib/doc/bin/docproc" defined here
/bin/sh ./libtool  --tag=CC    --mode=link riscv64-chimera-linux-musl-clang  -fstack-protector-strong -ffile-prefix-map=/builddir/libkcapi-1.5.0=. -Wformat -Werror=format-security -ftrivial-auto-var-init=zero -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -O2 -g2 -fpie -fPIE -DPIE   -Wl,-z,pack-relative-relocs -Wl,-O2 -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -pie -o lib/doc/bin/docproc lib/doc/bin/docproc.o  
libtool: link: riscv64-chimera-linux-musl-clang -fstack-protector-strong -ffile-prefix-map=/builddir/libkcapi-1.5.0=. -Wformat -Werror=format-security -ftrivial-auto-var-init=zero -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -O2 -g2 -fpie -fPIE -DPIE -Wl,-z -Wl,pack-relative-relocs -Wl,-O2 -fno-omit-frame-pointer -fsanitize=signed-integer-overflow,integer-divide-by-zero -fsanitize-trap=signed-integer-overflow,integer-divide-by-zero -fno-sanitize-recover -pie -o lib/doc/bin/docproc lib/doc/bin/docproc.o 
riscv64-chimera-linux-musl-ld: error: lib/doc/bin/docproc.o is incompatible with elf64lriscv
riscv64-chimera-linux-musl-clang: error: linker command failed with exit code 1 (use -v to see invocation)
```