### PR TITLE
gitignore: ignore neovim exrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ void-*.tar.xz
 bootstrap.*
 !bootstrap.sh
 !bootstrap.ini
+
+# custom configs
+.nvim.lua


### PR DESCRIPTION
Here neovim users who opted in for the exrc option can put some custom project-specific filetype definitions, user commands etc.