### PR TITLE
contrib/*: disable cfi and remove cfi todos for all kde stuff

### DIFF
--- a/contrib/attica/template.py
+++ b/contrib/attica/template.py
@@ -19,9 +19,7 @@ license = "LGPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/attica/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/attica-{pkgver}.tar.xz"
 sha256 = "c3f66e2c02ef313fa240f5aabfbcad3969fdfc788c9604d1cf7e4e0893fb5740"
-# cfi causes crash when pressing "Get New Plugins..." button in the
-# "Wallpaper" section of Plasma's system settings app
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("attica-devel")

--- a/contrib/baloo-widgets/template.py
+++ b/contrib/baloo-widgets/template.py
@@ -1,6 +1,6 @@
 pkgname = "baloo-widgets"
 pkgver = "24.05.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = ["-DQT_MAJOR_VERSION=6"]
 # FIXME: 'not connected to dbus server'
@@ -29,5 +29,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/baloo-widgets-{pkgver}.tar.xz"
 )
 sha256 = "b7c4680fbda02f337c775e8dde91ad6f065bcdf361ce77d5422110b2b6444318"
-# CFI: check
-hardening = ["vis", "cfi"]
+hardening = ["vis"]

--- a/contrib/baloo/template.py
+++ b/contrib/baloo/template.py
@@ -34,8 +34,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/baloo-{pkgver}.tar.xz"
 )
 sha256 = "07474aea2c407a4fb01cd2640589a93e8baadb04f8ba19ae6d8f40293c4c4699"
-# CFI: test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/bluedevil/template.py
+++ b/contrib/bluedevil/template.py
@@ -1,6 +1,6 @@
 pkgname = "bluedevil"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -30,4 +30,4 @@ license = "GPL-2.0-or-later AND LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/bluedevil"
 source = f"$(KDE_SITE)/plasma/{pkgver}/bluedevil-{pkgver}.tar.xz"
 sha256 = "b9a2880d361a1967bd8de9e50887ccd63b5e9ca9bb935e1948f6b619a2682b39"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]

--- a/contrib/bluez-qt/template.py
+++ b/contrib/bluez-qt/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/bluez-qt/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/bluez-qt-{pkgver}.tar.xz"
 sha256 = "d2d0aee9f42b501c00711565c2ebe87c608ae4c0786d901386fc55c65039b16b"
-# CFI: breaks at least almost every test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("bluez-qt-devel")

--- a/contrib/breeze-icons/template.py
+++ b/contrib/breeze-icons/template.py
@@ -29,7 +29,7 @@ broken_symlinks = [
     # broken symbolic link to fingerprint.svg
     "usr/share/icons/breeze/actions/24/fingerprint-symbolic.svg",
 ]
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("breeze-icons-devel")

--- a/contrib/breeze/template.py
+++ b/contrib/breeze/template.py
@@ -34,8 +34,7 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/breeze"
 source = f"$(KDE_SITE)/plasma/{pkgver}/breeze-{pkgver}.tar.xz"
 sha256 = "f15bba8dded07595534656de7ab0dbac9b0cdee8462d53aaaa309b3cf2d576d1"
-# CFI: kills plasma-apply-lookandfeel in breeze6.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO: split qt6 theme?
 
 

--- a/contrib/colord-kde/template.py
+++ b/contrib/colord-kde/template.py
@@ -26,5 +26,4 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/graphics/colord-kde"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/colord-kde-{pkgver}.tar.xz"
 sha256 = "65aa78a4a73529f0d6a3a35a518f3686c2335802e0f2377b11ce9778858c81b6"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/dolphin-plugins/template.py
+++ b/contrib/dolphin-plugins/template.py
@@ -29,5 +29,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/dolphin-plugins-{pkgver}.tar.xz"
 )
 sha256 = "39fe5034edffc4209ee416f6e0b65f44f948082b46e64e18b3086436b994be23"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/dolphin/template.py
+++ b/contrib/dolphin/template.py
@@ -53,8 +53,7 @@ source = f"$(KDE_SITE)/release-service/{pkgver}/src/dolphin-{pkgver}.tar.xz"
 sha256 = "5f850a4fd7f463f93e05c1b162be55f7d4360cca2189b446fa296ceef35f3567"
 # fixes copy/pasting file segfault in kio_file.so (KIO::WorkerThread) https://bugs.kde.org/show_bug.cgi?id=470763
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
-# CFI: breaks at least dolphinmainwindowtest in libdolphinprivate
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/elisa/template.py
+++ b/contrib/elisa/template.py
@@ -42,7 +42,6 @@ license = "LGPL-3.0-or-later"
 url = "https://apps.kde.org/elisa"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/elisa-{pkgver}.tar.xz"
 sha256 = "c0177ef091800dc36815bfcc7f268addbd65d3bc5a1c5c385f124c42899d1b0e"
-# CFI: crashes on start
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]

--- a/contrib/ffmpegthumbs/template.py
+++ b/contrib/ffmpegthumbs/template.py
@@ -24,5 +24,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/ffmpegthumbs-{pkgver}.tar.xz"
 )
 sha256 = "7c11ebd5897a6ab087ec4b349c3822a79cf02c460bac21d334afe47aac54f2ac"
-# CFI: test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/filelight/template.py
+++ b/contrib/filelight/template.py
@@ -28,5 +28,4 @@ license = " GPL-2.0-only OR GPL-3.0-only"
 url = "https://apps.kde.org/filelight"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/filelight-{pkgver}.tar.xz"
 sha256 = "33d3b61f7d9332f2506b58b3fa5ac0b2a0308e2f2e21be818e8b9da5207e2b56"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/flatpak-kcm/template.py
+++ b/contrib/flatpak-kcm/template.py
@@ -28,5 +28,4 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/flatpak-kcm"
 source = f"$(KDE_SITE)/plasma/{pkgver}/flatpak-kcm-{pkgver}.tar.xz"
 sha256 = "c7e6c89cac016cb32325a620c6dfe9c5a2a37e6e40501060bc0f067a3cba5481"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/frameworkintegration/template.py
+++ b/contrib/frameworkintegration/template.py
@@ -27,7 +27,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/frameworkintegration/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/frameworkintegration-{pkgver}.tar.xz"
 sha256 = "4682d15c3a2e49785eda8f6c309e5f30d82ff6a5bcc39228544374c64199ef71"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("frameworkintegration-devel")

--- a/contrib/gwenview/template.py
+++ b/contrib/gwenview/template.py
@@ -54,7 +54,6 @@ source = f"$(KDE_SITE)/release-service/{pkgver}/src/gwenview-{pkgver}.tar.xz"
 sha256 = "2f01edc994d2b96999242c73dbaa90dae5d4c6674c07c4517b0ab6c284ca7a79"
 # avoid crash in raw thumbnailer
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
-# CFI: crashes on start
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]

--- a/contrib/kaccounts-integration/template.py
+++ b/contrib/kaccounts-integration/template.py
@@ -32,8 +32,7 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/network/kaccounts-integration"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kaccounts-integration-{pkgver}.tar.xz"
 sha256 = "d1855ac6067378ffdf6af999a6b5bf3a0fc5ab3b7ed6cfa87c19606cb60f7b35"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 if self.profile().arch in ["aarch64", "ppc64le", "x86_64"]:

--- a/contrib/kaccounts-providers/template.py
+++ b/contrib/kaccounts-providers/template.py
@@ -24,5 +24,4 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/network/kaccounts-providers"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kaccounts-providers-{pkgver}.tar.xz"
 sha256 = "60ee944bec87a60da3b860584f5c61d06983455169d89b5356034ae4216dd1d5"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kactivitymanagerd/template.py
+++ b/contrib/kactivitymanagerd/template.py
@@ -1,6 +1,6 @@
 pkgname = "kactivitymanagerd"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -25,7 +25,7 @@ license = "GPL-2.0-only OR GPL-3.0-only"
 url = "https://invent.kde.org/plasma/kactivitymanagerd"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kactivitymanagerd-{pkgver}.tar.xz"
 sha256 = "40c498e65afe7039c464cfbaa442a9e3a56140cbd45b63b6957267260c537460"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kalk/template.py
+++ b/contrib/kalk/template.py
@@ -24,5 +24,4 @@ license = "GPL-3.0-or-later AND CC0-1.0"
 url = "https://apps.kde.org/kalk"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kalk-{pkgver}.tar.xz"
 sha256 = "a072343f4f71a08677f40c0b1087d91cc3ea5614bc827aa81d5ee6590d58607e"
-# CFI: crashes tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/karchive/template.py
+++ b/contrib/karchive/template.py
@@ -21,7 +21,7 @@ license = "LGPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://develop.kde.org/docs/features/karchive"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/karchive-{pkgver}.tar.xz"
 sha256 = "bce4d06384960c6c7c18c86908b2d74c18d8600816c6f15c2920303a4806dabb"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("karchive-devel")

--- a/contrib/kate/template.py
+++ b/contrib/kate/template.py
@@ -31,8 +31,7 @@ license = "LGPL-2.1-or-later"
 url = "https://apps.kde.org/kate"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kate-{pkgver}.tar.xz"
 sha256 = "774f08b7d53db0b282164e930a0e0cd4709e75938dcb8b3cb430fedf0d5db020"
-# CFI: breaks at least location_history_test & kate_view_mgmt_tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 # for kwrite to not pull in kate

--- a/contrib/kauth/template.py
+++ b/contrib/kauth/template.py
@@ -26,8 +26,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kauth-{pkgver}.tar.xz"
 )
 sha256 = "0598e205dedc670af3a077ba02110a44db2f9d5e55df5003b0fc2490ac2ff1ce"
-# CFI: kills systemsettings in libKF6AuthCore.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kauth-devel")

--- a/contrib/kbookmarks/template.py
+++ b/contrib/kbookmarks/template.py
@@ -22,7 +22,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kbookmarks/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kbookmarks-{pkgver}.tar.xz"
 sha256 = "13c72b0c47e333ada60a4665af7829910f5c83dd6ed57789fa3229ca68ad3280"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kbookmarks-devel")

--- a/contrib/kcachegrind/template.py
+++ b/contrib/kcachegrind/template.py
@@ -28,8 +28,7 @@ license = "GPL-2.0-only"
 url = "https://apps.kde.org/kcachegrind"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kcachegrind-{pkgver}.tar.xz"
 sha256 = "29b01c69da246cb884ae0ce246b58dec1a026acb503190091f2b08f7a24611c8"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kcmutils/template.py
+++ b/contrib/kcmutils/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kcmutils/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcmutils-{pkgver}.tar.xz"
 sha256 = "59b1293ffe67134ceba30fb7ce741889c54f85ad0c90d155688bdd0dfc8f31be"
-# CFI: crashes systemsettings (when entering almost any page) in libkcmutilsqmlplugin.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcmutils-devel")

--- a/contrib/kcodecs/template.py
+++ b/contrib/kcodecs/template.py
@@ -18,8 +18,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kcodecs/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcodecs-{pkgver}.tar.xz"
 sha256 = "2ca3e70634e8116dd32601c551e092cf9941ea1d19ae501eed9e5477e298bfd4"
-# CFI: at least a few tests fail
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcodecs-devel")

--- a/contrib/kcolorscheme/template.py
+++ b/contrib/kcolorscheme/template.py
@@ -21,7 +21,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/frameworks/kcolorscheme"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcolorscheme-{pkgver}.tar.xz"
 sha256 = "5c74af476b36fc99b246d17fa30f8c9b9480f79277fa077908e75a8fc171828c"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcolorscheme-devel")

--- a/contrib/kcompletion/template.py
+++ b/contrib/kcompletion/template.py
@@ -21,8 +21,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kcompletion/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcompletion-{pkgver}.tar.xz"
 sha256 = "f08e2af5046a7ba5a324e475a9f107294b3b83e45e14d70e422f99dda1459d51"
-# CFI: crashes kio kurl*test & e.g. kwrite save file dialog upon first char of filename in libKF6Completion.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcompletion-devel")

--- a/contrib/kconfig/template.py
+++ b/contrib/kconfig/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.0-or-later AND LGPL-2.0-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kconfig/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kconfig-{pkgver}.tar.xz"
 sha256 = "fbb3d06fde4ea19955cfdbcbcec03de78a46f8c228f41d4e7aa6ceb88dc116dd"
-# CFI: breaks at least 5 tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kconfig-devel")

--- a/contrib/kconfigwidgets/template.py
+++ b/contrib/kconfigwidgets/template.py
@@ -30,7 +30,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://develop.kde.org/docs/features/kconfigwidgets"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kconfigwidgets-{pkgver}.tar.xz"
 sha256 = "98f7e9e11557d2d1db59711052a3b4cb4f8572316eff6421459b90b5d4393983"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kconfigwidgets-devel")

--- a/contrib/kcontacts/template.py
+++ b/contrib/kcontacts/template.py
@@ -25,7 +25,7 @@ license = "LGPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/kcontacts/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcontacts-{pkgver}.tar.xz"
 sha256 = "b9b72d3bd1a64c0016b7122e79e657358226d239faf31699d6700d95e52bd59d"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcontacts-devel")

--- a/contrib/kcoreaddons/template.py
+++ b/contrib/kcoreaddons/template.py
@@ -18,8 +18,7 @@ license = "LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
 url = "https://api.kde.org/frameworks/kcoreaddons/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcoreaddons-{pkgver}.tar.xz"
 sha256 = "c5cd321350bca1193d0ce86c8ede70c6902a2ba03c577637b4aa537fcd8ce2b8"
-# CFI: breaks at least kpluginfactorytest
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcoreaddons-devel")

--- a/contrib/kcrash/template.py
+++ b/contrib/kcrash/template.py
@@ -18,8 +18,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kcrash/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kcrash-{pkgver}.tar.xz"
 sha256 = "011215bc952a430c1d093b0bf5cdad7057c9a9098d86116e69c6dd1000567697"
-# CFI: least "./test_crasher ES" is broken
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kcrash-devel")

--- a/contrib/kdbusaddons/template.py
+++ b/contrib/kdbusaddons/template.py
@@ -21,7 +21,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://api.kde.org/frameworks/kdbusaddons/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kdbusaddons-{pkgver}.tar.xz"
 sha256 = "212fa6be4194a819f0fb48f3c6fd2b58846ba911612b73e97dc7e90f6104c987"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdbusaddons-devel")

--- a/contrib/kde-cli-tools/template.py
+++ b/contrib/kde-cli-tools/template.py
@@ -30,5 +30,4 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://invent.kde.org/plasma/kde-cli-tools"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kde-cli-tools-{pkgver}.tar.xz"
 sha256 = "d969051e2832ca6eb00ebc22234834e46a2f3cbfc6c3d4ee8a962058b14bc87a"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kde-inotify-survey/template.py
+++ b/contrib/kde-inotify-survey/template.py
@@ -25,7 +25,6 @@ license = "GPL-2.0-only OR GPL-3.0-only"
 url = "https://invent.kde.org/system/kde-inotify-survey"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kde-inotify-survey-{pkgver}.tar.xz"
 sha256 = "d185ae82e31764617b209686169185d52e3c2b51e85f43643a922cccb862ec20"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]

--- a/contrib/kdeclarative/template.py
+++ b/contrib/kdeclarative/template.py
@@ -22,7 +22,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kdeclarative/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kdeclarative-{pkgver}.tar.xz"
 sha256 = "bb47b521a4c843f6b3de78d46fe430de15886598c6d89d39bd91c767f40f6a85"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdeclarative-devel")

--- a/contrib/kdecoration/template.py
+++ b/contrib/kdecoration/template.py
@@ -19,8 +19,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://api.kde.org/plasma/kdecoration/html"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kdecoration-{pkgver}.tar.xz"
 sha256 = "15dd479f42eb4ab6752694d3129aa42164aec9954db5be04b7c3bb7c811b0dfb"
-# CFI: breaks at least 20+ kwin tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdecoration-devel")

--- a/contrib/kded/template.py
+++ b/contrib/kded/template.py
@@ -24,7 +24,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kded-{pkgver}.tar.xz"
 )
 sha256 = "be5ae21cf9b436eafe49ca8be750259899dc803501c47ee436d8dad6d33bfb9c"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kdegraphics-mobipocket/template.py
+++ b/contrib/kdegraphics-mobipocket/template.py
@@ -21,8 +21,7 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/graphics/kdegraphics-mobipocket"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kdegraphics-mobipocket-{pkgver}.tar.xz"
 sha256 = "0408ec55e3df317b29763f56662bf3ca0844ca538ab4471f316832c197a58fc1"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdegraphics-mobipocket-devel")

--- a/contrib/kdenlive/template.py
+++ b/contrib/kdenlive/template.py
@@ -55,9 +55,8 @@ source = f"$(KDE_SITE)/release-service/{pkgver}/src/kdenlive-{pkgver}.tar.xz"
 sha256 = "057f12c28b5eec9716383b5093f7ca0a345cc9066dd5c7614fe3d9188429a708"
 # avoid crashes
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
-# CFI: crashes most tests
 # INT: crashes spacertest/trimmingtest
-hardening = ["vis", "!cfi", "!int"]
+hardening = ["vis", "!int"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/kdesu/template.py
+++ b/contrib/kdesu/template.py
@@ -23,8 +23,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kdesu-{pkgver}.tar.xz"
 )
 sha256 = "f27ae587eb5f93bb1890b414ee3eb63b25404f96f6dbd0048426b60e0acacb5a"
-# CFI: test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdesu-devel")

--- a/contrib/kdialog/template.py
+++ b/contrib/kdialog/template.py
@@ -24,7 +24,6 @@ license = "GPL-2.0-or-later"
 url = "https://develop.kde.org/docs/administration/kdialog"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kdialog-{pkgver}.tar.xz"
 sha256 = "ae6cb760f9d61581c1a811834ad15998d5678817d28fa476077646c86813041a"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]

--- a/contrib/kdnssd/template.py
+++ b/contrib/kdnssd/template.py
@@ -20,8 +20,7 @@ license = "GPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/kdnssd/html/index.html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kdnssd-{pkgver}.tar.xz"
 sha256 = "0bc639a41b3beedecd0900caa757ff864e29357e3582f9150092be0e5558cc12"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdnssd-devel")

--- a/contrib/kdoctools/template.py
+++ b/contrib/kdoctools/template.py
@@ -28,7 +28,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kdoctools/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kdoctools-{pkgver}.tar.xz"
 sha256 = "63e112f907118cafd4584ce8eb3149d3557a7f9e9a4005d10c40cccf46d24dc2"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kdoctools-devel")

--- a/contrib/kdsoap-ws-discover-client/template.py
+++ b/contrib/kdsoap-ws-discover-client/template.py
@@ -15,8 +15,7 @@ license = "GPL-3.0-or-later"
 url = "https://invent.kde.org/libraries/kdsoap-ws-discovery-client"
 source = f"$(KDE_SITE)/kdsoap-ws-discovery-client/kdsoap-ws-discovery-client-{pkgver}.tar.xz"
 sha256 = "2cd247c013e75f410659bac372aff93d22d71c5a54c059e137b9444af8b3427a"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # FIXME: needs network?
 options = ["!check"]
 

--- a/contrib/kfilemetadata/template.py
+++ b/contrib/kfilemetadata/template.py
@@ -31,8 +31,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kfilemetadata/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kfilemetadata-{pkgver}.tar.xz"
 sha256 = "45ff433054be4c5ef14a2aa842373c0679d632aacfdb78dfba989f7388c4c5ed"
-# CFI: breaks at least indexextractortest/dump_fulltext
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/kgamma/template.py
+++ b/contrib/kgamma/template.py
@@ -23,5 +23,4 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/kgamma"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kgamma-{pkgver}.tar.xz"
 sha256 = "aded428452f081141613f46748b56c907850aa305573b06929fba94ea0de535b"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kglobalaccel/template.py
+++ b/contrib/kglobalaccel/template.py
@@ -17,7 +17,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kglobalaccel/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kglobalaccel-{pkgver}.tar.xz"
 sha256 = "0d6a274be3891b9cadf65e3c1fc7c9575b6e68b5373888f54f9d89df91cda8a6"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kglobalaccel-devel")

--- a/contrib/kglobalacceld/template.py
+++ b/contrib/kglobalacceld/template.py
@@ -27,8 +27,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/kglobalacceld"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kglobalacceld-{pkgver}.tar.xz"
 sha256 = "359155f3454948f2717ae6785ed1e6dc2dc8c281e6526cb06852cf4aa1a2a062"
-# CFI: breaks at least 50+ kwin tests (together with kidletime)
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kguiaddons/template.py
+++ b/contrib/kguiaddons/template.py
@@ -20,7 +20,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://api.kde.org/frameworks/kguiaddons/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kguiaddons-{pkgver}.tar.xz"
 sha256 = "e1c25df0b8095be2497d2041e71cc843eaf75a6707f65b1cd74386fe3262cf11"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kguiaddons-devel")

--- a/contrib/kholidays/template.py
+++ b/contrib/kholidays/template.py
@@ -17,7 +17,7 @@ license = "LGPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/kholidays/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kholidays-{pkgver}.tar.xz"
 sha256 = "1200fab6bd1546f016688597eef6c10c948f999d4eeab1e8eaaca345ccd2adcd"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kholidays-devel")

--- a/contrib/ki18n/template.py
+++ b/contrib/ki18n/template.py
@@ -26,8 +26,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/ki18n-{pkgver}.tar.xz"
 )
 sha256 = "c069e559e3a311bf977f136d77732c5f3e4253752deff9ba999a6a8d7b4ae255"
-# CFI: breaks at least ki18n-ktranscripttest
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("ki18n-devel")

--- a/contrib/kiconthemes/template.py
+++ b/contrib/kiconthemes/template.py
@@ -28,7 +28,7 @@ license = "LGPL-2.1-only"
 url = "https://api.kde.org/frameworks/kiconthemes/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kiconthemes-{pkgver}.tar.xz"
 sha256 = "d5a52c338ec3f7a91ed8c552830dd688bdf040651ad2c4a794c18eee4b161f47"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kiconthemes-devel")

--- a/contrib/kidletime/template.py
+++ b/contrib/kidletime/template.py
@@ -21,8 +21,7 @@ license = "LGPL-2.0-only"
 url = "https://api.kde.org/frameworks/kidletime/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kidletime-{pkgver}.tar.xz"
 sha256 = "4e2e0455a803ded2bee74d573701d2d95359eaed2f7964f230a40e3058a84c2c"
-# CFI: breaks at least 50+ kwin tests (together with kglobalacceld)
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kidletime-devel")

--- a/contrib/kinfocenter/template.py
+++ b/contrib/kinfocenter/template.py
@@ -34,8 +34,7 @@ source = f"$(KDE_SITE)/plasma/{pkgver}/kinfocenter-{pkgver}.tar.xz"
 sha256 = "69c4bebf97c5a980c3da57deedfff628254f03b7c094cca8d742f537bfc45738"
 # symlink to systemsettings, runtime dep provided
 broken_symlinks = ["usr/bin/kinfocenter"]
-# CFI: kills app on launch in kcm_about-distro.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kinfocenter-meta")

--- a/contrib/kio-admin/template.py
+++ b/contrib/kio-admin/template.py
@@ -22,5 +22,4 @@ license = "GPL-2.0-only OR GPL-3.0-only"
 url = "https://invent.kde.org/system/kio-admin"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kio-admin-{pkgver}.tar.xz"
 sha256 = "51640fd2322406d05c474c43a8cadf0efb85e0a5b22d16a537f24fdd683da994"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kio-extras/template.py
+++ b/contrib/kio-extras/template.py
@@ -53,8 +53,7 @@ license = "LGPL-3.0-or-later"
 url = "https://invent.kde.org/network/kio-extras"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kio-extras-{pkgver}.tar.xz"
 sha256 = "19e9c6d3625511a7f9f7c0e5c9e9e6b0ca365aeed4914c7781a937fd1807e240"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/kio-fuse/template.py
+++ b/contrib/kio-fuse/template.py
@@ -22,8 +22,7 @@ license = "GPL-3.0-or-later"
 url = "https://invent.kde.org/system/kio-fuse"
 source = f"$(KDE_SITE)/kio-fuse/kio-fuse-{pkgver}.tar.xz"
 sha256 = "7d104581227d5a19b424b33f4168d181556b1015d6df2218e01a88d64449e94b"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # needs real fuse mounted
 options = ["!check"]
 

--- a/contrib/kio-zeroconf/template.py
+++ b/contrib/kio-zeroconf/template.py
@@ -25,4 +25,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/kio-zeroconf-{pkgver}.tar.xz"
 )
 sha256 = "8b939e1a6d22ac78afed596b2fba49472cf46056f84a2c2b628b227dec191c15"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kio/template.py
+++ b/contrib/kio/template.py
@@ -53,8 +53,7 @@ source = (
 )
 sha256 = "5fa031f3b97e96ed228b7c42c9625e9f3e5477e4ca2d5a6ba2ff1d2d8d74075d"
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
-# CFI: breaks at least plasma-workspace's testrunnermodel
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # >60% (40/62) tests fail, pain to get working in a limited enviroment due to expecting e.g. real disks
 options = ["!check"]
 

--- a/contrib/kirigami-addons/template.py
+++ b/contrib/kirigami-addons/template.py
@@ -36,8 +36,7 @@ license = "LGPL-2.0-or-later AND GPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/kirigami-addons/html"
 source = f"$(KDE_SITE)/kirigami-addons/kirigami-addons-{pkgver}.tar.xz"
 sha256 = "f5e44d7a7d7dfd866c529bb004f7204013609a16c9757091fcdb2c6c5be00ff3"
-# CFI: kills plasmashell (started under kwin_wayland) in libcomponents.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kirigami-addons-devel")

--- a/contrib/kirigami/template.py
+++ b/contrib/kirigami/template.py
@@ -19,8 +19,7 @@ license = "LGPL-2.0-only"
 url = "https://develop.kde.org/frameworks/kirigami"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kirigami-{pkgver}.tar.xz"
 sha256 = "eca20cd9ce72d0eeb57bd5fba394f20d83bb4612ac4a4c23fb8ca74a93188c37"
-# CFI: breaks at least kcmutils' kcmloadtest
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kirigami-devel")

--- a/contrib/kitemmodels/template.py
+++ b/contrib/kitemmodels/template.py
@@ -17,7 +17,7 @@ license = "LGPL-2.0-only AND LGPL-2.0-or-later"
 url = "https://api.kde.org/frameworks/kitemmodels/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kitemmodels-{pkgver}.tar.xz"
 sha256 = "9608312c5564279b624c4965fbe198bfb2d26804a915cf51a468e31bb9982d61"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kitemmodels-devel")

--- a/contrib/kitemviews/template.py
+++ b/contrib/kitemviews/template.py
@@ -20,7 +20,7 @@ license = "GPL-2.0-only AND LGPL-2.1-only"
 url = "https://api.kde.org/frameworks/kitemviews/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kitemviews-{pkgver}.tar.xz"
 sha256 = "4280b9bcdc527979b364ed122d152e75951ff78fd801d46ccce2de6608d56440"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # fails
 options = ["!cross"]
 

--- a/contrib/kjobwidgets/template.py
+++ b/contrib/kjobwidgets/template.py
@@ -20,7 +20,7 @@ license = "LGPL-2.1-only AND (LGPL-2.1-only OR LGPL-3.0-only)"
 url = "https://api.kde.org/frameworks/kjobwidgets/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kjobwidgets-{pkgver}.tar.xz"
 sha256 = "22621a52cc69532a5495c7e8549d26af1ddd3b8532e9aa0d3c108950114dd565"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kjobwidgets-devel")

--- a/contrib/kmenuedit/template.py
+++ b/contrib/kmenuedit/template.py
@@ -28,5 +28,4 @@ license = "GPL-2.0-only"
 url = "https://invent.kde.org/plasma/kmenuedit"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kmenuedit-{pkgver}.tar.xz"
 sha256 = "9006fb0e55cad0fad48f9db662c8145f89e4550f108aa74efb27467328fc4d85"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/knewstuff/template.py
+++ b/contrib/knewstuff/template.py
@@ -27,9 +27,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/knewstuff/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/knewstuff-{pkgver}.tar.xz"
 sha256 = "aef6f5085adec31dc09f073f3884935156f7f9276cc8e7a1b1d846c39cd8126f"
-# CFI: causes crash when pressing "Get New Plugins..." button in the "Wallpaper"
-# section of Plasma's system settings app
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("knewstuff-devel")

--- a/contrib/knotifications/template.py
+++ b/contrib/knotifications/template.py
@@ -19,9 +19,7 @@ license = "BSD-3-Clause AND LGPL-2.0-or-later AND LGPL-2.0-only AND (LGPL-2.1-on
 url = "https://api.kde.org/frameworks/knotifications/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/knotifications-{pkgver}.tar.xz"
 sha256 = "77e9b680066dc49c8d5e23ac6291fbba05328dda327d5c34ca3141e1ffeb25dc"
-# CFI: kills systemsettings (going from "Spell Check" to "Region & Language" and attempting close) in ~NotifyByAudio()
-# https://invent.kde.org/frameworks/knotifications/-/blob/v6.4.0/src/notifybyaudio.cpp#L56
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/knotifyconfig/template.py
+++ b/contrib/knotifyconfig/template.py
@@ -25,7 +25,7 @@ license = "LGPL-2.0-only"
 url = "https://api.kde.org/frameworks/knotifyconfig/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/knotifyconfig-{pkgver}.tar.xz"
 sha256 = "d8ef414b68c09a649f2f89d42d142b07967ce597b66fbb3f85dd02223c3cf278"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("knotifyconfig-devel")

--- a/contrib/konqueror/template.py
+++ b/contrib/konqueror/template.py
@@ -50,8 +50,7 @@ license = "LGPL-3.0-only AND GPL-2.0-or-later"
 url = "https://apps.kde.org/konqueror"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/konqueror-{pkgver}.tar.xz"
 sha256 = "8a61ebc08d814e710cafc14ee45fc2d04ad3b35247c5856f08e37814ec7834fa"
-# CFI: crashes tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("konqueror-devel")

--- a/contrib/kpackage/template.py
+++ b/contrib/kpackage/template.py
@@ -23,7 +23,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kpackage/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kpackage-{pkgver}.tar.xz"
 sha256 = "ba4a16abb7bd527c42d12c57631e5178b8fd0ffbf01ccf7758a0eb6ab1adc008"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kpackage-devel")

--- a/contrib/kparts/template.py
+++ b/contrib/kparts/template.py
@@ -25,7 +25,7 @@ license = (
 url = "https://api.kde.org/frameworks/kparts/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kparts-{pkgver}.tar.xz"
 sha256 = "ff30c51d3b7c63f95420faaf7c9a61ad3a6b5937328a4cbd56ad525b021e998d"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kparts-devel")

--- a/contrib/kpeople/template.py
+++ b/contrib/kpeople/template.py
@@ -25,7 +25,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kpeople/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kpeople-{pkgver}.tar.xz"
 sha256 = "4a1385b7fca2fa804ed7a0111f9c6c5a25ba98c7bf811e75c1bf1dd3fb472964"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kpeople-devel")

--- a/contrib/kpipewire/template.py
+++ b/contrib/kpipewire/template.py
@@ -27,7 +27,7 @@ url = "https://invent.kde.org/plasma/kpipewire"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kpipewire-{pkgver}.tar.xz"
 sha256 = "eb2217024e3bf3a4777548b9a0bda88ca0b97912d20336b03f5942b28b1baef9"
 # CFI: breaks at least mediamonitortest (further) and xwaylandvideobridge upon screen share
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # only available test needs running pipewire
 options = ["!check"]
 

--- a/contrib/kpmcore/template.py
+++ b/contrib/kpmcore/template.py
@@ -26,7 +26,7 @@ license = "GPL-3.0-or-later"
 url = "https://apps.kde.org/kate"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/kpmcore-{pkgver}.tar.xz"
 sha256 = "8e8646bfe990834acbbe56149015aaecd3099cc2e9115ac7426a2d88747735db"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kpmcore-devel")

--- a/contrib/kpty/template.py
+++ b/contrib/kpty/template.py
@@ -21,7 +21,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kpty-{pkgver}.tar.xz"
 )
 sha256 = "68626789dcb79d9fd1b3a4c55016747260085ba4c68f7b408a5f1d190cca4623"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kpty-devel")

--- a/contrib/kquickcharts/template.py
+++ b/contrib/kquickcharts/template.py
@@ -18,8 +18,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kquickcharts/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kquickcharts-{pkgver}.tar.xz"
 sha256 = "a41629caef3877ce03c739c0950f094890f5b2a20a041dd338bdeb240c6401de"
-# CFI: crashes plasma-systemmonitor on launch in libQuickChartsControls.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kquickcharts-devel")

--- a/contrib/krunner/template.py
+++ b/contrib/krunner/template.py
@@ -33,8 +33,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/krunner/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/krunner-{pkgver}.tar.xz"
 sha256 = "aac498f1d313bfc1a8388ff47617e68c50413da15a744a38a05c473378316fbc"
-# CFI: breaks at least a bunch of tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("krunner-devel")

--- a/contrib/ksanecore/template.py
+++ b/contrib/ksanecore/template.py
@@ -22,8 +22,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/libraries-ksanecore"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/ksanecore-{pkgver}.tar.xz"
 sha256 = "a9439b6f686363fa32c6f4a5287e8c5df86547015e64b88587691d64492ec95d"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/kscreen/template.py
+++ b/contrib/kscreen/template.py
@@ -31,8 +31,7 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://invent.kde.org/plasma/kscreen"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kscreen-{pkgver}.tar.xz"
 sha256 = "300919305a79f1d425141e8d368de3b0e35e8b4ff4c5fa40e4df07017ae6056b"
-# CFI: breaks both tests like https://paste.c-net.org/zfdjtfn6ssy6
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kscreenlocker/template.py
+++ b/contrib/kscreenlocker/template.py
@@ -1,6 +1,6 @@
 pkgname = "kscreenlocker"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # circular plasma-workspace dep (QML org.kde.plasma.private.sessions) needed by kscreenlocker_greet,
 # ksmserver-ksldTest even needs it installed under /usr/lib/libexec
@@ -41,7 +41,7 @@ license = "GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only)"
 url = "https://invent.kde.org/plasma/kscreenlocker"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kscreenlocker-{pkgver}.tar.xz"
 sha256 = "c29c0f09864111a933cba754e0db2f954fe515d13c390496770adc9eec0ce653"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kservice/template.py
+++ b/contrib/kservice/template.py
@@ -23,8 +23,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kservice/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kservice-{pkgver}.tar.xz"
 sha256 = "cdb9d7e3c6ffa3f7da8ff33a7b3ecb95ef8451bdefb97bcb79452fa03e7d8a1f"
-# CFI: breaks at least k{applicationtrader,mimeassociations}test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kservice-devel")

--- a/contrib/kstatusnotifieritem/template.py
+++ b/contrib/kstatusnotifieritem/template.py
@@ -19,7 +19,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/frameworks/kstatusnotifieritem"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kstatusnotifieritem-{pkgver}.tar.xz"
 sha256 = "32790111741482844ae1901c37db568346efc2ae68f712cecc6b9a5c1cba81b9"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kstatusnotifieritem-devel")

--- a/contrib/ksvg/template.py
+++ b/contrib/ksvg/template.py
@@ -26,7 +26,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/ksvg-{pkgver}.tar.xz"
 )
 sha256 = "3391c74fc31526e7ff2659622d00e93b5cd8667397611d5676062e4b32d86530"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("ksvg-devel")

--- a/contrib/ksystemstats/template.py
+++ b/contrib/ksystemstats/template.py
@@ -35,8 +35,7 @@ source = f"$(KDE_SITE)/plasma/{pkgver}/ksystemstats-{pkgver}.tar.xz"
 sha256 = "c9fdb5cc47cc4f3f66d92a6c492ca8125b03f03475516decfb4c887bbb034e85"
 # silence some ~600 lines of spam...
 tool_flags = {"CXXFLAGS": ["-Wno-deprecated-declarations"]}
-# CFI: breaks at least ksystemstatstest in dbusApi() like https://paste.c-net.org/tnqlkafoixrz
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/ktexteditor/template.py
+++ b/contrib/ktexteditor/template.py
@@ -36,8 +36,7 @@ license = "LGPL-2.0-or-later AND (LGPL-2.0-only OR LGPL-3.0-only)"
 url = "https://api.kde.org/frameworks/ktexteditor/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/ktexteditor-{pkgver}.tar.xz"
 sha256 = "825e1a79549d66f204d50869f1dfbbc8a14ab96e76b3e8c3e899b236edccd6d4"
-# CFI: breaks at least vast majority of tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("ktexteditor-devel")

--- a/contrib/ktexttemplate/template.py
+++ b/contrib/ktexttemplate/template.py
@@ -14,7 +14,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/ktexttemplate/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/ktexttemplate-{pkgver}.tar.xz"
 sha256 = "74300fe80fd7d0e8724b381d8f885345d91f47ae341003d4655e82b0dab6bf90"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("ktexttemplate-devel")

--- a/contrib/ktextwidgets/template.py
+++ b/contrib/ktextwidgets/template.py
@@ -25,7 +25,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/ktextwidgets/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/ktextwidgets-{pkgver}.tar.xz"
 sha256 = "08bc69461ade9944d35e5055f7bddd5313774d7a6c6727f12a68e58d1d3fce70"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("ktextwidgets-devel")

--- a/contrib/kunitconversion/template.py
+++ b/contrib/kunitconversion/template.py
@@ -20,7 +20,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kunitconversion/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kunitconversion-{pkgver}.tar.xz"
 sha256 = "30e969467cb6f20c97e263e5381371ead458517758128022141d52272a660474"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kunitconversion-devel")

--- a/contrib/kuserfeedback/template.py
+++ b/contrib/kuserfeedback/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kuserfeedback/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kuserfeedback-{pkgver}.tar.xz"
 sha256 = "4cc42c4433c80441aec21883899816e812518e8f2c8c10c8d8add9e774538257"
-# CFI: makes openglinfosourcetest fail
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kuserfeedback-devel")

--- a/contrib/kwallet-pam/template.py
+++ b/contrib/kwallet-pam/template.py
@@ -21,8 +21,7 @@ license = "LGPL-2.1-or-later"
 url = "https://invent.kde.org/plasma/kwallet-pam"
 source = f"$(KDE_SITE)/plasma/{pkgver}/kwallet-pam-{pkgver}.tar.xz"
 sha256 = "6b8071d838c810fa9821f7daa67d929fb6d63c766f746cc5ac855f778c0740da"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kwallet/template.py
+++ b/contrib/kwallet/template.py
@@ -30,8 +30,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kwallet/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kwallet-{pkgver}.tar.xz"
 sha256 = "b2885a088e5f70754511cc1ddb0a434c1a6d7939d9c77ffc36e95483491f9e40"
-# CFI: kills kwalletd6 (on launch of e.g. chromium) in libKF6WalletBackend.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kwallet-devel")

--- a/contrib/kwalletmanager/template.py
+++ b/contrib/kwalletmanager/template.py
@@ -33,5 +33,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/kwalletmanager-{pkgver}.tar.xz"
 )
 sha256 = "c3549db2bc28fcfc6d7e2b7c9efddb14978c07f7d4bc10a02ad3a1c6e95bc2fc"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/kwidgetsaddons/template.py
+++ b/contrib/kwidgetsaddons/template.py
@@ -22,9 +22,7 @@ license = "GPL-2.0-only AND LGPL-2.1-only AND Unicode-DFS-2016"
 url = "https://api.kde.org/frameworks/kwidgetsaddons/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kwidgetsaddons-{pkgver}.tar.xz"
 sha256 = "fda7e2e813a2dcf3a391652994499079c0b222c01f62778979287c602a3f0dbf"
-# CFI: kills systemsettings/kwrite etc upon "save unsaved changes?" dialog in
-# https://invent.kde.org/frameworks/kwidgetsaddons/-/blob/v6.2.2/src/kmessagedialog.cpp#L496
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # fails
 options = ["!cross"]
 

--- a/contrib/kwin/template.py
+++ b/contrib/kwin/template.py
@@ -102,8 +102,7 @@ file_xattrs = {
         "security.capability": "cap_sys_nice+ep",
     },
 }
-# CFI: breaks lots of tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kwindowsystem/template.py
+++ b/contrib/kwindowsystem/template.py
@@ -44,8 +44,7 @@ license = "MIT AND (LGPL-2.1-only OR LGPL-3.0-only)"
 url = "https://invent.kde.org/frameworks/kwindowsystem"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kwindowsystem-{pkgver}.tar.xz"
 sha256 = "c4e8742cbdd294d56a689d66a73b03a660702037ac46242f17cc01b24f014a59"
-# CFI: breaks at least kwin testDontCrashUseractionsMenu
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/kxmlgui/template.py
+++ b/contrib/kxmlgui/template.py
@@ -32,7 +32,7 @@ license = "LGPL-2.1-only AND LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/kxmlgui/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/kxmlgui-{pkgver}.tar.xz"
 sha256 = "04952bc7f9eaefc7a55c762d77e65888a2a71e638d3fc7126576dfe645564b0b"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("kxmlgui-devel")

--- a/contrib/layer-shell-qt/template.py
+++ b/contrib/layer-shell-qt/template.py
@@ -19,8 +19,7 @@ license = "GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only)"
 url = "https://api.kde.org/plasma/layer-shell-qt/html"
 source = f"$(KDE_SITE)/plasma/{pkgver}/layer-shell-qt-{pkgver}.tar.xz"
 sha256 = "a201bd3c867130e96cae75dcfec07f82af74dc2e8074d8d1bd9b0ae2645bf802"
-# CFI: kills plasmashell (on desktop/panel right click) in libLayerShellQtInterface.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("layer-shell-qt-devel")

--- a/contrib/libkdcraw/template.py
+++ b/contrib/libkdcraw/template.py
@@ -24,8 +24,7 @@ license = "GPL-2.0-or-later"
 url = "https://api.kde.org/libkdcraw/html/index.html"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/libkdcraw-{pkgver}.tar.xz"
 sha256 = "59ebc1634eccfc5b9a10c92ec2ab9f3e49245c2044692c6cfb717239a28b8a28"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("libkdcraw-devel")

--- a/contrib/libkexiv2/template.py
+++ b/contrib/libkexiv2/template.py
@@ -24,8 +24,7 @@ license = "GPL-2.0-or-later"
 url = "https://api.kde.org/libkexiv2/html/index.html"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/libkexiv2-{pkgver}.tar.xz"
 sha256 = "90595f61e2f4dcb3d8b32cb0a4a1c7f4fc5e3105111add514c99db24f734e313"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("libkexiv2-devel")

--- a/contrib/libksane/template.py
+++ b/contrib/libksane/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/graphics/libksane"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/libksane-{pkgver}.tar.xz"
 sha256 = "6fdcf6d8c38963dc46c60c68ece4f07226fd5d5a0ee1644c908baf797ab54ad9"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/libkscreen/template.py
+++ b/contrib/libkscreen/template.py
@@ -32,8 +32,7 @@ license = (
 url = "https://invent.kde.org/plasma/libkscreen"
 source = f"$(KDE_SITE)/plasma/{pkgver}/libkscreen-{pkgver}.tar.xz"
 sha256 = "9988f3736ec3d917f7b8bf1759c11c155a8ec57fcfd7876420e4bb9718b3b293"
-# CFI: breaks almost all tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/libksysguard/template.py
+++ b/contrib/libksysguard/template.py
@@ -48,8 +48,7 @@ file_xattrs = {
         "security.capability": "cap_net_raw+ep",
     },
 }
-# CFI: crashes plasma-systemmonitor on launch in libKSysGuardSensors.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("libksysguard-devel")

--- a/contrib/libplasma/template.py
+++ b/contrib/libplasma/template.py
@@ -42,8 +42,7 @@ license = "LGPL-2.1-or-later AND GPL-2.0-or-later"
 url = "https://api.kde.org/plasma/libplasma/html"
 source = f"$(KDE_SITE)/plasma/{pkgver}/libplasma-{pkgver}.tar.xz"
 sha256 = "5a2b6b7c539b6d171a9c2b743d554a74dcf3e57512a0423b46fce92fa2a545de"
-# CFI: kills plasmashell (on launch of startplasma-wayland) in liborg_kde_plasmacomponents3.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("libplasma-devel")

--- a/contrib/libqaccessibilityclient/template.py
+++ b/contrib/libqaccessibilityclient/template.py
@@ -21,8 +21,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/libraries/libqaccessibilityclient"
 source = f"$(KDE_SITE)/libqaccessibilityclient/libqaccessibilityclient-{pkgver}.tar.xz"
 sha256 = "4c50c448622dc9c5041ed10da7d87b3e4e71ccb49d4831a849211d423c5f5d33"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("libqaccessibilityclient-devel")

--- a/contrib/markdownpart/template.py
+++ b/contrib/markdownpart/template.py
@@ -22,5 +22,4 @@ source = (
     f"$(KDE_SITE)/release-service/{pkgver}/src/markdownpart-{pkgver}.tar.xz"
 )
 sha256 = "5d6d7f32904b559b430634889547fd1689855aa86fa8b08b0f86dcd36c287514"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/milou/template.py
+++ b/contrib/milou/template.py
@@ -23,5 +23,4 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://api.kde.org/plasma/milou/html"
 source = f"$(KDE_SITE)/plasma/{pkgver}/milou-{pkgver}.tar.xz"
 sha256 = "de698adc56d297f336b756dcc1e311d55b84c3433c22d1b36ded7ec59e09eb88"
-# CFI: kills krunner (plasma-workspace) on launch (Alt+Space) in libmilouqmlplugin.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/modemmanager-qt/template.py
+++ b/contrib/modemmanager-qt/template.py
@@ -25,7 +25,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/modemmanager-qt/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/modemmanager-qt-{pkgver}.tar.xz"
 sha256 = "f2bc2aa916bce3ea58c38def984c35fada25e8756add400131782bfc62deee9d"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("modemmanager-qt-devel")

--- a/contrib/mpvqt/template.py
+++ b/contrib/mpvqt/template.py
@@ -17,7 +17,7 @@ license = " LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/libraries/mpvqt"
 source = f"$(KDE_SITE)/mpvqt/mpvqt-{pkgver}.tar.xz"
 sha256 = "9131d2a925e5f33e19b9d081dfd5f30d576abd87464d67c70bef41a486f54eb9"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("mpvqt-devel")

--- a/contrib/networkmanager-qt/template.py
+++ b/contrib/networkmanager-qt/template.py
@@ -27,7 +27,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/networkmanager-qt/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/networkmanager-qt-{pkgver}.tar.xz"
 sha256 = "3d2c905dd9c7445c44023ecf0646dd1b6fcdc83968f56dfa762296b0d15e9498"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("networkmanager-qt-devel")

--- a/contrib/okular/template.py
+++ b/contrib/okular/template.py
@@ -60,8 +60,7 @@ url = "https://apps.kde.org/okular"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/okular-{pkgver}.tar.xz"
 sha256 = "e718d4884b46fbf430033c2ed0e80cb50e6d476e76ccfda4a2c71d840051034e"
 tool_flags = {"CFLAGS": ["-D_GNU_SOURCE"]}
-# CFI: crashes tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 # TODO
 options = ["!cross"]
 

--- a/contrib/oxygen/template.py
+++ b/contrib/oxygen/template.py
@@ -34,8 +34,7 @@ license = "GPL-2.0-or-later"  # FIXME
 url = "https://invent.kde.org/plasma/oxygen"
 source = f"$(KDE_SITE)/plasma/{pkgver}/oxygen-{pkgver}.tar.xz"
 sha256 = "b2e781f5dc4f111e17485a34299700f48fe6bf668494b3a00857b842b8caeda1"
-# CFI: test
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("oxygen-cursors")

--- a/contrib/phonon/template.py
+++ b/contrib/phonon/template.py
@@ -21,8 +21,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/phonon/html"
 source = f"$(KDE_SITE)/phonon/{pkgver}/phonon-{pkgver}.tar.xz"
 sha256 = "3287ffe0fbcc2d4aa1363f9e15747302d0b080090fe76e5f211d809ecb43f39a"
-# CFI: crashes in juk instantly
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("phonon-devel")

--- a/contrib/plasma-activities-stats/template.py
+++ b/contrib/plasma-activities-stats/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma-activities-stats"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -20,7 +20,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/plasma/plasma-activities-stats"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-activities-stats-{pkgver}.tar.xz"
 sha256 = "fbe2235d911f6f712f5cc312d807999cc28d84a246d467781ad528956b89d669"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 @subpackage("plasma-activities-stats-devel")

--- a/contrib/plasma-activities/template.py
+++ b/contrib/plasma-activities/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma-activities"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -21,7 +21,7 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later AND (LGPL-2.1-only OR LGPL-3.0
 url = "https://invent.kde.org/plasma/plasma-activities"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-activities-{pkgver}.tar.xz"
 sha256 = "65533076dbbf3f805a527891d704134f9134ae22b0203c61929a6088efddeb90"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 @subpackage("plasma-activities-devel")

--- a/contrib/plasma-desktop/template.py
+++ b/contrib/plasma-desktop/template.py
@@ -105,8 +105,7 @@ license = "GPL-2.0-only AND LGPL-2.1-only"
 url = "https://kde.org/plasma-desktop"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-desktop-{pkgver}.tar.xz"
 sha256 = "362f64fa1af1c295d7fdade146bf5751176256c19fd41dd1850fff3603c21fad"
-# CFI: kills systemsettings (when entering "Date & Time") in kcm_clock.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 # most kdepim stuff depends on messagelib which depends on qtwebengine
 _have_kdepim = False

--- a/contrib/plasma-disks/template.py
+++ b/contrib/plasma-disks/template.py
@@ -30,5 +30,4 @@ license = "GPL-2.0-only OR GPL-3.0-only"
 url = "https://invent.kde.org/plasma/plasma-disks"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-disks-{pkgver}.tar.xz"
 sha256 = "116edeb311b2887c47fda7eb2040e0238cec30990ae928f96e2b35c78c7ff3c6"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/plasma-integration/template.py
+++ b/contrib/plasma-integration/template.py
@@ -44,5 +44,4 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/plasma-integration"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-integration-{pkgver}.tar.xz"
 sha256 = "a3ef73795b5f7d4d4b3c562645c0fdc31c3034499cc6ad61cd48ccfb3fe3e55b"
-# CFI: crashes e.g. kwrite upon "Save" in save file dialog in KDEPlasmaPlatformTheme6.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/plasma-nm/template.py
+++ b/contrib/plasma-nm/template.py
@@ -37,5 +37,4 @@ license = "GPL-2.0-or-later AND LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/plasma-nm"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-nm-{pkgver}.tar.xz"
 sha256 = "5b5102ad7c808eb2fa4b036ef485d6586d2575f0789076dedefc1300ab90117c"
-# CFI: kills systemsettings (upon apply of change and clicking another NIC) in libplasmanm_editor.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/plasma-pa/template.py
+++ b/contrib/plasma-pa/template.py
@@ -39,5 +39,4 @@ license = "GPL-2.0-or-later AND LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/plasma-pa"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-pa-{pkgver}.tar.xz"
 sha256 = "4211b05f036d80e455a4c2a32184266017fe5dcd01fb7532760ac81d886aadf7"
-# CFI: kills systemsettings (when leaving "Sound" page) in libplasma-volume-declarative.so
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/plasma-systemmonitor/template.py
+++ b/contrib/plasma-systemmonitor/template.py
@@ -35,5 +35,4 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://apps.kde.org/plasma-systemmonitor"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-systemmonitor-{pkgver}.tar.xz"
 sha256 = "ff82e2fd7a844d3d2c652537a783e009f3c42869776714520d439815fcb2d8f9"
-# CFI: crash on launch
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/plasma-workspace/template.py
+++ b/contrib/plasma-workspace/template.py
@@ -125,8 +125,7 @@ license = "MIT AND GPL-3.0-only AND LGPL-3.0-only"
 url = "https://api.kde.org/plasma/plasma-workspace/html"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma-workspace-{pkgver}.tar.xz"
 sha256 = "799cdefb52856db7273bb49a205c6e057165e77baec484c7c622ee6882c4d5ca"
-# CFI: breaks at least 3 tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/plasma5support/template.py
+++ b/contrib/plasma5support/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma5support"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # needs plasma-workspace plugin and is circular with it
 make_check_args = ["-E", "pluginloadertest"]
@@ -28,7 +28,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/plasma5support"
 source = f"$(KDE_SITE)/plasma/{pkgver}/plasma5support-{pkgver}.tar.xz"
 sha256 = "37d875f77f8f0d463b409cc31e296c581dbe73e75ac014db3ae11372a51ff76d"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 @subpackage("plasma5support-devel")

--- a/contrib/polkit-kde-agent-1/template.py
+++ b/contrib/polkit-kde-agent-1/template.py
@@ -1,6 +1,6 @@
 pkgname = "polkit-kde-agent-1"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -24,8 +24,7 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/polkit-kde-agent-1"
 source = f"$(KDE_SITE)/plasma/{pkgver}/polkit-kde-agent-1-{pkgver}.tar.xz"
 sha256 = "27b9da65056b1d07aca3b60641fc8ffa41e9dd03ffd1e138183f641613f2396f"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/polkit-qt-1/template.py
+++ b/contrib/polkit-qt-1/template.py
@@ -1,6 +1,6 @@
 pkgname = "polkit-qt-1"
 pkgver = "0.200.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = ["-DQT_MAJOR_VERSION=6"]
 hostmakedepends = [
@@ -19,7 +19,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/libraries/polkit-qt-1"
 source = f"$(KDE_SITE)/polkit-qt-1/polkit-qt-1-{pkgver}.tar.xz"
 sha256 = "5d3b611c062d2b76a93750bb10c907bfd21d1ff08d0a15dc2cf63e278e1677fb"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 @subpackage("polkit-qt-1-devel")

--- a/contrib/powerdevil/template.py
+++ b/contrib/powerdevil/template.py
@@ -1,6 +1,6 @@
 pkgname = "powerdevil"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # FIXME: all tests broken like on alpine, migrateconfig_test*
 make_check_args = [
@@ -62,7 +62,7 @@ file_xattrs = {
         "security.capability": "cap_wake_alarm+ep",
     },
 }
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/print-manager/template.py
+++ b/contrib/print-manager/template.py
@@ -30,5 +30,4 @@ license = "GPL-2.0-or-later AND LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0
 url = "https://invent.kde.org/plasma/print-manager"
 source = f"$(KDE_SITE)/plasma/{pkgver}/print-manager-{pkgver}.tar.xz"
 sha256 = "9505469e86e20363e4beddc6948d9d9e07a8373aedb7af99928cb98101ddbb04"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/prison/template.py
+++ b/contrib/prison/template.py
@@ -20,7 +20,7 @@ license = "MIT"
 url = "https://api.kde.org/frameworks/prison/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/prison-{pkgver}.tar.xz"
 sha256 = "dd6eb0b640e02636a876e69f8e2dba4043c8e444a6630eb20488754f5f57ea8d"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/pulseaudio-qt/template.py
+++ b/contrib/pulseaudio-qt/template.py
@@ -19,7 +19,7 @@ license = "LGPL-2.1-only OR LGPL-3.0-only"
 url = "https://invent.kde.org/libraries/pulseaudio-qt"
 source = f"$(KDE_SITE)/pulseaudio-qt/pulseaudio-qt-{pkgver}.tar.xz"
 sha256 = "cd8f51c8700073d0fd90d5784083aceb73e72ba9a704e605e0a67909426a8520"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("pulseaudio-qt-devel")

--- a/contrib/purpose/template.py
+++ b/contrib/purpose/template.py
@@ -33,8 +33,7 @@ license = "LGPL-2.1-only"
 url = "https://api.kde.org/frameworks/purpose/html/index.html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/purpose-{pkgver}.tar.xz"
 sha256 = "318169f201548eaa3c8a76e6eb00d9b10f51872d7f91c7f9749fcb518699e50e"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("purpose-devel")

--- a/contrib/qca/template.py
+++ b/contrib/qca/template.py
@@ -1,6 +1,6 @@
 pkgname = "qca"
 pkgver = "2.3.9"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = ["-DBUILD_WITH_QT6=ON"]
 hostmakedepends = ["cmake", "ninja", "pkgconf"]
@@ -16,7 +16,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/qca/html"
 source = f"$(KDE_SITE)/qca/{pkgver}/qca-{pkgver}.tar.xz"
 sha256 = "c555d5298cdd7b6bafe2b1f96106f30cfa543a23d459d50c8a91eac33c476e4e"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 @subpackage("qca-devel")

--- a/contrib/qqc2-breeze-style/template.py
+++ b/contrib/qqc2-breeze-style/template.py
@@ -25,8 +25,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/qqc2-breeze-style"
 source = f"$(KDE_SITE)/plasma/{pkgver}/qqc2-breeze-style-{pkgver}.tar.xz"
 sha256 = "4947312e1e7282923dfabfe6c6db60e90c3cf4c329092cb7d077f7184551be68"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("qqc2-breeze-style-devel")

--- a/contrib/qqc2-desktop-style/template.py
+++ b/contrib/qqc2-desktop-style/template.py
@@ -27,9 +27,7 @@ license = "LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only)"
 url = "https://api.kde.org/frameworks/qqc2-desktop-style/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/qqc2-desktop-style-{pkgver}.tar.xz"
 sha256 = "9b133056638a11b998883edff0d9078e868c09725868bdaee8e733fde308f0fb"
-# CFI: makes kwin_wayland die top-left hotcorner and
-# kcmshell6 on konsole titlebar right-click -> More Actions -> Configure Special * Settings...
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("qqc2-desktop-style-devel")

--- a/contrib/signon-kwallet-extension/template.py
+++ b/contrib/signon-kwallet-extension/template.py
@@ -19,5 +19,4 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/network/signon-kwallet-extension"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/signon-kwallet-extension-{pkgver}.tar.xz"
 sha256 = "ad77c595d254a029815e376002f038ca7f81a1023c60d7b2a51e59253f716f46"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/solid/template.py
+++ b/contrib/solid/template.py
@@ -25,7 +25,7 @@ source = (
     f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/solid-{pkgver}.tar.xz"
 )
 sha256 = "56793b71d4fb9f4af8ec8af9293b777eccafdc1af757f5962429f0b1f93595c3"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("solid-devel")

--- a/contrib/sonnet/template.py
+++ b/contrib/sonnet/template.py
@@ -24,7 +24,7 @@ license = "LGPL-2.1-only"
 url = "https://develop.kde.org/docs/features/spellchecking"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/sonnet-{pkgver}.tar.xz"
 sha256 = "954205989da5d3443bfc256f8b31e05e23effb836f1810894d6fb9cc9d0cdda9"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("sonnet-devel")

--- a/contrib/spectacle/template.py
+++ b/contrib/spectacle/template.py
@@ -38,8 +38,7 @@ license = "GPL-2.0-or-later"
 url = "https://apps.kde.org/spectacle"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/spectacle-{pkgver}.tar.xz"
 sha256 = "14c1435fb057aa3d088529e28b6407b9f4f89d5f5399d58859044c2b75476d82"
-# CFI: kills app on launch
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/svgpart/template.py
+++ b/contrib/svgpart/template.py
@@ -24,5 +24,4 @@ license = "GPL-2.0-or-later"
 url = "https://apps.kde.org/svgpart"
 source = f"$(KDE_SITE)/release-service/{pkgver}/src/svgpart-{pkgver}.tar.xz"
 sha256 = "5d3bd75183f96d2c42cdd5484f0c526a4b262822c15959c4211d1bfab822b79a"
-# CFI: check
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/syndication/template.py
+++ b/contrib/syndication/template.py
@@ -17,8 +17,7 @@ license = "LGPL-2.0-or-later AND BSD-2-Clause"
 url = "https://api.kde.org/frameworks/syndication/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/syndication-{pkgver}.tar.xz"
 sha256 = "d5637eaf255c4d3e110765d2ed5aba06c994560801e4e6c4b0698acc53954dcb"
-# CFI: breaks 2/3 tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/syntax-highlighting/template.py
+++ b/contrib/syntax-highlighting/template.py
@@ -19,7 +19,7 @@ license = "MIT"
 url = "https://api.kde.org/frameworks/syntax-highlighting/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/syntax-highlighting-{pkgver}.tar.xz"
 sha256 = "1f825afa7ca094937f1b8d357ae6b2cd37e58accf009290341ebada288c51505"
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/systemsettings/template.py
+++ b/contrib/systemsettings/template.py
@@ -37,5 +37,4 @@ url = "https://userbase.kde.org/System_Settings"
 source = f"$(KDE_SITE)/plasma/{pkgver}/systemsettings-{pkgver}.tar.xz"
 sha256 = "65ba04f22ab4dbfeb8c9a06b540b2ea9d56fe7e9ba295344a5c7e6b63f182131"
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x100000"]}
-# CFI: crash on launch
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]

--- a/contrib/threadweaver/template.py
+++ b/contrib/threadweaver/template.py
@@ -14,8 +14,7 @@ license = "LGPL-2.1-or-later"
 url = "https://api.kde.org/frameworks/threadweaver/html"
 source = f"$(KDE_SITE)/frameworks/{pkgver[:pkgver.rfind('.')]}/threadweaver-{pkgver}.tar.xz"
 sha256 = "a317ad5b4e0ae8dee7fd95026a3df3f5fc1c2e53aec6d5ccbadddfc753c29598"
-# CFI: fails most tests
-hardening = ["vis", "!cfi"]
+hardening = ["vis"]
 
 
 @subpackage("threadweaver-devel")

--- a/contrib/xdg-desktop-portal-kde/template.py
+++ b/contrib/xdg-desktop-portal-kde/template.py
@@ -1,6 +1,6 @@
 pkgname = "xdg-desktop-portal-kde"
 pkgver = "6.1.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 make_check_env = {"QT_QPA_PLATFORM": "offscreen"}
 make_check_wrapper = ["dbus-run-session"]
@@ -45,7 +45,7 @@ license = "LGPL-2.0-or-later"
 url = "https://invent.kde.org/plasma/xdg-desktop-portal-kde"
 source = f"$(KDE_SITE)/plasma/{pkgver}/xdg-desktop-portal-kde-{pkgver}.tar.xz"
 sha256 = "824cfe7b065785be7f802a812692d509b8213d64a984d97e830448f70aa13cc6"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):

--- a/contrib/xwaylandvideobridge/template.py
+++ b/contrib/xwaylandvideobridge/template.py
@@ -1,6 +1,6 @@
 pkgname = "xwaylandvideobridge"
 pkgver = "0.4.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = ["-DQT_MAJOR_VERSION=6"]
 hostmakedepends = [
@@ -25,5 +25,4 @@ license = "GPL-2.0-or-later"
 url = "https://invent.kde.org/system/xwaylandvideobridge"
 source = f"$(KDE_SITE)/xwaylandvideobridge/xwaylandvideobridge-{pkgver}.tar.xz"
 sha256 = "ea72ac7b2a67578e9994dcb0619602ead3097a46fb9336661da200e63927ebe6"
-# TODO: check CFI stability again, previously crashed on screenshare
-hardening = ["vis", "cfi"]
+hardening = ["vis"]


### PR DESCRIPTION
cfi causes a lot of crashes for kde projects, and fixing them just doesn't seem worth it

[ci skip]