### PR TITLE
IIO sensor proxy

### DIFF
--- a/contrib/plasma-desktop/template.py
+++ b/contrib/plasma-desktop/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma-desktop"
 pkgver = "6.1.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # FIXME: missing layout memory xml file? QTemporaryFile broken?
 make_check_args = ["-E", "kcm-keyboard-keyboard_memory_persister_test"]
@@ -151,7 +151,7 @@ def _(self):
         # non-kde, misc integrations
         "desktop-file-utils",
         "fprintd-meta",
-        # "iio-sensor-proxy",  # FIXME: package and test on device with accelerometer
+        "iio-sensor-proxy-meta",
         "power-profiles-daemon-meta",  # battery power saving
     ]
     self.options = ["empty"]
@@ -177,7 +177,7 @@ def _(self):
 @subpackage("plasma-desktop-apps-meta")
 def _(self):
     self.subdesc = "apps recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         # - core
         "discover",  # extra app management
@@ -253,7 +253,7 @@ def _(self):
 @subpackage("plasma-desktop-multimedia-meta")
 def _(self):
     self.subdesc = "multimedia recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "audiocd-kio",  # kio plugin for audio cds
         "audiotube",  # youtube music client
@@ -272,7 +272,7 @@ def _(self):
 @subpackage("plasma-desktop-devtools-meta")
 def _(self):
     self.subdesc = "devtools recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "heaptrack",
         "kcachegrind",
@@ -285,7 +285,7 @@ def _(self):
 @subpackage("plasma-desktop-games-meta")
 def _(self):
     self.subdesc = "games recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "kpat",
     ]
@@ -296,7 +296,7 @@ def _(self):
 @subpackage("plasma-desktop-accessibility-meta")
 def _(self):
     self.subdesc = "accessibility recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "accessibility-inspector",  # accesibility tree inspector
         # "kmag",  # magnifier TODO: broken?
@@ -313,7 +313,7 @@ def _(self):
 def _(self):
     # contact/calendar/etc
     self.subdesc = "kdepim recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "akonadi-calendar-tools",
         "akonadi-import-wizard",

--- a/main/gnome-settings-daemon/template.py
+++ b/main/gnome-settings-daemon/template.py
@@ -1,6 +1,6 @@
 pkgname = "gnome-settings-daemon"
 pkgver = "46.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 configure_args = [
     "-Dsystemd=false",
@@ -53,6 +53,7 @@ checkdepends = [
     "udev",
     "umockdev",
 ]
+depends = ["iio-sensor-proxy-meta"]
 pkgdesc = "GNOME settings daemon"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"

--- a/main/iio-sensor-proxy-meta
+++ b/main/iio-sensor-proxy-meta
@@ -1,0 +1,1 @@
+iio-sensor-proxy

--- a/main/iio-sensor-proxy/files/iio-sensor-proxy
+++ b/main/iio-sensor-proxy/files/iio-sensor-proxy
@@ -1,0 +1,5 @@
+# iio-sensor-proxy service
+
+type = process
+command = /usr/libexec/iio-sensor-proxy
+depends-on = dbus

--- a/main/iio-sensor-proxy/patches/french-pt1.patch
+++ b/main/iio-sensor-proxy/patches/french-pt1.patch
@@ -1,0 +1,81 @@
+Patch-Source: https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/commit/fe56bdba1243cc5f6a652eb75d11ae1d1957ff7e
+--- a/src/test-mount-matrix.c
++++ b/src/test-mount-matrix.c
+@@ -66,12 +66,16 @@ test_mount_matrix (void)
+ static void
+ test_comma_decimal_separator (void)
+ {
++	const char *fr_locale = "fr_FR.UTF-8";
+ 	char *old_locale;
+ 	AccelVec3 *vecs;
+ 
+-	old_locale = setlocale (LC_ALL, "fr_FR.UTF-8");
++	old_locale = setlocale (LC_ALL, fr_locale);
+ 	/* French locale not available? */
+-	g_assert_nonnull (old_locale);
++	if (!old_locale) {
++		g_test_skip_printf ("Local %s not available", fr_locale);
++		return;
++	}
+ 
+ 	/* Default matrix */
+ 	g_assert_true (parse_mount_matrix (DEFAULT_MATRIX, &vecs));
+--- a/tests/integration-test.py
++++ b/tests/integration-test.py
+@@ -27,6 +27,7 @@ import tempfile
+ import psutil
+ import subprocess
+ import unittest
++import locale
+ import time
+ 
+ try:
+@@ -50,6 +51,7 @@ SP_COMPASS = 'net.hadess.SensorProxy.Compass'
+ SP_COMPASS_PATH = '/net/hadess/SensorProxy/Compass'
+ 
+ class Tests(dbusmock.DBusTestCase):
++
+     @classmethod
+     def setUpClass(cls):
+         # run from local build tree if we are in one, otherwise use system instance
+@@ -92,6 +94,15 @@ class Tests(dbusmock.DBusTestCase):
+         cls.dbus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+         cls.dbus_con = cls.get_dbus(True)
+ 
++        # Some test outputs require the daemon to run under the fr locale:
++        # so check if that's available
++        try:
++            old_loc = locale.setlocale(locale.LC_ALL, 'fr_FR.UTF-8')
++            cls.has_fr = True
++            locale.setlocale(locale.LC_ALL, old_loc)
++        except:
++            cls.has_fr = False
++
+     @classmethod
+     def tearDownClass(cls):
+         cls.test_bus.down()
+@@ -612,10 +623,9 @@ class Tests(dbusmock.DBusTestCase):
+             mock_file.write(data)
+         self.proxy.ClaimAccelerometer()
+         self.assertEventually(lambda: self.have_text_in_log('Accel sent by driver'))
+-        # If the 2nd test fails, it's likely that fr_FR.UTF-8 locale isn't supported
+         self.assertEqual(self.have_text_in_log('scale: 0,000000,0,000000,0,000000'), False)
+-        self.assertEqual(self.have_text_in_log('scale: 0,000010,0,000010,0,000010'), True)
+-
++        if self.has_fr:
++            self.assertEqual(self.have_text_in_log('scale: 0,000010,0,000010,0,000010'), True)
+         self.stop_daemon()
+ 
+     def test_iio_scale_decimal_separator_offset(self):
+@@ -715,9 +725,9 @@ class Tests(dbusmock.DBusTestCase):
+ 
+         self.proxy.ClaimAccelerometer()
+         self.assertEventually(lambda: self.have_text_in_log('Accel read from IIO on'))
+-        # If the 2nd test fails, it's likely that fr_FR.UTF-8 locale isn't supported
+         self.assertEqual(self.have_text_in_log('scale 1,000000,1,000000,1,000000'), False)
+-        self.assertEqual(self.have_text_in_log('scale 0,000001,0,000001,0,000001'), True)
++        if self.has_fr:
++            self.assertEqual(self.have_text_in_log('scale 0,000001,0,000001,0,000001'), True)
+ 
+         self.assertEventually(lambda: self.get_dbus_property('AccelerometerOrientation') == 'normal')
+ 

--- a/main/iio-sensor-proxy/patches/french-pt2.patch
+++ b/main/iio-sensor-proxy/patches/french-pt2.patch
@@ -1,0 +1,15 @@
+Patch-Source: https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/385
+--- a/tests/integration-test.py
++++ b/tests/integration-test.py
+@@ -98,8 +98,10 @@ class Tests(dbusmock.DBusTestCase):
+         # so check if that's available
+         try:
+             old_loc = locale.setlocale(locale.LC_ALL, 'fr_FR.UTF-8')
+-            cls.has_fr = True
+             locale.setlocale(locale.LC_ALL, old_loc)
++	    # We need to make sure the decimal point is correct as on musl libc the above
++	    # succeeds yet the tests just fail due to the output being in unexpected format
++            cls.has_fr = locale.localeconv()["decimal_point"] == ","
+         except:
+             cls.has_fr = False
+ 

--- a/main/iio-sensor-proxy/template.py
+++ b/main/iio-sensor-proxy/template.py
@@ -1,0 +1,45 @@
+pkgname = "iio-sensor-proxy"
+pkgver = "3.5"
+pkgrel = 0
+build_style = "meson"
+configure_args = [
+    "-Dgeoclue-user=_geoclue",
+    "-Dsystemdsystemunitdir=",
+    "-Dtests=true",
+]
+hostmakedepends = [
+    "meson",
+    "pkgconf",
+]
+makedepends = [
+    "glib-devel",
+    "libgudev-devel",
+    "linux-headers",
+    "polkit-devel",
+    "udev-devel",
+]
+checkdepends = [
+    "python-dbusmock",
+    "python-gobject",
+    "python-psutil",
+    "umockdev",
+]
+install_if = [f"iio-sensor-proxy-meta={pkgver}-r{pkgrel}"]
+pkgdesc = "IIO accelerometer sensor to input device proxy"
+maintainer = "Jami Kettunen <jami.kettunen@protonmail.com>"
+license = "GPL-3.0-or-later"
+url = "https://gitlab.freedesktop.org/hadess/iio-sensor-proxy"
+source = f"{url}/-/archive/{pkgver}/iio-sensor-proxy-{pkgver}.tar.gz"
+sha256 = "8689425f2287626a95d95b1e1e5b62e497d09dd08cf411084ed22166d4a49da5"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_service(self.files_path / "iio-sensor-proxy")
+
+
+@subpackage("iio-sensor-proxy-meta")
+def _(self):
+    self.subdesc = "recommends package"
+    self.options = ["empty"]
+    return []


### PR DESCRIPTION
Running tests for `iio-sensor-proxy` with `-Dtests=true` requires at least `umockdev` and it'd probably be nicer to have this under `main/` for the auto-soft-deps on GNOME at least.

As a part of adding `iio-sensor-proxy-meta` to `plasma-desktop-meta` deps also make it easier to mask out potentially unwanted plasma apps `-meta` packages basically turning .e.g.
```
apk add plasma-desktop '!'plasma-desktop{,-apps,-multimedia,-games,-accessibility,-kdepim,-devtools}-meta
```
into just:
```
apk add plasma-desktop '!plasma-desktop-meta'
```
While on my Minisforum V3 tablet I still don't have automatic rotation (yet) working due to missing accelerometer sensor from driver side I think it's fair enough to add it as default for KDE Plasma too even though it doesn't seem to e.g. have automatic brightness as an option which I could successfully test in GDM/GNOME already; someone else could try this too instead :)

Marking as a draft for now because for some reason after installing `plasma-desktop` I've not seen ALS work in GDM/GNOME despite `monitor-sensor` actively claiming otherwise...