### PR TITLE
contrib/nushell: new package (0.95.0)

### DIFF
--- a/Packaging.md
+++ b/Packaging.md
@@ -1499,6 +1499,7 @@ These are (with their package description suffixes):
 * `bashcomp` - `(bash completions)`
 * `zshcomp` - `(zsh completions)`
 * `fishcomp` - `(fish completions)`
+* `nucomp` - `(nushell completions)`
 * `locale` - `(locale data)`
 * `static` - `(static libraries)`
 * `pycache` - `(Python bytecode)`
@@ -1527,6 +1528,7 @@ the package they were split off needs to be installed, plus the following:
 * `bash-completion` for `-bashcomp` packages
 * `zsh` for `-zshcomp` packages
 * `fish-shell` for `-fishcomp` packages
+* `nushell` for `-nucomp` packages
 * `python-pycache` for `-pycache` packages (except `python-pycache` itself)
 
 Development packages may be automatically installed if `base-devel` is
@@ -3073,7 +3075,7 @@ Equivalent to `self.install_file(src, "usr/share/licenses/" + pkgname, 0o644, na
 Install a shell completion `src`. If not given, `name` will be expanded
 to the package name. The `name` is the root of the completion file name
 that will be adjusted according to the shell. The `shell` must be one of
-`bash`, `zsh`, `fish`.
+`bash`, `zsh`, `fish`, `nushell`.
 
 When `name` is not given, `self.pkgname` is used.
 

--- a/contrib/minijinja-cli/template.py
+++ b/contrib/minijinja-cli/template.py
@@ -1,5 +1,5 @@
 pkgname = "minijinja-cli"
-pkgver = "2.0.1"
+pkgver = "2.0.3"
 pkgrel = 0
 build_wrksrc = "minijinja-cli"
 build_style = "cargo"
@@ -15,7 +15,7 @@ maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license = "Apache-2.0"
 url = "https://github.com/mitsuhiko/minijinja"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "9ba95d52c7d5addcd9cc0f52ba03b9bb9298c2f9650154e1f12c36c4f9e46213"
+sha256 = "34c0726bf1ef54ed6069c66258a786e69ed1ca47e14220fee8f6216ac710e4c9"
 
 
 def post_install(self):
@@ -23,3 +23,4 @@ def post_install(self):
     self.install_completion("assets/completions/minijinja-cli.bash", "bash")
     self.install_completion("assets/completions/minijinja-cli.fish", "fish")
     self.install_completion("assets/completions/_minijinja-cli", "zsh")
+    self.install_completion("assets/completions/minijinja-cli.nu", "nushell")

--- a/contrib/nushell/patches/0001-implement-autoloading-13217.patch
+++ b/contrib/nushell/patches/0001-implement-autoloading-13217.patch
@@ -1,7 +1,7 @@
-From f241110005006f10e16c6080ebab7abec6f3e5ce Mon Sep 17 00:00:00 2001
+From fceea60c37df07020d0fc9d899aa7a445e304c96 Mon Sep 17 00:00:00 2001
 From: Darren Schroeder <343840+fdncred@users.noreply.github.com>
 Date: Tue, 25 Jun 2024 20:31:54 -0500
-Subject: [PATCH] implement autoloading (#13217)
+Subject: [PATCH 1/3] implement autoloading (#13217)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -73,7 +73,7 @@ PR is merged, if necessary. This will help us keep the docs up to date.
  2 files changed, 84 insertions(+), 26 deletions(-)
 
 diff --git a/crates/nu-protocol/src/eval_const.rs b/crates/nu-protocol/src/eval_const.rs
-index 8f6382ae4436..87913e4ee3c0 100644
+index 8f6382ae4..87913e4ee 100644
 --- a/crates/nu-protocol/src/eval_const.rs
 +++ b/crates/nu-protocol/src/eval_const.rs
 @@ -194,31 +194,11 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
@@ -156,7 +156,7 @@ index 8f6382ae4436..87913e4ee3c0 100644
      working_set: &StateWorkingSet,
      call: &Call,
 diff --git a/src/config_files.rs b/src/config_files.rs
-index ec4511860f04..30977a6d0e7e 100644
+index ec4511860..30977a6d0 100644
 --- a/src/config_files.rs
 +++ b/src/config_files.rs
 @@ -9,8 +9,9 @@ use nu_protocol::{
@@ -226,3 +226,6 @@ index ec4511860f04..30977a6d0e7e 100644
      }));
      if result.is_err() {
          eprintln!(
+-- 
+2.45.2
+

--- a/contrib/nushell/patches/0002-Switch-from-dirs_next-2.0-to-dirs-5.0-13384.patch
+++ b/contrib/nushell/patches/0002-Switch-from-dirs_next-2.0-to-dirs-5.0-13384.patch
@@ -1,0 +1,364 @@
+From 8c1e2c43e8ed07ef205689befde39a6493f09757 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Tue, 16 Jul 2024 14:16:26 +0200
+Subject: [PATCH 2/3] Switch from dirs_next 2.0 to dirs 5.0 (#13384)
+
+<!--
+if this PR closes one or more issues, you can automatically link the PR
+with
+them by using one of the [*linking
+keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword),
+e.g.
+- this PR should close #xxxx
+- fixes #xxxx
+
+you can also mention related issues, PRs or discussions!
+-->
+
+<!--
+Thank you for improving Nushell. Please, check our [contributing
+guide](../CONTRIBUTING.md) and talk to the core team before making major
+changes.
+
+Description of your pull request goes here. **Provide examples and/or
+screenshots** if your changes affect the user experience.
+-->
+Replaces the `dirs_next` family of crates with `dirs`. `dirs_next` was
+born when the `dirs` crates were abandoned three years ago, but they're
+being maintained again and most projects depend on `dirs` nowadays.
+`dirs_next` has been abandoned since.
+
+This came up while working on
+https://github.com/nushell/nushell/pull/13382.
+
+<!-- List of all changes that impact the user experience here. This
+helps us keep track of breaking changes. -->
+None.
+
+<!--
+Don't forget to add tests that cover your changes.
+
+Make sure you've run and fixed any issues with these commands:
+
+- `cargo fmt --all -- --check` to check standard code formatting (`cargo
+fmt --all` applies these changes)
+- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to
+check that you're using the standard code style
+- `cargo test --workspace` to check that all tests pass (on Windows make
+sure to [enable developer
+mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
+- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the
+tests for the standard library
+
+> **Note**
+> from `nushell` you can also use the `toolkit` as follows
+> ```bash
+> use toolkit.nu # or use an `env_change` hook to activate it
+automatically
+> toolkit check pr
+> ```
+-->
+Tests and formatter have been run.
+
+<!-- If your PR had any user-facing changes, update [the
+documentation](https://github.com/nushell/nushell.github.io) after the
+PR is merged, if necessary. This will help us keep the docs up to date.
+-->
+---
+ Cargo.lock                                    | 30 +++++++++++--------
+ Cargo.toml                                    |  6 ++--
+ crates/nu-command/Cargo.toml                  |  4 +--
+ crates/nu-command/src/system/run_external.rs  |  2 +-
+ crates/nu-command/tests/commands/cd.rs        |  2 +-
+ .../nu-command/tests/commands/run_external.rs |  2 +-
+ crates/nu-path/Cargo.toml                     |  4 +--
+ crates/nu-path/src/helpers.rs                 |  8 ++---
+ crates/nu-path/src/tilde.rs                   |  4 +--
+ src/main.rs                                   |  2 +-
+ tests/repl/test_config_path.rs                |  4 +--
+ 11 files changed, 37 insertions(+), 31 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9b8f5273c..7c5bdbacb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1183,24 +1183,24 @@ dependencies = [
+ ]
+ 
+ [[package]]
+-name = "dirs-next"
+-version = "2.0.0"
++name = "dirs"
++version = "5.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
++checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+ dependencies = [
+- "cfg-if",
+- "dirs-sys-next",
++ "dirs-sys",
+ ]
+ 
+ [[package]]
+-name = "dirs-sys-next"
+-version = "0.1.2"
++name = "dirs-sys"
++version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
++checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+ dependencies = [
+  "libc",
++ "option-ext",
+  "redox_users",
+- "winapi",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+@@ -2774,7 +2774,7 @@ dependencies = [
+  "assert_cmd",
+  "crossterm",
+  "ctrlc",
+- "dirs-next",
++ "dirs",
+  "log",
+  "miette",
+  "mimalloc",
+@@ -2946,7 +2946,7 @@ dependencies = [
+  "csv",
+  "dialoguer",
+  "digest",
+- "dirs-next",
++ "dirs",
+  "dtparse",
+  "encoding_rs",
+  "fancy-regex",
+@@ -3140,7 +3140,7 @@ dependencies = [
+ name = "nu-path"
+ version = "0.95.0"
+ dependencies = [
+- "dirs-next",
++ "dirs",
+  "omnipath",
+  "pwd",
+ ]
+@@ -3722,6 +3722,12 @@ dependencies = [
+  "vcpkg",
+ ]
+ 
++[[package]]
++name = "option-ext"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
++
+ [[package]]
+ name = "ordered-multimap"
+ version = "0.7.3"
+diff --git a/Cargo.toml b/Cargo.toml
+index 696c012b8..d05bebaa2 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -82,7 +82,7 @@ csv = "1.3"
+ ctrlc = "3.4"
+ dialoguer = { default-features = false, version = "0.11" }
+ digest = { default-features = false, version = "0.10" }
+-dirs-next = "2.0"
++dirs = "5.0"
+ dtparse = "2.0"
+ encoding_rs = "0.8"
+ fancy-regex = "0.13"
+@@ -201,7 +201,7 @@ reedline = { workspace = true, features = ["bashisms", "sqlite"] }
+ 
+ crossterm = { workspace = true }
+ ctrlc = { workspace = true }
+-dirs-next = { workspace = true }
++dirs = { workspace = true }
+ log = { workspace = true }
+ miette = { workspace = true, features = ["fancy-no-backtrace", "fancy"] }
+ mimalloc = { version = "0.1.42", default-features = false, optional = true }
+@@ -229,7 +229,7 @@ nu-test-support = { path = "./crates/nu-test-support", version = "0.95.0" }
+ nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.95.0" }
+ nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.95.0" }
+ assert_cmd = "2.0"
+-dirs-next = { workspace = true }
++dirs = { workspace = true }
+ tango-bench = "0.5"
+ pretty_assertions = { workspace = true }
+ rstest = { workspace = true, default-features = false }
+diff --git a/crates/nu-command/Cargo.toml b/crates/nu-command/Cargo.toml
+index 355232b93..71cabc553 100644
+--- a/crates/nu-command/Cargo.toml
++++ b/crates/nu-command/Cargo.toml
+@@ -139,10 +139,10 @@ trash-support = ["trash"]
+ nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.95.0" }
+ nu-test-support = { path = "../nu-test-support", version = "0.95.0" }
+ 
+-dirs-next = { workspace = true }
++dirs = { workspace = true }
+ mockito = { workspace = true, default-features = false }
+ quickcheck = { workspace = true }
+ quickcheck_macros = { workspace = true }
+ rstest = { workspace = true, default-features = false }
+ pretty_assertions = { workspace = true }
+-tempfile = { workspace = true }
+\ No newline at end of file
++tempfile = { workspace = true }
+diff --git a/crates/nu-command/src/system/run_external.rs b/crates/nu-command/src/system/run_external.rs
+index f82c23a0e..c4564da4f 100644
+--- a/crates/nu-command/src/system/run_external.rs
++++ b/crates/nu-command/src/system/run_external.rs
+@@ -635,7 +635,7 @@ mod test {
+             assert_eq!(actual, expected);
+ 
+             let actual = expand_glob("~/foo.txt", cwd, Span::unknown(), &None).unwrap();
+-            let home = dirs_next::home_dir().expect("failed to get home dir");
++            let home = dirs::home_dir().expect("failed to get home dir");
+             let expected: Vec<OsString> = vec![home.join("foo.txt").into()];
+             assert_eq!(actual, expected);
+         })
+diff --git a/crates/nu-command/tests/commands/cd.rs b/crates/nu-command/tests/commands/cd.rs
+index 87af52aa4..f58638cc3 100644
+--- a/crates/nu-command/tests/commands/cd.rs
++++ b/crates/nu-command/tests/commands/cd.rs
+@@ -151,7 +151,7 @@ fn filesystem_change_to_home_directory() {
+             "
+         );
+ 
+-        assert_eq!(Some(PathBuf::from(actual.out)), dirs_next::home_dir());
++        assert_eq!(Some(PathBuf::from(actual.out)), dirs::home_dir());
+     })
+ }
+ 
+diff --git a/crates/nu-command/tests/commands/run_external.rs b/crates/nu-command/tests/commands/run_external.rs
+index 154c31b71..17667c9bb 100644
+--- a/crates/nu-command/tests/commands/run_external.rs
++++ b/crates/nu-command/tests/commands/run_external.rs
+@@ -309,7 +309,7 @@ fn external_arg_expand_tilde() {
+             "#
+         ));
+ 
+-        let home = dirs_next::home_dir().expect("failed to find home dir");
++        let home = dirs::home_dir().expect("failed to find home dir");
+ 
+         assert_eq!(
+             actual.out,
+diff --git a/crates/nu-path/Cargo.toml b/crates/nu-path/Cargo.toml
+index cf716b457..412fef6f1 100644
+--- a/crates/nu-path/Cargo.toml
++++ b/crates/nu-path/Cargo.toml
+@@ -12,10 +12,10 @@ exclude = ["/fuzz"]
+ bench = false
+ 
+ [dependencies]
+-dirs-next = { workspace = true }
++dirs = { workspace = true }
+ 
+ [target.'cfg(windows)'.dependencies]
+ omnipath = { workspace = true }
+ 
+ [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies]
+-pwd = { workspace = true }
+\ No newline at end of file
++pwd = { workspace = true }
+diff --git a/crates/nu-path/src/helpers.rs b/crates/nu-path/src/helpers.rs
+index 5b389410e..a6e35bddf 100644
+--- a/crates/nu-path/src/helpers.rs
++++ b/crates/nu-path/src/helpers.rs
+@@ -3,14 +3,14 @@ use omnipath::WinPathExt;
+ use std::path::PathBuf;
+ 
+ pub fn home_dir() -> Option<PathBuf> {
+-    dirs_next::home_dir()
++    dirs::home_dir()
+ }
+ 
+ /// Return the data directory for the current platform or XDG_DATA_HOME if specified.
+ pub fn data_dir() -> Option<PathBuf> {
+     match std::env::var("XDG_DATA_HOME").map(PathBuf::from) {
+         Ok(xdg_data) if xdg_data.is_absolute() => Some(canonicalize(&xdg_data).unwrap_or(xdg_data)),
+-        _ => get_canonicalized_path(dirs_next::data_dir()),
++        _ => get_canonicalized_path(dirs::data_dir()),
+     }
+ }
+ 
+@@ -20,7 +20,7 @@ pub fn cache_dir() -> Option<PathBuf> {
+         Ok(xdg_cache) if xdg_cache.is_absolute() => {
+             Some(canonicalize(&xdg_cache).unwrap_or(xdg_cache))
+         }
+-        _ => get_canonicalized_path(dirs_next::cache_dir()),
++        _ => get_canonicalized_path(dirs::cache_dir()),
+     }
+ }
+ 
+@@ -30,7 +30,7 @@ pub fn config_dir() -> Option<PathBuf> {
+         Ok(xdg_config) if xdg_config.is_absolute() => {
+             Some(canonicalize(&xdg_config).unwrap_or(xdg_config))
+         }
+-        _ => get_canonicalized_path(dirs_next::config_dir()),
++        _ => get_canonicalized_path(dirs::config_dir()),
+     }
+ }
+ 
+diff --git a/crates/nu-path/src/tilde.rs b/crates/nu-path/src/tilde.rs
+index 60cc7d11e..95c91addf 100644
+--- a/crates/nu-path/src/tilde.rs
++++ b/crates/nu-path/src/tilde.rs
+@@ -77,7 +77,7 @@ fn user_home_dir(username: &str) -> PathBuf {
+ fn user_home_dir(username: &str) -> PathBuf {
+     use std::path::Component;
+ 
+-    match dirs_next::home_dir() {
++    match dirs::home_dir() {
+         None => {
+             // Termux always has the same home directory
+             #[cfg(target_os = "android")]
+@@ -145,7 +145,7 @@ fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
+ /// Expand tilde ("~") into a home directory if it is the first path component
+ pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
+     // TODO: Extend this to work with "~user" style of home paths
+-    expand_tilde_with_home(path, dirs_next::home_dir())
++    expand_tilde_with_home(path, dirs::home_dir())
+ }
+ 
+ #[cfg(test)]
+diff --git a/src/main.rs b/src/main.rs
+index c74fd7641..6290d2567 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -105,7 +105,7 @@ fn main() -> Result<()> {
+                     },
+                 );
+             } else if let Some(old_config) =
+-                nu_path::get_canonicalized_path(dirs_next::config_dir()).map(|p| p.join("nushell"))
++                nu_path::get_canonicalized_path(dirs::config_dir()).map(|p| p.join("nushell"))
+             {
+                 let xdg_config_empty = nushell_config_path
+                     .read_dir()
+diff --git a/tests/repl/test_config_path.rs b/tests/repl/test_config_path.rs
+index 534ac38a2..895b1bd8b 100644
+--- a/tests/repl/test_config_path.rs
++++ b/tests/repl/test_config_path.rs
+@@ -235,7 +235,7 @@ fn test_xdg_config_empty() {
+         playground.with_env("XDG_CONFIG_HOME", "");
+ 
+         let actual = run(playground, "$nu.default-config-dir");
+-        let expected = dirs_next::config_dir().unwrap().join("nushell");
++        let expected = dirs::config_dir().unwrap().join("nushell");
+         assert_eq!(
+             actual,
+             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
+@@ -250,7 +250,7 @@ fn test_xdg_config_bad() {
+         playground.with_env("XDG_CONFIG_HOME", xdg_config_home);
+ 
+         let actual = run(playground, "$nu.default-config-dir");
+-        let expected = dirs_next::config_dir().unwrap().join("nushell");
++        let expected = dirs::config_dir().unwrap().join("nushell");
+         assert_eq!(
+             actual,
+             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
+-- 
+2.45.2
+

--- a/contrib/nushell/patches/0003-Use-proper-directories-for-autoloading.patch
+++ b/contrib/nushell/patches/0003-Use-proper-directories-for-autoloading.patch
@@ -1,0 +1,274 @@
+From 22cdab5f9ab99f72025846ad6a47f30760df2553 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Mon, 15 Jul 2024 18:49:21 +0200
+Subject: [PATCH 3/3] Use proper directories for autoloading
+
+---
+ Cargo.lock                             |   3 +
+ Cargo.toml                             |   2 +
+ crates/nu-cli/tests/completions/mod.rs |   2 +-
+ crates/nu-protocol/Cargo.toml          |   5 +
+ crates/nu-protocol/src/eval_const.rs   | 145 ++++++++++++++++---------
+ src/config_files.rs                    |   3 +-
+ 6 files changed, 108 insertions(+), 52 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 7c5bdbacb..d751a2f79 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3237,6 +3237,8 @@ dependencies = [
+  "chrono",
+  "chrono-humanize",
+  "convert_case",
++ "dirs",
++ "dirs-sys",
+  "fancy-regex",
+  "indexmap",
+  "lru",
+@@ -3259,6 +3261,7 @@ dependencies = [
+  "tempfile",
+  "thiserror",
+  "typetag",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index d05bebaa2..345472d21 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -83,6 +83,7 @@ ctrlc = "3.4"
+ dialoguer = { default-features = false, version = "0.11" }
+ digest = { default-features = false, version = "0.10" }
+ dirs = "5.0"
++dirs-sys = "0.4"
+ dtparse = "2.0"
+ encoding_rs = "0.8"
+ fancy-regex = "0.13"
+@@ -177,6 +178,7 @@ v_htmlescape = "0.15.0"
+ wax = "0.6"
+ which = "6.0.0"
+ windows = "0.54"
++windows-sys = "0.48"
+ winreg = "0.52"
+ 
+ [dependencies]
+diff --git a/crates/nu-cli/tests/completions/mod.rs b/crates/nu-cli/tests/completions/mod.rs
+index 35e9435b4..5f751a115 100644
+--- a/crates/nu-cli/tests/completions/mod.rs
++++ b/crates/nu-cli/tests/completions/mod.rs
+@@ -783,7 +783,7 @@ fn variables_completions() {
+         "plugin-path".into(),
+         "startup-time".into(),
+         "temp-path".into(),
+-        "vendor-autoload-dir".into(),
++        "vendor-autoload-dirs".into(),
+     ];
+ 
+     // Match results
+diff --git a/crates/nu-protocol/Cargo.toml b/crates/nu-protocol/Cargo.toml
+index 73637cf29..13085a5ed 100644
+--- a/crates/nu-protocol/Cargo.toml
++++ b/crates/nu-protocol/Cargo.toml
+@@ -23,6 +23,7 @@ byte-unit = { version = "5.1", features = [ "serde" ] }
+ chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], default-features = false }
+ chrono-humanize = { workspace = true }
+ convert_case = { workspace = true }
++dirs = { workspace = true }
+ fancy-regex = { workspace = true }
+ indexmap = { workspace = true }
+ lru = { workspace = true }
+@@ -37,6 +38,10 @@ os_pipe = { workspace = true, features = ["io_safety"] }
+ [target.'cfg(unix)'.dependencies]
+ nix = { workspace = true, default-features = false, features = ["signal"] }
+ 
++[target.'cfg(windows)'.dependencies]
++dirs-sys = { workspace = true }
++windows-sys = { workspace = true }
++
+ [features]
+ plugin = [
+   "brotli",
+diff --git a/crates/nu-protocol/src/eval_const.rs b/crates/nu-protocol/src/eval_const.rs
+index 87913e4ee..6c6923179 100644
+--- a/crates/nu-protocol/src/eval_const.rs
++++ b/crates/nu-protocol/src/eval_const.rs
+@@ -181,24 +181,15 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
+         },
+     );
+ 
+-    // Create a system level directory for nushell scripts, modules, completions, etc
+-    // that can be changed by setting the NU_VENDOR_AUTOLOAD_DIR env var on any platform
+-    // before nushell is compiled OR if NU_VENDOR_AUTOLOAD_DIR is not set for non-windows
+-    // systems, the PREFIX env var can be set before compile and used as PREFIX/nushell/vendor/autoload
+     record.push(
+-        "vendor-autoload-dir",
+-        // pseudo code
+-        // if env var NU_VENDOR_AUTOLOAD_DIR is set, in any platform, use it
+-        // if not, if windows, use ALLUSERPROFILE\nushell\vendor\autoload
+-        // if not, if non-windows, if env var PREFIX is set, use PREFIX/share/nushell/vendor/autoload
+-        // if not, use the default /usr/share/nushell/vendor/autoload
+-
+-        // check to see if NU_VENDOR_AUTOLOAD_DIR env var is set, if not, use the default
+-        if let Some(path) = get_vendor_autoload_dir(engine_state) {
+-            Value::string(path.to_string_lossy(), span)
+-        } else {
+-            Value::error(ShellError::ConfigDirNotFound { span: Some(span) }, span)
+-        },
++        "vendor-autoload-dirs",
++        Value::list(
++            get_vendor_autoload_dirs(engine_state)
++                .iter()
++                .map(|path| Value::string(path.to_string_lossy(), span))
++                .collect(),
++            span,
++        ),
+     );
+ 
+     record.push("temp-path", {
+@@ -255,39 +246,95 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
+     Value::record(record, span)
+ }
+ 
+-pub fn get_vendor_autoload_dir(engine_state: &EngineState) -> Option<PathBuf> {
+-    // pseudo code
+-    // if env var NU_VENDOR_AUTOLOAD_DIR is set, in any platform, use it
+-    // if not, if windows, use ALLUSERPROFILE\nushell\vendor\autoload
+-    // if not, if non-windows, if env var PREFIX is set, use PREFIX/share/nushell/vendor/autoload
+-    // if not, use the default /usr/share/nushell/vendor/autoload
+-
+-    // check to see if NU_VENDOR_AUTOLOAD_DIR env var is set, if not, use the default
+-    Some(
+-        option_env!("NU_VENDOR_AUTOLOAD_DIR")
+-            .map(String::from)
+-            .unwrap_or_else(|| {
+-                if cfg!(windows) {
+-                    let all_user_profile = match engine_state.get_env_var("ALLUSERPROFILE") {
+-                        Some(v) => format!(
+-                            "{}\\nushell\\vendor\\autoload",
+-                            v.coerce_string().unwrap_or("C:\\ProgramData".into())
+-                        ),
+-                        None => "C:\\ProgramData\\nushell\\vendor\\autoload".into(),
+-                    };
+-                    all_user_profile
+-                } else {
+-                    // In non-Windows environments, if NU_VENDOR_AUTOLOAD_DIR is not set
+-                    // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
+-                    // otherwise default to /usr/share/nushell/vendor/autoload
+-                    option_env!("PREFIX").map(String::from).map_or_else(
+-                        || "/usr/local/share/nushell/vendor/autoload".into(),
+-                        |prefix| format!("{}/share/nushell/vendor/autoload", prefix),
+-                    )
+-                }
++pub fn get_vendor_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
++    // load order for autoload dirs
++    // /Library/Application Support/nushell/vendor/autoload on macOS
++    // <dir>/nushell/vendor/autoload for every dir in XDG_DATA_DIRS in reverse order on platforms other than windows. If XDG_DATA_DIRS is not set, it falls back to <PREFIX>/share if PREFIX ends in local, or <PREFIX>/local/share:<PREFIX>/share otherwise. If PREFIX is not set, fall back to /usr/local/share:/usr/share.
++    // %PROGRAM_DATA%\nushell\vendor\autoload on windows
++    // NU_VENDOR_AUTOLOAD_DIR from compile time, if env var is set at compile time
++    // if on macOS, additionally check XDG_DATA_HOME, which `dirs` is only doing on Linux
++    // <data_dir>/nushell/vendor/autoload of the current user according to the `dirs` crate
++    // NU_VENDOR_AUTOLOAD_DIR at runtime, if env var is set
++
++    let into_autoload_path_fn = |mut path: PathBuf| {
++        path.push("nushell");
++        path.push("vendor");
++        path.push("autoload");
++        path
++    };
++
++    let mut dirs = Vec::new();
++
++    let mut append_fn = |path: PathBuf| {
++        if !dirs.contains(&path) {
++            dirs.push(path)
++        }
++    };
++
++    #[cfg(target_os = "macos")]
++    std::iter::once("/Library/Application Support")
++        .map(PathBuf::from)
++        .map(into_autoload_path_fn)
++        .for_each(&mut append_fn);
++    #[cfg(unix)]
++    {
++        use std::os::unix::ffi::OsStrExt;
++
++        std::env::var_os("XDG_DATA_DIRS")
++            .or_else(|| {
++                option_env!("PREFIX").map(|prefix| {
++                    if prefix.ends_with("local") {
++                        std::ffi::OsString::from(format!("{prefix}/share"))
++                    } else {
++                        std::ffi::OsString::from(format!("{prefix}/local/share:{prefix}/share"))
++                    }
++                })
++            })
++            .unwrap_or_else(|| std::ffi::OsString::from("/usr/local/share/:/usr/share/"))
++            .as_encoded_bytes()
++            .split(|b| *b == b':')
++            .map(|split| into_autoload_path_fn(PathBuf::from(std::ffi::OsStr::from_bytes(split))))
++            .rev()
++            .for_each(&mut append_fn);
++    }
++
++    #[cfg(target_os = "windows")]
++    dirs_sys::known_folder(windows_sys::Win32::UI::Shell::FOLDERID_ProgramData)
++        .into_iter()
++        .map(into_autoload_path_fn)
++        .for_each(&mut append_fn);
++
++    option_env!("NU_VENDOR_AUTOLOAD_DIR")
++        .into_iter()
++        .map(PathBuf::from)
++        .for_each(&mut append_fn);
++
++    #[cfg(target_os = "macos")]
++    std::env::var("XDG_DATA_HOME")
++        .ok()
++        .map(PathBuf::from)
++        .or_else(|| {
++            dirs::home_dir().map(|mut home| {
++                home.push(".local");
++                home.push("share");
++                home
+             })
+-            .into(),
+-    )
++        })
++        .map(into_autoload_path_fn)
++        .into_iter()
++        .for_each(&mut append_fn);
++
++    dirs::data_dir()
++        .into_iter()
++        .map(into_autoload_path_fn)
++        .for_each(&mut append_fn);
++
++    std::env::var_os("NU_VENDOR_AUTOLOAD_DIR")
++        .into_iter()
++        .map(PathBuf::from)
++        .for_each(&mut append_fn);
++
++    dirs
+ }
+ 
+ fn eval_const_call(
+diff --git a/src/config_files.rs b/src/config_files.rs
+index 30977a6d0..cf7281960 100644
+--- a/src/config_files.rs
++++ b/src/config_files.rs
+@@ -200,8 +200,7 @@ pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack:
+         column!()
+     );
+ 
+-    // read and source vendor_autoload_files file if exists
+-    if let Some(autoload_dir) = nu_protocol::eval_const::get_vendor_autoload_dir(engine_state) {
++    for autoload_dir in nu_protocol::eval_const::get_vendor_autoload_dirs(engine_state) {
+         warn!("read_vendor_autoload_files: {}", autoload_dir.display());
+ 
+         if autoload_dir.exists() {
+-- 
+2.45.2
+

--- a/contrib/nushell/patches/autoload.patch
+++ b/contrib/nushell/patches/autoload.patch
@@ -1,0 +1,228 @@
+From f241110005006f10e16c6080ebab7abec6f3e5ce Mon Sep 17 00:00:00 2001
+From: Darren Schroeder <343840+fdncred@users.noreply.github.com>
+Date: Tue, 25 Jun 2024 20:31:54 -0500
+Subject: [PATCH] implement autoloading (#13217)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+# Description
+
+This PR implements script or module autoloading. It does this by finding
+the `$nu.vendor-autoload-dir`, lists the contents and sorts them by file
+name. These files are evaluated in that order.
+
+To see what's going on, you can use `--log-level warn`
+```
+❯ cargo r -- --log-level warn
+    Finished dev [unoptimized + debuginfo] target(s) in 0.58s
+     Running `target\debug\nu.exe --log-level warn`
+2024-06-24 09:23:20.494 PM [WARN ] nu::config_files: set_config_path() cwd: "C:\\Users\\fdncred\\source\\repos\\nushell", default_config: config.nu, key: config-path, config_file_specified: None
+2024-06-24 09:23:20.495 PM [WARN ] nu::config_files: set_config_path() cwd: "C:\\Users\\fdncred\\source\\repos\\nushell", default_config: env.nu, key: env-path, config_file_specified: None
+2024-06-24 09:23:20.629 PM [WARN ] nu::config_files: setup_config() config_file_specified: None, env_file_specified: None, login: false
+2024-06-24 09:23:20.660 PM [WARN ] nu::config_files: read_config_file() config_file_specified: None, is_env_config: true
+Hello, from env.nu
+2024-06-24 09:23:20.679 PM [WARN ] nu::config_files: read_config_file() config_file_specified: None, is_env_config: false
+Hello, from config.nu
+Hello, from defs.nu
+Activating Microsoft Visual Studio environment.
+2024-06-24 09:23:21.398 PM [WARN ] nu::config_files: read_vendor_autoload_files() src\config_files.rs:234:9
+2024-06-24 09:23:21.399 PM [WARN ] nu::config_files: read_vendor_autoload_files: C:\ProgramData\nushell\vendor\autoload
+2024-06-24 09:23:21.399 PM [WARN ] nu::config_files: AutoLoading: "C:\\ProgramData\\nushell\\vendor\\autoload\\01_get-weather.nu"
+2024-06-24 09:23:21.675 PM [WARN ] nu::config_files: AutoLoading: "C:\\ProgramData\\nushell\\vendor\\autoload\\02_temp.nu"
+2024-06-24 09:23:21.817 PM [WARN ] nu_cli::repl: Terminal doesn't support use_kitty_protocol config
+```
+
+# User-Facing Changes
+<!-- List of all changes that impact the user experience here. This
+helps us keep track of breaking changes. -->
+
+# Tests + Formatting
+<!--
+Don't forget to add tests that cover your changes.
+
+Make sure you've run and fixed any issues with these commands:
+
+- `cargo fmt --all -- --check` to check standard code formatting (`cargo
+fmt --all` applies these changes)
+- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to
+check that you're using the standard code style
+- `cargo test --workspace` to check that all tests pass (on Windows make
+sure to [enable developer
+mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
+- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the
+tests for the standard library
+
+> **Note**
+> from `nushell` you can also use the `toolkit` as follows
+> ```bash
+> use toolkit.nu # or use an `env_change` hook to activate it
+automatically
+> toolkit check pr
+> ```
+-->
+
+# After Submitting
+<!-- If your PR had any user-facing changes, update [the
+documentation](https://github.com/nushell/nushell.github.io) after the
+PR is merged, if necessary. This will help us keep the docs up to date.
+-->
+---
+ crates/nu-protocol/src/eval_const.rs | 65 +++++++++++++++++-----------
+ src/config_files.rs                  | 45 ++++++++++++++++++-
+ 2 files changed, 84 insertions(+), 26 deletions(-)
+
+diff --git a/crates/nu-protocol/src/eval_const.rs b/crates/nu-protocol/src/eval_const.rs
+index 8f6382ae4436..87913e4ee3c0 100644
+--- a/crates/nu-protocol/src/eval_const.rs
++++ b/crates/nu-protocol/src/eval_const.rs
+@@ -194,31 +194,11 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
+         // if not, use the default /usr/share/nushell/vendor/autoload
+ 
+         // check to see if NU_VENDOR_AUTOLOAD_DIR env var is set, if not, use the default
+-        Value::string(
+-            option_env!("NU_VENDOR_AUTOLOAD_DIR")
+-                .map(String::from)
+-                .unwrap_or_else(|| {
+-                    if cfg!(windows) {
+-                        let all_user_profile = match engine_state.get_env_var("ALLUSERPROFILE") {
+-                            Some(v) => format!(
+-                                "{}\\nushell\\vendor\\autoload",
+-                                v.coerce_string().unwrap_or("C:\\ProgramData".into())
+-                            ),
+-                            None => "C:\\ProgramData\\nushell\\vendor\\autoload".into(),
+-                        };
+-                        all_user_profile
+-                    } else {
+-                        // In non-Windows environments, if NU_VENDOR_AUTOLOAD_DIR is not set
+-                        // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
+-                        // otherwise default to /usr/share/nushell/vendor/autoload
+-                        option_env!("PREFIX").map(String::from).map_or_else(
+-                            || "/usr/local/share/nushell/vendor/autoload".into(),
+-                            |prefix| format!("{}/share/nushell/vendor/autoload", prefix),
+-                        )
+-                    }
+-                }),
+-            span,
+-        ),
++        if let Some(path) = get_vendor_autoload_dir(engine_state) {
++            Value::string(path.to_string_lossy(), span)
++        } else {
++            Value::error(ShellError::ConfigDirNotFound { span: Some(span) }, span)
++        },
+     );
+ 
+     record.push("temp-path", {
+@@ -275,6 +255,41 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
+     Value::record(record, span)
+ }
+ 
++pub fn get_vendor_autoload_dir(engine_state: &EngineState) -> Option<PathBuf> {
++    // pseudo code
++    // if env var NU_VENDOR_AUTOLOAD_DIR is set, in any platform, use it
++    // if not, if windows, use ALLUSERPROFILE\nushell\vendor\autoload
++    // if not, if non-windows, if env var PREFIX is set, use PREFIX/share/nushell/vendor/autoload
++    // if not, use the default /usr/share/nushell/vendor/autoload
++
++    // check to see if NU_VENDOR_AUTOLOAD_DIR env var is set, if not, use the default
++    Some(
++        option_env!("NU_VENDOR_AUTOLOAD_DIR")
++            .map(String::from)
++            .unwrap_or_else(|| {
++                if cfg!(windows) {
++                    let all_user_profile = match engine_state.get_env_var("ALLUSERPROFILE") {
++                        Some(v) => format!(
++                            "{}\\nushell\\vendor\\autoload",
++                            v.coerce_string().unwrap_or("C:\\ProgramData".into())
++                        ),
++                        None => "C:\\ProgramData\\nushell\\vendor\\autoload".into(),
++                    };
++                    all_user_profile
++                } else {
++                    // In non-Windows environments, if NU_VENDOR_AUTOLOAD_DIR is not set
++                    // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
++                    // otherwise default to /usr/share/nushell/vendor/autoload
++                    option_env!("PREFIX").map(String::from).map_or_else(
++                        || "/usr/local/share/nushell/vendor/autoload".into(),
++                        |prefix| format!("{}/share/nushell/vendor/autoload", prefix),
++                    )
++                }
++            })
++            .into(),
++    )
++}
++
+ fn eval_const_call(
+     working_set: &StateWorkingSet,
+     call: &Call,
+diff --git a/src/config_files.rs b/src/config_files.rs
+index ec4511860f04..30977a6d0e7e 100644
+--- a/src/config_files.rs
++++ b/src/config_files.rs
+@@ -9,8 +9,9 @@ use nu_protocol::{
+ };
+ use nu_utils::{get_default_config, get_default_env};
+ use std::{
++    fs,
+     fs::File,
+-    io::Write,
++    io::{Result, Write},
+     panic::{catch_unwind, AssertUnwindSafe},
+     path::Path,
+     sync::Arc,
+@@ -176,6 +177,46 @@ pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut
+     }
+ }
+ 
++fn read_and_sort_directory(path: &Path) -> Result<Vec<String>> {
++    let mut entries = Vec::new();
++
++    for entry in fs::read_dir(path)? {
++        let entry = entry?;
++        let file_name = entry.file_name();
++        let file_name_str = file_name.into_string().unwrap_or_default();
++        entries.push(file_name_str);
++    }
++
++    entries.sort();
++
++    Ok(entries)
++}
++
++pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack: &mut Stack) {
++    warn!(
++        "read_vendor_autoload_files() {}:{}:{}",
++        file!(),
++        line!(),
++        column!()
++    );
++
++    // read and source vendor_autoload_files file if exists
++    if let Some(autoload_dir) = nu_protocol::eval_const::get_vendor_autoload_dir(engine_state) {
++        warn!("read_vendor_autoload_files: {}", autoload_dir.display());
++
++        if autoload_dir.exists() {
++            let entries = read_and_sort_directory(&autoload_dir);
++            if let Ok(entries) = entries {
++                for entry in entries {
++                    let path = autoload_dir.join(entry);
++                    warn!("AutoLoading: {:?}", path);
++                    eval_config_contents(path, engine_state, stack);
++                }
++            }
++        }
++    }
++}
++
+ fn eval_default_config(
+     engine_state: &mut EngineState,
+     stack: &mut Stack,
+@@ -236,6 +277,8 @@ pub(crate) fn setup_config(
+         if is_login_shell {
+             read_loginshell_file(engine_state, stack);
+         }
++        // read and auto load vendor autoload files
++        read_vendor_autoload_files(engine_state, stack);
+     }));
+     if result.is_err() {
+         eprintln!(

--- a/contrib/nushell/template.py
+++ b/contrib/nushell/template.py
@@ -1,0 +1,22 @@
+pkgname = "nushell"
+pkgver = "0.95.0"
+pkgrel = 0
+build_style = "cargo"
+make_env = {
+    "PREFIX": "/usr",
+}
+hostmakedepends = ["cargo-auditable", "pkgconf"]
+makedepends = ["libgit2-devel", "openssl-devel", "sqlite-devel", "zstd-devel"]
+pkgdesc = "Shell with a focus on structured data"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "MIT"
+url = "https://www.nushell.sh"
+source = f"https://github.com/nushell/nushell/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "f41a0f41af3996581f9bd485cfe5d55f26dd486dc3812b386bd43439c72a6d16"
+# Checks fail with libgit2 < 1.8.1
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_shell("/usr/bin/nu")
+    self.install_license("LICENSE")

--- a/contrib/nushell/template.py
+++ b/contrib/nushell/template.py
@@ -2,6 +2,8 @@ pkgname = "nushell"
 pkgver = "0.95.0"
 pkgrel = 0
 build_style = "cargo"
+# We patch Cargo.toml and Cargo.lock
+prepare_after_patch = True
 make_env = {
     "PREFIX": "/usr",
 }

--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -1782,6 +1782,10 @@ class Template(Package):
                     "usr/share/fish/vendor_completions.d",
                     name=f"{name}.fish",
                 )
+            case "nushell":
+                self.install_file(
+                    src, "usr/share/nushell/vendor/autoload", name=f"{name}.nu"
+                )
             case _:
                 self.error(f"unknown shell: {shell}")
 
@@ -1931,6 +1935,12 @@ autopkgs = [
         "fish completions",
         "fish-shell",
         _split_fishcomp,
+    ),
+    (
+        "nucomp",
+        "nu completions",
+        "nushell",
+        lambda p: p.take("usr/share/nushell/vendor/autoload", missing_ok=True),
     ),
     (
         "locale",
@@ -2125,6 +2135,7 @@ class Subpackage(Package):
         self.take("usr/share/zsh", missing_ok=True)
         self.take("usr/share/fish/completions", missing_ok=True)
         self.take("usr/share/fish/vendor_completions.d", missing_ok=True)
+        self.take("usr/share/nushell/vendor/autoload", missing_ok=True)
         if man:
             self.take(f"usr/share/man/man[{man}]", missing_ok=True)
 


### PR DESCRIPTION
- **contrib/nushell: new package (0.95.0)**: There's a patch in here for autoloading. The patch is upstream, but not yet released. I've tested it locally, it seems to work fine as far as I can tell.
- **cbuild: split nucomp**: I've done this based on 0744645a09d3b4aff93fda6665db9e248f8ef993 and 8536d97eb4bc1eaad7c6af9a33e5b329856896d5, and while I think I understand what's happening there for the most part, I'd appreciate another look from someone else here.
- **contrib/minijinja-cli: update to 2.0.3**: Only included as an example of a tool that I know has nushell completions, allowing to try this out easily.
