### PR TITLE
main/openrc-settingsd: fixed localed reading kbd-model map from wrong location

### DIFF
--- a/main/openrc-settingsd/patches/0001-adjust-files-to-match-Chimera-s-setup.patch
+++ b/main/openrc-settingsd/patches/0001-adjust-files-to-match-Chimera-s-setup.patch
@@ -54,7 +54,7 @@ index ed07dba..1618a0f 100644
      x11_gentoo_file = g_file_new_for_path (SYSCONFDIR "/X11/xorg.conf.d/30-keyboard.conf");
      x11_systemd_file = g_file_new_for_path (SYSCONFDIR "/X11/xorg.conf.d/00-keyboard.conf");
 +#else
-+    kbd_model_map_file = g_file_new_for_path (PKGDATADIR "/openrc-settingsd/kbd-model-map");
++    kbd_model_map_file = g_file_new_for_path (PKGDATADIR "/kbd-model-map");
 +    locale_file = g_file_new_for_path (SYSCONFDIR "/locale.conf");
 +    keymaps_file = g_file_new_for_path (SYSCONFDIR "/default/keyboard");
 +    /* Use systemd-style always */

--- a/main/openrc-settingsd/template.py
+++ b/main/openrc-settingsd/template.py
@@ -1,6 +1,6 @@
 pkgname = "openrc-settingsd"
 pkgver = "1.5.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = ["-Dopenrc=disabled", "-Denv-update="]
 hostmakedepends = ["meson", "pkgconf"]


### PR DESCRIPTION
I think `openrc-settingsd` is mistakenly being appended twice. `meson.build` sets `PKGDATADIR` to `/usr/share/openrc-settingsd` and installs `kbd-model-map` there. Then localed looks for `kbd-model-map` in `PKGDATADIR "/openrc-settingsd"` which obviously it doesn't find. This looks like it might be an upstream issue too, but I couldn't say that for certain. 