### PR TITLE
contrib/helix: specify runtime installation dir explicitly

### DIFF
--- a/contrib/helix/template.py
+++ b/contrib/helix/template.py
@@ -1,6 +1,6 @@
 pkgname = "helix"
 pkgver = "24.07"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "git"]
 makedepends = ["rust-std"]
@@ -10,14 +10,13 @@ license = "MPL-2.0"
 url = "https://github.com/helix-editor/helix"
 source = f"{url}/releases/download/{pkgver}/helix-{pkgver}-source.tar.xz"
 sha256 = "44d9eb113a54a80a2891ac6374c74bcd2bce63d317f1e1c69c286a6fc919922c"
+env = {"HELIX_DEFAULT_RUNTIME": "/usr/lib/helix/runtime"}
 
 
 def do_install(self):
     self.cargo.install(wrksrc="helix-term")
-    runtime_dir = "usr/libexec/helix/runtime"
+    runtime_dir = "usr/lib/helix/runtime"
     self.install_dir(runtime_dir)
-    self.rename("usr/bin/hx", "usr/libexec/helix/hx", relative=False)
-    self.install_link("usr/bin/hx", "../libexec/helix/hx")
 
     self.install_files("runtime/queries", runtime_dir)
     self.install_files("runtime/themes", runtime_dir)


### PR DESCRIPTION
cc @wezm

Feels like the dir itself should be `/usr/lib/helix/runtime` since there is no binary there anymore, but I didn't want to do preemptive changes.