### PR TITLE
main/btrfs-progs: prevent cross build

### DIFF
--- a/main/btrfs-progs/template.py
+++ b/main/btrfs-progs/template.py
@@ -43,7 +43,8 @@ source = (
 sha256 = "43865bb272dc0ab2585de3605434d81ba217578f0897bf700cd36c14ac40652a"
 hardening = ["vis", "!cfi"]
 # non-portable testsuite assumptions, possibly FIXME
-options = ["!check"]
+# libbtrfsutils/python broken on cross
+options = ["!check", "!cross"]
 
 
 def post_install(self):


### PR DESCRIPTION
for armhf:

```
In file included from constants.c:4:
In file included from ./btrfsutilpy.h:27:
In file included from /usr/include/python3.12/Python.h:38:
/usr/include/python3.12/pyport.h:586:2: error: "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  586 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
      |  ^
1 error generated.
```