### PR TITLE
*/*: re-enable debug for go packages

### DIFF
--- a/contrib/aerc/template.py
+++ b/contrib/aerc/template.py
@@ -1,6 +1,6 @@
 pkgname = "aerc"
 pkgver = "0.18.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_cmd = "gmake"
 make_check_target = "tests"
@@ -23,8 +23,6 @@ url = "https://sr.ht/~rjarry/aerc"
 source = f"https://git.sr.ht/~rjarry/aerc/archive/{pkgver}.tar.gz"
 sha256 = "f8a2923b1749b1b0eaa9ce221121536d13974297143b597f812b11ebbef0c1bf"
 tool_flags = {"GOFLAGS": ["-tags=notmuch", "-buildmode=pie"]}
-# ppc64le objcopy
-options = ["!debug"]
 
 
 def post_prepare(self):

--- a/contrib/age/template.py
+++ b/contrib/age/template.py
@@ -1,6 +1,6 @@
 pkgname = "age"
 pkgver = "1.2.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "go"
 make_build_args = [f"-ldflags=-X main.Version={pkgver}", "./cmd/..."]
 hostmakedepends = ["go"]
@@ -11,7 +11,7 @@ url = "https://github.com/FiloSottile/age"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "cefe9e956401939ad86a9c9d7dcf843a43b6bcdf4ee7d8e4508864f227a3f6f0"
 # tests invoke network downloads for vectors
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/bluetuith/template.py
+++ b/contrib/bluetuith/template.py
@@ -1,6 +1,6 @@
 pkgname = "bluetuith"
 pkgver = "0.2.2"
-pkgrel = 3
+pkgrel = 4
 build_style = "go"
 hostmakedepends = ["go"]
 depends = ["bluez"]
@@ -10,8 +10,6 @@ license = "MIT"
 url = "https://github.com/darkhz/bluetuith"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "2a02f51c53668fa3171e642e25f268fc50fbb2438f764956fb7cd46fb786083d"
-# objcopy ppc64le fails
-options = ["!debug"]
 
 
 def post_install(self):

--- a/contrib/buildkit/template.py
+++ b/contrib/buildkit/template.py
@@ -1,6 +1,6 @@
 pkgname = "buildkit"
 pkgver = "0.15.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["./cmd/..."]
 hostmakedepends = ["go"]
@@ -11,9 +11,8 @@ license = "Apache-2.0"
 url = "https://github.com/moby/buildkit"
 source = f"https://github.com/moby/buildkit/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "ebf4b82f7379818d8fcfe5c54034e7f93c062c95f663bfd3c2a622583f62a8a4"
-# debug: objcopy ppc64
-# check: cannot work in bwrap
-options = ["!debug", "!check"]
+# cannot work in bwrap
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/chezmoi/template.py
+++ b/contrib/chezmoi/template.py
@@ -1,6 +1,6 @@
 pkgname = "chezmoi"
 pkgver = "2.51.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = [
     f"-ldflags=-X main.version={pkgver} -X 'main.builtBy=Chimera Linux'",
@@ -14,8 +14,6 @@ license = "MIT"
 url = "https://chezmoi.io"
 source = f"https://github.com/twpayne/chezmoi/archive/v{pkgver}.tar.gz"
 sha256 = "70c0c7887a42bcd77fe33faa7ba546b7eb4e933bc68065b0028de4146738ebce"
-# debug: fails to split on powerpc
-options = ["!debug"]
 
 
 def do_check(self):

--- a/contrib/cliphist/template.py
+++ b/contrib/cliphist/template.py
@@ -1,6 +1,6 @@
 pkgname = "cliphist"
 pkgver = "0.5.0"
-pkgrel = 4
+pkgrel = 5
 build_style = "go"
 hostmakedepends = ["go"]
 depends = ["wl-clipboard", "xdg-utils"]
@@ -10,5 +10,3 @@ license = "GPL-3.0-only"
 url = "https://github.com/sentriz/cliphist"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "02285cf3358a1851e34f95c0c369b27284d8d0996759d759fa2bbcb5b30fb13d"
-# objcopy fails on ppc
-options = ["!debug"]

--- a/contrib/cni-plugins/template.py
+++ b/contrib/cni-plugins/template.py
@@ -1,6 +1,6 @@
 pkgname = "cni-plugins"
 pkgver = "1.5.1"
-pkgrel = 1
+pkgrel = 2
 hostmakedepends = ["bash", "go"]
 makedepends = ["linux-headers"]
 pkgdesc = "Standard CNI plugins for containers"
@@ -9,9 +9,8 @@ license = "Apache-2.0"
 url = "https://www.cni.dev"
 source = f"https://github.com/containernetworking/plugins/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "a2eff5f064f809ee41f8f49ef8aed1f0a4093c0c772f2ce2caaee4e6f395050a"
-# objcopy fails on ppc
 # can't run tests inside namespaces
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_prepare(self):

--- a/contrib/containerd/template.py
+++ b/contrib/containerd/template.py
@@ -1,6 +1,6 @@
 pkgname = "containerd"
 pkgver = "1.7.20"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_cmd = "gmake"
 make_build_args = [
@@ -32,9 +32,8 @@ license = "Apache-2.0"
 url = "https://github.com/containerd/containerd"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "c4268561e514a2e8322bc8cdd39113d5e164fb31c2cef76f479d683395ea9bd6"
-# objcopy fails to split on ppc
 # can't run tests inside namespaces
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 if self.profile().arch == "riscv64":

--- a/contrib/croc/template.py
+++ b/contrib/croc/template.py
@@ -1,6 +1,6 @@
 pkgname = "croc"
 pkgver = "10.0.10"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "File transfer tool"
@@ -9,9 +9,8 @@ license = "MIT"
 url = "https://github.com/schollz/croc"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "0c36b63ce4c60d9cfc0d338329911e7f358d11a2a9463e2bf5a8972d9a9f4b36"
-# debug: fails to split on powerpc
 # check: needs network access
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/docker-cli/template.py
+++ b/contrib/docker-cli/template.py
@@ -1,6 +1,6 @@
 pkgname = "docker-cli"
 pkgver = "27.0.3"
-pkgrel = 2
+pkgrel = 3
 build_style = "makefile"
 _commit = "7d4bcd863a4c863e650eed02a550dfeb98560b83"
 make_cmd = "gmake"
@@ -25,8 +25,7 @@ env = {
     "VERSION": pkgver,
     "DISABLE_WARN_OUTSIDE_CONTAINER": "1",
 }
-# objcopy fails to split on ppc
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def init_build(self):

--- a/contrib/docker-compose/template.py
+++ b/contrib/docker-compose/template.py
@@ -1,6 +1,6 @@
 pkgname = "docker-compose"
 pkgver = "2.29.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = [
     "-ldflags",
@@ -15,8 +15,7 @@ license = "Apache-2.0"
 url = "https://docs.docker.com/compose"
 source = f"https://github.com/docker/compose/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "0e34f4822e6e1076e94cff203b50c0f4a624b7a2673531ec97b04d5859c9dac2"
-# need a running docker daemon
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def do_install(self):

--- a/contrib/fzf/template.py
+++ b/contrib/fzf/template.py
@@ -1,6 +1,6 @@
 pkgname = "fzf"
 pkgver = "0.54.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
 makedepends = ["ncurses-devel"]
@@ -10,8 +10,6 @@ license = "MIT"
 url = "https://github.com/junegunn/fzf"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "ce658b153254e25cf4244365d639cf3ac5b91230a20f76bd6845d88e1267a2db"
-# debug: fails to split on powerpc
-options = ["!debug"]
 
 
 def post_install(self):

--- a/contrib/go-md2man/template.py
+++ b/contrib/go-md2man/template.py
@@ -1,6 +1,6 @@
 pkgname = "go-md2man"
 pkgver = "2.0.4"
-pkgrel = 3
+pkgrel = 4
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "Markdown to manpage converter"
@@ -9,8 +9,6 @@ license = "MIT"
 url = "https://github.com/cpuguy83/go-md2man"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "b0a4c7c077ede56967deef6ab7e7696c0f46124b0b3360fd05564ec5a536f11f"
-# objcopy fails on ppc
-options = ["!debug"]
 
 
 def post_build(self):

--- a/contrib/goawk/template.py
+++ b/contrib/goawk/template.py
@@ -1,6 +1,6 @@
 pkgname = "goawk"
 pkgver = "1.27.0"
-pkgrel = 2
+pkgrel = 3
 build_style = "go"
 hostmakedepends = ["go"]
 checkdepends = ["gawk"]
@@ -10,7 +10,6 @@ license = "MIT"
 url = "https://github.com/benhoyt/goawk"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "f39d5b3ff50f3c16cbfaaa40eb01ec045092afa66988e9728661c65c0e5d6a93"
-options = ["!debug"]
 
 
 def post_install(self):

--- a/contrib/gopass/template.py
+++ b/contrib/gopass/template.py
@@ -1,6 +1,6 @@
 pkgname = "gopass"
 pkgver = "1.15.13"
-pkgrel = 3
+pkgrel = 4
 build_style = "go"
 hostmakedepends = ["go"]
 checkdepends = ["git", "gnupg"]
@@ -12,9 +12,8 @@ source = (
     f"https://github.com/gopasspw/gopass/archive/refs/tags/v{pkgver}.tar.gz"
 )
 sha256 = "8f7ee347f517bf66a7d0760e7a5ed6c948d66737559bd04fa8da594801ed9b4f"
-# debug: fails to split on powerpc
-# check: needs initialising git config
-options = ["!debug", "!check"]
+# needs initialising git config
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/gopls/template.py
+++ b/contrib/gopls/template.py
@@ -1,6 +1,6 @@
 pkgname = "gopls"
 pkgver = "0.16.1"
-pkgrel = 0
+pkgrel = 1
 build_wrksrc = "gopls"
 build_style = "go"
 hostmakedepends = ["go"]
@@ -13,9 +13,8 @@ source = (
     f"https://github.com/golang/tools/archive/refs/tags/gopls/v{pkgver}.tar.gz"
 )
 sha256 = "0805bb9d3bfa51334b4d45a3182daea3e77ecbe27f4ddc672841ec72f63ed20a"
-# debug: fails to split on powerpc
-# check: regtest/marker fails with go1.22
-options = ["!debug", "!check"]
+# regtest/marker fails with go1.22
+options = ["!check"]
 
 
 def do_prepare(self):

--- a/contrib/hut/template.py
+++ b/contrib/hut/template.py
@@ -1,6 +1,6 @@
 pkgname = "hut"
 pkgver = "0.6.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "go"
 hostmakedepends = ["go", "scdoc"]
 pkgdesc = "CLI tool for sr.ht"
@@ -9,8 +9,8 @@ license = "AGPL-3.0-only"
 url = "https://git.sr.ht/~xenrox/hut"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "f6abe54b433c30557c49aa41d351ec97ef24b4bee3f9dbc91e7db8f366592f99"
-# !cross: completions are generated with built artifact
-options = ["!debug", "!cross"]
+# completions are generated with built artifact
+options = ["!cross"]
 
 
 def post_build(self):

--- a/contrib/nerdctl/template.py
+++ b/contrib/nerdctl/template.py
@@ -1,6 +1,6 @@
 pkgname = "nerdctl"
 pkgver = "1.7.6"
-pkgrel = 3
+pkgrel = 4
 build_style = "go"
 make_build_args = ["./cmd/nerdctl"]
 hostmakedepends = ["go"]
@@ -11,10 +11,9 @@ license = "Apache-2.0"
 url = "https://github.com/containerd/nerdctl"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "9a204b15ab4a0c260a9615a0254fb91ec2ccd9815be85b0890130ef1f3920717"
-# objcopy fails to split on ppc
 # can't run tests inside namespaces
 # cross: generates completions with host binary
-options = ["!debug", "!check", "!cross"]
+options = ["!check", "!cross"]
 
 
 def post_build(self):

--- a/contrib/podman/template.py
+++ b/contrib/podman/template.py
@@ -1,6 +1,6 @@
 pkgname = "podman"
 pkgver = "5.1.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["-mod", "vendor", "./cmd/podman", "./cmd/rootlessport"]
 hostmakedepends = [
@@ -46,8 +46,7 @@ license = "Apache-2.0"
 url = "https://podman.io"
 source = f"https://github.com/containers/podman/archive/v{pkgver}.tar.gz"
 sha256 = "0e1c4202d25dc270b996583cff97d806eab88682beb9586a6813431559273fc9"
-# objcopy fails to split on ppc
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_build(self):

--- a/contrib/restic/template.py
+++ b/contrib/restic/template.py
@@ -1,6 +1,6 @@
 pkgname = "restic"
 pkgver = "0.16.5"
-pkgrel = 1
+pkgrel = 2
 build_style = "go"
 make_build_args = [f"-ldflags=-X main.version=v{pkgver}", "./cmd/restic"]
 hostmakedepends = ["go"]
@@ -10,9 +10,8 @@ license = "BSD-2-Clause"
 url = "https://restic.net"
 source = f"https://github.com/restic/restic/releases/download/v{pkgver}/restic-{pkgver}.tar.gz"
 sha256 = "2e8a57f0d1d2b90d67253d1287159dc467bdb7f3b385be2db39e7213b44672be"
-# debug: fails to split on powerpc
-# check: fails in bwrap chroot
-options = ["!debug", "!check"]
+# fails in bwrap chroot
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/rootlesskit/template.py
+++ b/contrib/rootlesskit/template.py
@@ -1,6 +1,6 @@
 pkgname = "rootlesskit"
 pkgver = "2.2.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = [
     f"-ldflags=-X github.com/rootless-containers/rootlesskit/pkg/version.Version={pkgver}",
@@ -15,4 +15,4 @@ url = "https://github.com/rootless-containers/rootlesskit"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "0075af5f14ea7ff5b1431ba30671d7c0e18e0e57453be58600293b283a9d8e2e"
 # no tests
-options = ["!debug", "!check"]
+options = ["!check"]

--- a/contrib/runc/template.py
+++ b/contrib/runc/template.py
@@ -1,6 +1,6 @@
 pkgname = "runc"
 pkgver = "1.1.13"
-pkgrel = 1
+pkgrel = 2
 build_style = "makefile"
 make_cmd = "gmake"
 make_build_args = ["all", "man", f"COMMIT=chimera-r{pkgrel}"]
@@ -22,9 +22,8 @@ license = "Apache-2.0"
 url = "https://github.com/opencontainers/runc"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "789d5749a08ef1fbe5d1999b67883206a68a4e58e6ca0151c411d678f3480b25"
-# objcopy fails on ppc
 # tests create namespaces and fail because no perms
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_extract(self):

--- a/contrib/scc/template.py
+++ b/contrib/scc/template.py
@@ -1,6 +1,6 @@
 pkgname = "scc"
 pkgver = "3.3.5"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "Fast and accurate code counter"
@@ -9,8 +9,6 @@ license = "MIT OR Unlicense"
 url = "https://github.com/boyter/scc"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "028869a7d053879a8e3f2872fdd792f165db13696918d08863475c638f08ef06"
-# objcopy fails on ppc
-options = ["!debug"]
 
 
 def post_install(self):

--- a/contrib/senpai/template.py
+++ b/contrib/senpai/template.py
@@ -1,6 +1,6 @@
 pkgname = "senpai"
 pkgver = "0.3.0"
-pkgrel = 5
+pkgrel = 6
 build_style = "go"
 make_build_args = ["./cmd/senpai"]
 hostmakedepends = ["gmake", "go", "scdoc"]
@@ -10,7 +10,6 @@ license = "ISC"
 url = "https://git.sr.ht/~delthas/senpai"
 source = f"https://git.sr.ht/~delthas/senpai/archive/v{pkgver}.tar.gz"
 sha256 = "c02f63a7d76ae13ed888fc0de17fa9fd5117dcb3c9edc5670341bf2bf3b88718"
-options = ["!debug"]
 
 
 def post_build(self):

--- a/contrib/shfmt/template.py
+++ b/contrib/shfmt/template.py
@@ -1,6 +1,6 @@
 pkgname = "shfmt"
 pkgver = "3.8.0"
-pkgrel = 4
+pkgrel = 5
 build_style = "go"
 make_build_args = [
     "-ldflags",
@@ -15,7 +15,6 @@ license = "BSD-3-Clause"
 url = "https://github.com/mvdan/sh"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "d8f28156a6ebfd36b68f5682b34ec7824bf61c3f3a38be64ad22e2fc2620bf44"
-options = ["!debug"]
 
 
 def post_install(self):

--- a/contrib/tailscale/template.py
+++ b/contrib/tailscale/template.py
@@ -1,6 +1,6 @@
 pkgname = "tailscale"
 pkgver = "1.70.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = [
     "-ldflags="
@@ -17,9 +17,8 @@ license = "BSD-3-Clause"
 url = "https://github.com/tailscale/tailscale"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f"
-# debug: fails to split on powerpc
 # check: needs network access
-options = ["!debug", "!check"]
+options = ["!check"]
 
 
 def post_install(self):

--- a/contrib/yj/template.py
+++ b/contrib/yj/template.py
@@ -1,6 +1,6 @@
 pkgname = "yj"
 pkgver = "5.1.0"
-pkgrel = 5
+pkgrel = 6
 build_style = "go"
 hostmakedepends = ["go"]
 pkgdesc = "Convert between YAML, TOML, JSON, and HCL"
@@ -9,4 +9,3 @@ license = "Apache-2.0"
 url = "https://github.com/sclevine/yj"
 source = f"{url}/archive/v{pkgver}.tar.gz"
 sha256 = "9a3e9895181d1cbd436a1b02ccf47579afacd181c73f341e697a8fe74f74f99d"
-options = ["!debug"]


### PR DESCRIPTION
objcopy failing on ppc64le is not an issue anymore

can also just postpone this to the next go bump global rebuild if you want @nekopsykose 