### PR TITLE
contrib/emptty: new package (0.12.1)

### DIFF
--- a/contrib/emptty/files/dinit-service
+++ b/contrib/emptty/files/dinit-service
@@ -1,0 +1,4 @@
+type = process
+command = /usr/bin/emptty -d
+smooth-recovery = true
+depends-on = login.target

--- a/contrib/emptty/template.py
+++ b/contrib/emptty/template.py
@@ -1,0 +1,21 @@
+pkgname = "emptty"
+pkgver = "0.12.1"
+pkgrel = 0
+build_style = "go"
+make_env = {"CGO_ENABLED": "1"}
+hostmakedepends = ["go"]
+makedepends = ["libx11-devel", "linux-pam-devel"]
+pkgdesc = "TTY display manager"
+maintainer = "Michal Tvrznik <emporeor@gmail.com>"
+license = "MIT"
+url = "https://github.com/tvrzna/emptty"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "0220230cdee3dedd7ccd6f2d81c57b29e2169159c8e28263d58abaf20093ce23"
+
+
+def post_install(self):
+    self.install_file("res/pam", "usr/lib/pam.d", name="emptty")
+    self.install_file("res/conf", "etc/emptty")
+    self.install_service(self.files_path / "dinit-service", "emptty")
+    self.install_license("LICENSE")
+    self.install_man("res/emptty.1")


### PR DESCRIPTION
### emptty
[emptty](https://github.com/tvrzna/emptty) is CLI display manager on TTY, that supports Xorg and Wayland desktops. 

### Cross-compilation
#### Tier 1
- `ppc64le` - ok
- `aarch64` - ok
- `x86_64` - ok

#### Tier 3
- `ppc64` - unknown to Golang (after adding into `etc/build_profiles/ppc64.ini` it fails on "-buildmode=pie not supported on linux/ppc64")
- `riscv664` - ok

#### Untiered
`armhf`, `armv7`, `ppc` - `libx11` cannot be crosscompiled (`emptty` supports `noxlib` tag, it is theoretically possible to make it work)
