### PR TITLE
contrib/ddclient: disable automake treating warnings as error

### DIFF
--- a/contrib/ddclient/patches/disable_automake_warnings_as_errors.patch
+++ b/contrib/ddclient/patches/disable_automake_warnings_as_errors.patch
@@ -1,0 +1,12 @@
+diff --color -ruN ddclient-3.11.2/configure.ac ddclient-3.11.2-patched/configure.ac
+--- ddclient-3.11.2/configure.ac	2023-11-23 12:06:21.000000000 +0000
++++ ddclient-3.11.2-patched/configure.ac	2024-08-01 20:34:10.320269673 +0000
+@@ -11,7 +11,7 @@
+ # tap-driver.sh, so build-aux/tap-driver.sh is checked in to keep the
+ # above AC_REQUIRE_AUX_FILE line from causing configure to complain
+ # about a mising file if the user has Automake 1.11.)
+-AM_INIT_AUTOMAKE([1.11 -Wall -Werror foreign subdir-objects parallel-tests])
++AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects parallel-tests])
+ AM_SILENT_RULES
+ 
+ AC_PROG_MKDIR_P

--- a/contrib/ddclient/template.py
+++ b/contrib/ddclient/template.py
@@ -1,6 +1,6 @@
 pkgname = "ddclient"
 pkgver = "3.11.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 hostmakedepends = [
     "automake",


### PR DESCRIPTION
Not sure when this broke, but packaging ddclient started giving
```
automake: warnings are treated as errors
Makefile.am:20: warning: escaping \# comment markers is not portable
autoreconf: error: automake failed with exit status: 1
```