### PR TITLE
contrib/containers-common: clean up unused skopeo source

### DIFF
--- a/contrib/containers-common/template.py
+++ b/contrib/containers-common/template.py
@@ -1,6 +1,6 @@
 pkgname = "containers-common"
 pkgver = "0.60.0"
-pkgrel = 0
+pkgrel = 1
 make_cmd = "gmake"
 make_build_args = ["-C", "docs"]
 make_install_args = [*make_build_args]
@@ -13,20 +13,17 @@ _base_url = url.removesuffix("/common")
 _common_ver = pkgver
 _storage_ver = "1.55.0"
 _image_ver = "5.32.0"
-_skopeo_ver = "1.16.0"
 _shortnames_ver = "2023.02.20"
 source = [
     f"{_base_url}/common/archive/v{_common_ver}.tar.gz",
     f"{_base_url}/storage/archive/v{_storage_ver}.tar.gz",
     f"{_base_url}/image/archive/v{_image_ver}.tar.gz",
-    f"{_base_url}/skopeo/archive/v{_skopeo_ver}.tar.gz",
     f"{_base_url}/shortnames/archive/v{_shortnames_ver}.tar.gz",
 ]
 sha256 = [
     "c9f9a2ba78c69234b78d4b168bb2f70e3459e66d7931e68fde449af9b52e0062",
     "d6c2d3af9e0f674c248477d521d0f8fc5eac050c65e2fd3f823cc42502b22847",
     "f7582d2b4fed4967921ff154752cc33e8f319a232b561710a3e2872ba754945d",
-    "fed91fd067605460ef33431163227471b1e85c8768203fc393345d6ffd645448",
     "336ba679d4e510d2eb59cb11321bf16a36ef2dba58024e79dd76b89ffee539e6",
 ]
 # no tests


### PR DESCRIPTION
It is not used since 7bc50781a3d992709c70fe3392cae83fa7b12286
