### PR TITLE
contrib/*: drop `-mod vendor` from build args

### DIFF
--- a/contrib/podman/template.py
+++ b/contrib/podman/template.py
@@ -5,8 +5,6 @@ build_style = "go"
 # for install.bin compat
 make_dir = "bin"
 make_build_args = [
-    "-mod",
-    "vendor",
     "./cmd/podman",
     "./cmd/rootlessport",
 ]

--- a/contrib/skopeo/template.py
+++ b/contrib/skopeo/template.py
@@ -5,8 +5,6 @@ build_style = "go"
 # for compatibility with Makefile targets
 make_dir = "bin"
 make_build_args = [
-    "-mod",
-    "vendor",
     "./cmd/skopeo",
 ]
 hostmakedepends = [


### PR DESCRIPTION
With the current package go versions this is the default.

No version bump as there is no change in how build happens.
