### PR TITLE
contrib/skopeo: link against system libsqlite3

### DIFF
--- a/contrib/skopeo/template.py
+++ b/contrib/skopeo/template.py
@@ -1,6 +1,6 @@
 pkgname = "skopeo"
 pkgver = "1.16.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 # for compatibility with Makefile targets
 make_dir = "bin"
@@ -18,9 +18,13 @@ makedepends = [
     "gpgme-devel",
     "libbtrfs-devel",
     "linux-headers",
+    "sqlite-devel",
 ]
 depends = [
     "containers-common",
+]
+go_build_tags = [
+    "libsqlite3",
 ]
 pkgdesc = "OCI image and repo manipulation tool"
 maintainer = "Radosław Piliszek <radek@piliszek.it>"


### PR DESCRIPTION
This is to be on the same page as other container tools from the
same family: buildah and podman. There does not seem to exist
a behavioural change in my (and probably any typical) use.
It seems Debian does it this way too, but Arch does not, so
it is strictly a matter of builder's preference.
