### PR TITLE
main/openjpeg: run tests

### DIFF
--- a/main/openjpeg/template.py
+++ b/main/openjpeg/template.py
@@ -1,5 +1,6 @@
 pkgname = "openjpeg"
 pkgver = "2.5.2"
+_test_commit = "1f4c3cfb0f0266f9731db8a168186a9462358f28"
 pkgrel = 0
 build_style = "cmake"
 # we skip static libs or they get referenced in cmake devel files
@@ -10,11 +11,20 @@ pkgdesc = "Open-source JPEG 2000 codec written in C"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-2-Clause"
 url = "https://www.openjpeg.org"
-source = f"https://github.com/uclouvain/openjpeg/archive/v{pkgver}.tar.gz"
-sha256 = "90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a"
+source = [
+    f"https://github.com/uclouvain/openjpeg/archive/v{pkgver}.tar.gz",
+    f"https://github.com/uclouvain/openjpeg-data/archive/{_test_commit}.tar.gz",
+]
+source_paths = [".", "data"]
+sha256 = [
+    "90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a",
+    "502631509e911eec543c7b300bf699020bfd88f118275a4a225326266385f469",
+]
 hardening = ["!vis", "!cfi"]
-# missing test data
-options = ["!check"]
+
+
+def init_configure(self):
+    self.configure_args += [f"-DOPJ_DATA_ROOT:PATH={self.chroot_cwd}/data"]
 
 
 def post_install(self):


### PR DESCRIPTION
draft because i get 30 failing tests that i need to figure out:
```
98% tests passed, 30 tests failed out of 1577

Total Test time (real) = 141.10 sec

The following tests FAILED:
	1145 - NR-DEC-issue226.j2k-74-decode (Failed)
	1146 - NR-DEC-issue226.j2k-74-decode-md5 (Failed)
	1205 - NR-DEC-p1_04.j2k-124-decode-md5 (Failed)
	1219 - NR-DEC-p1_04.j2k-131-decode-md5 (Failed)
	1221 - NR-DEC-p1_04.j2k-132-decode-md5 (Failed)
	1237 - NR-DEC-p1_04.j2k-140-decode-md5 (Failed)
	1241 - NR-DEC-p1_06.j2k-142-decode-md5 (Failed)
	1243 - NR-DEC-p1_06.j2k-143-decode-md5 (Failed)
	1255 - NR-DEC-p1_06.j2k-149-decode-md5 (Failed)
	1287 - NR-DEC-p0_04.j2k-166-decode-md5 (Failed)
	1289 - NR-DEC-p0_04.j2k-167-decode-md5 (Failed)
	1291 - NR-DEC-p0_04.j2k-168-decode-md5 (Failed)
	1295 - NR-DEC-p0_04.j2k-170-decode-md5 (Failed)
	1385 - NR-DEC-a1_mono.j2c-215-decode-md5 (Failed)
	1387 - NR-DEC-a1_mono.j2c-216-decode-md5 (Failed)
	1389 - NR-DEC-a1_mono.j2c-217-decode-md5 (Failed)
	1401 - NR-DEC-a1_mono.j2c-223-decode-md5 (Failed)
	1439 - NR-DEC-basn6a08.jp2-242-decode-md5 (Failed)
	1443 - NR-DEC-basn6a08.jp2-244-decode-md5 (Failed)
	1445 - NR-DEC-basn6a08.jp2-245-decode-md5 (Failed)
	1447 - NR-DEC-basn6a08.jp2-246-decode-md5 (Failed)
	1451 - NR-DEC-basn6a08.jp2-248-decode-md5 (Failed)
	1455 - NR-DEC-basn6a08.jp2-250-decode-md5 (Failed)
	1542 - NR-DEC-file1.jp2-298-decode-md5 (Failed)
	1550 - NR-DEC-file1.jp2-302-decode-md5 (Failed)
	1556 - NR-DEC-db11217111510058.jp2-306-decode-md5 (Failed)
	1558 - NR-DEC-tnsot_zero.jp2-307-decode-md5 (Failed)
	1563 - NR-DEC-Bretagne1_ht.j2k-310-decode-md5 (Failed)
	1565 - NR-DEC-Bretagne1_ht_lossy.j2k-311-decode-md5 (Failed)
	1573 - Found-But-No-Test-small_world_non_consecutive_tilepart_tlm.jp2 (Failed)
```

also note that the testdata archive is fairly massive (~500 MB)