### PR TITLE
cbuild: correct check for empty soname in scanelf

### DIFF
--- a/src/cbuild/core/scanelf.py
+++ b/src/cbuild/core/scanelf.py
@@ -239,7 +239,7 @@ def _scan_one(fpath):
     inf.close()
 
     # sanitize
-    if soname and len(soname) == 0:
+    if soname is not None and len(soname) == 0:
         soname = None
 
     return (


### PR DESCRIPTION
the original condition evaluates to false for empty strings because they are falsy in python