### PR TITLE
main/clang-rt-crt-cross: add missing gmake dependency

### DIFF
--- a/main/clang-rt-crt-cross/template.py
+++ b/main/clang-rt-crt-cross/template.py
@@ -1,7 +1,7 @@
 pkgname = "clang-rt-crt-cross"
 _musl_ver = "1.2.5"
 pkgver = "18.1.8"
-pkgrel = 0
+pkgrel = 1
 build_wrksrc = f"llvm-project-{pkgver}.src"
 build_style = "cmake"
 configure_args = [
@@ -33,6 +33,7 @@ configure_args = [
 hostmakedepends = [
     "clang-tools-extra",
     "cmake",
+    "gmake",
     "ninja",
     "llvm-devel",
     "python",


### PR DESCRIPTION
not sure how that would end up missing? a transitive dependency that got changed?