### PR TITLE
cbuild: skip apk update before upgrade call

### DIFF
--- a/src/cbuild/core/chroot.py
+++ b/src/cbuild/core/chroot.py
@@ -564,9 +564,12 @@ def update(pkg):
     _prepare_etc()
 
     with flock.lock(flock.apklock(host_cpu())):
-        apki.call_chroot("update", ["-q"], pkg, check=True, use_stage=True)
         apki.call_chroot(
-            "upgrade", ["--available"], pkg, check=True, use_stage=True
+            "upgrade",
+            ["--available", "--cache-max-age", "0"],
+            pkg,
+            check=True,
+            use_stage=True,
         )
 
     # this is bootstrap-update


### PR DESCRIPTION
does it in one :)  

---

this isn't strictly identical; `--update-cache` defaults to a 1 minute cache age so repeated calls for a minute will just no-op. it can be made identical by passing `0` to it to always update just like update does, and then the behaviour should be actually the same

but maybe it's not super relevant to miss a minute?