### PR TITLE
cbuild: make print-build-graph aware of -a

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -1289,7 +1289,7 @@ def do_print_build_graph(tgt):
         try:
             tp = template.Template(
                 template.sanitize_pkgname(pkgn),
-                chroot.host_cpu(),
+                opt_arch or chroot.host_cpu(),
                 True,
                 False,
                 (1, 1),


### PR DESCRIPTION
(note that this does not print any hostdepends for cross, since `Template.get_build_deps` doesn't include those)