### PR TITLE
user/cppcheck: new package

### DIFF
--- a/contrib/tinyxml2-devel
+++ b/contrib/tinyxml2-devel
@@ -1,0 +1,1 @@
+tinyxml2

--- a/contrib/tinyxml2/template.py
+++ b/contrib/tinyxml2/template.py
@@ -1,0 +1,21 @@
+pkgname = "tinyxml2"
+pkgver = "10.0.0"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DBUILD_SHARED_LIBS=ON"]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+]
+pkgdesc = "C++ XML parser"
+maintainer = "xunil-cloud <river_electron@proton.me>"
+license = "Zlib"
+url = "https://github.com/leethomason/tinyxml2"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839"
+
+
+@subpackage("tinyxml2-devel")
+def _(self):
+    return self.default_devel()

--- a/user/cppcheck-gui
+++ b/user/cppcheck-gui
@@ -1,0 +1,1 @@
+cppcheck

--- a/user/cppcheck/patches/feenableexcept.patch
+++ b/user/cppcheck/patches/feenableexcept.patch
@@ -1,0 +1,15 @@
+Patch-Source: https://gitlab.alpinelinux.org/alpine/aports/-/blob/8dd3d8861eff2b4b5171d861e9cde50a92adb93b/community/cppcheck/feenableexcept.patch
+diff --git a/test/signal/test-signalhandler.cpp b/test/signal/test-signalhandler.cpp
+index 023137c2a..92b3fe8af 100644
+--- a/test/signal/test-signalhandler.cpp
++++ b/test/signal/test-signalhandler.cpp
+@@ -46,9 +46,6 @@
+ 
+ /*static*/ void my_fpe()
+ {
+-#if !defined(__APPLE__)
+-    feenableexcept(FE_ALL_EXCEPT); // TODO: check result
+-#endif
+     std::feraiseexcept(FE_UNDERFLOW | FE_DIVBYZERO); // TODO: check result
+     // TODO: to generate this via code
+ }

--- a/user/cppcheck/patches/translation-files.patch
+++ b/user/cppcheck/patches/translation-files.patch
@@ -1,0 +1,42 @@
+From 47403d3b7e355c69dcf391ed4cfdcf4c895a7fdd Mon Sep 17 00:00:00 2001
+From: xunil-cloud <freed602om@gmail.com>
+Date: Fri, 23 Aug 2024 22:55:27 +0800
+Subject: [PATCH] translation files
+
+---
+ gui/CMakeLists.txt         | 2 +-
+ gui/translationhandler.cpp | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gui/CMakeLists.txt b/gui/CMakeLists.txt
+index 31fe62eaf..4656be53a 100644
+--- a/gui/CMakeLists.txt
++++ b/gui/CMakeLists.txt
+@@ -72,7 +72,7 @@ CheckOptions:
+     endif()
+ 
+     install(TARGETS cppcheck-gui RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)
+-    install(FILES ${qms} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)
++    install(FILES ${qms} DESTINATION ${CMAKE_INSTALL_DATADIR}/cppcheck/translations COMPONENT applications)
+ 
+     install(FILES cppcheck-gui.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+ 
+diff --git a/gui/translationhandler.cpp b/gui/translationhandler.cpp
+index aae7e2608..6cbcfab71 100644
+--- a/gui/translationhandler.cpp
++++ b/gui/translationhandler.cpp
+@@ -102,8 +102,10 @@ bool TranslationHandler::setLanguage(const QString &code)
+         else if (QFile::exists(datadir + "/" + mTranslations[index].mFilename + ".qm"))
+             translationFile = datadir + "/" + mTranslations[index].mFilename + ".qm";
+ 
+-        else
++        else if (QFile::exists(appPath + "/" + mTranslations[index].mFilename + ".qm"))
+             translationFile = appPath + "/" + mTranslations[index].mFilename + ".qm";
++        else
++            translationFile = "/usr/share/cppcheck/translations/" + mTranslations[index].mFilename + ".qm";
+ 
+         if (!mTranslator->load(translationFile)) {
+             failure = true;
+-- 
+2.46.0
+

--- a/user/cppcheck/template.py
+++ b/user/cppcheck/template.py
@@ -1,0 +1,59 @@
+pkgname = "cppcheck"
+pkgver = "2.14.2"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DUSE_MATCHCOMPILER=ON",
+    "-DFILESDIR=/usr/share/cppcheck",
+    "-DBUILD_GUI=ON",
+    "-DUSE_QT6=ON",
+    "-DWITH_QCHART=ON",
+    "-DBUILD_TESTS=ON",
+    "-DUSE_BUNDLED_TINYXML2=OFF",
+]
+hostmakedepends = [
+    "cmake",
+    "docbook-xsl-nons",
+    "gmake",
+    "ninja",
+    "pkgconf",
+    "xsltproc",
+]
+makedepends = [
+    "qt6-qtbase-devel",
+    "qt6-qtcharts-devel",
+    "qt6-qttools-devel",
+    "tinyxml2-devel",
+]
+pkgdesc = "Static analysis of C/C++ code"
+maintainer = "xunil-cloud <river_electron@proton.me>"
+license = "GPL-3.0-or-later"
+url = "https://cppcheck.sourceforge.io"
+source = f"https://github.com/danmar/cppcheck/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "9c3acea5f489336bd83a8ea33917a9a04a80c56d874bf270287e7de27acf2d00"
+# TestSymbolDatabase::enum14 test failed
+# (0x7FFFFFFFFFFFFFFF + 1 cause signed overflow)
+hardening = ["!int"]
+
+
+def post_build(self):
+    self.do(
+        "make", "DB2MAN=/usr/share/xsl-nons/docbook/manpages/docbook.xsl", "man"
+    )
+
+
+def post_install(self):
+    self.install_man("cppcheck.1")
+
+
+@subpackage("cppcheck-gui")
+def _(self):
+    self.subdesc = "GUI tool"
+    self.depends = [self.parent]
+
+    return [
+        "usr/bin/cppcheck-gui",
+        "usr/share/applications",
+        "usr/share/cppcheck/translations",
+        "usr/share/icons",
+    ]


### PR DESCRIPTION
`HAVE_RULES` (I believe this let you define your own rules and cppcheck will check for you) require pcre, so it's not enabled. And `feenableexcept.patch` is copied from [alpine](https://git.alpinelinux.org/aports/tree/community/cppcheck/feenableexcept.patch).