### PR TITLE
cbuild: require fish completions to go in vendor_completions.d

### DIFF
--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -2346,11 +2346,6 @@ def _split_dlinks(pkg):
     pkg.take("usr/lib/dinit.d/user/boot.d", missing_ok=True)
 
 
-def _split_fishcomp(pkg):
-    pkg.take("usr/share/fish/completions", missing_ok=True)
-    pkg.take("usr/share/fish/vendor_completions.d", missing_ok=True)
-
-
 def _split_locale(pkg):
     pkg.take("usr/share/locale", missing_ok=True)
     # lxqt uses its own special dir since it uses a .qm format
@@ -2405,7 +2400,9 @@ autopkgs = [
         "fishcomp",
         "fish completions",
         "fish-shell",
-        _split_fishcomp,
+        lambda p: p.take(
+            "usr/share/fish/vendor_completions.d", missing_ok=True
+        ),
     ),
     (
         "nucomp",
@@ -2624,7 +2621,6 @@ class Subpackage(Package):
         self.take("usr/bin/*")
         self.take("usr/share/bash-completion", missing_ok=True)
         self.take("usr/share/zsh", missing_ok=True)
-        self.take("usr/share/fish/completions", missing_ok=True)
         self.take("usr/share/fish/vendor_completions.d", missing_ok=True)
         self.take("usr/share/nushell/vendor/autoload", missing_ok=True)
         if man:

--- a/src/cbuild/hooks/pre_pkg/098_lint.py
+++ b/src/cbuild/hooks/pre_pkg/098_lint.py
@@ -199,6 +199,15 @@ def invoke(pkg):
             pkg.log_red(f"{d} should go in /usr/share, not /etc")
             lintfail = True
 
+    if (
+        pkg.pkgname != "fish-shell"
+        and (pkg.destdir / "usr/share/fish/completions").exists()
+    ):
+        pkg.log_red(
+            "fish completions should go in usr/share/fish/vendor_completions.d, not usr/share/fish/completions"
+        )
+        lintfail = True
+
     # stuff in /usr that should go in /usr/share
     for d in ["man", "doc", "dict"]:
         if (pkg.destdir / "usr" / d).exists():


### PR DESCRIPTION
that is the correct directory to install third-party fish completions to rather than usr/share/fish/completions, as explained in https://fishshell.com/docs/current/completions.html#where-to-put-completions

there doesn't seem to be any package installing to the incorrect location at the moment, but add lint anyway just in case

related: #2767