### PR TITLE
cbuild: add rust to binaries section in meson crossfile

### DIFF
--- a/src/cbuild/util/meson.py
+++ b/src/cbuild/util/meson.py
@@ -33,6 +33,7 @@ readelf = '{pkg.get_tool("READELF")}'
 objcopy = '{pkg.get_tool("OBJCOPY")}'
 pkgconfig = '{pkg.get_tool("PKG_CONFIG")}'
 llvm-config = '/usr/bin/llvm-config'
+rust = ['rustc', '--target', '{pkg.profile().triplet}', '--sysroot', '{pkg.profile().sysroot / 'usr'}']
 
 [properties]
 needs_exe_wrapper = true


### PR DESCRIPTION
fixes cross builds for meson packages that have `rust` as a language passed to `project`:

meson.build:1:0: ERROR: 'rust' compiler binary not defined in cross file [binaries] section