### PR TITLE
contrib/merkuro: fix launching merkuro-calendar

### DIFF
--- a/contrib/merkuro/patches/fix-contact_plugin-load.patch
+++ b/contrib/merkuro/patches/fix-contact_plugin-load.patch
@@ -1,0 +1,16 @@
+merkuro-calendar otherwise fails to launch with:
+QQmlApplicationEngine failed to load component
+qrc:/main.qml:328:19: Type MainDrawer unavailable
+qrc:/MainDrawer.qml:341:9: Type CheckableCollectionNavigationView unavailable
+qrc:/CheckableCollectionNavigationView.qml:11:1: Failed to extract plugin meta data from '/usr/lib/qt6/qml/org/kde/merkuro/contact/libmerkuro_contact_pluginplugin.so': '/usr/lib/qt6/qml/org/kde/merkuro/contact/libmerkuro_contact_pluginplugin.so' is not a Qt plugin (metadata not found)
+
+--- a/src/contacts/CMakeLists.txt
++++ b/src/contacts/CMakeLists.txt
+@@ -76,6 +76,7 @@ target_sources(merkuro_contact_plugin PRIVATE
+ 
+ ecm_add_qml_module(merkuro_contact_plugin
+     URI "org.kde.merkuro.contact"
++    GENERATE_PLUGIN_SOURCE
+     RESOURCES
+         resources/fallbackBackground.png
+ )

--- a/contrib/merkuro/template.py
+++ b/contrib/merkuro/template.py
@@ -1,6 +1,6 @@
 pkgname = "merkuro"
 pkgver = "24.08.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 make_check_args = ["-E", "akonadi-sqlite-.*"]
 make_check_wrapper = ["wlheadless-run", "--"]


### PR DESCRIPTION
`merkuro-calendar` was failing to launch with:
```
QQmlApplicationEngine failed to load component
qrc:/main.qml:328:19: Type MainDrawer unavailable
qrc:/MainDrawer.qml:341:9: Type CheckableCollectionNavigationView unavailable
qrc:/CheckableCollectionNavigationView.qml:11:1: Failed to extract plugin meta data from '/usr/lib/qt6/qml/org/kde/merkuro/contact/libmerkuro_contact_pluginplugin.so': '/usr/lib/qt6/qml/org/kde/merkuro/contact/libmerkuro_contact_pluginplugin.so' is not a Qt plugin (metadata not found)
```