### PR TITLE
contrib/python-websockets: update to 0.13

### DIFF
--- a/contrib/python-websockets/template.py
+++ b/contrib/python-websockets/template.py
@@ -1,5 +1,5 @@
 pkgname = "python-websockets"
-pkgver = "12.0"
+pkgver = "13.0"
 pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = [
@@ -12,12 +12,12 @@ makedepends = ["python-devel"]
 checkdepends = ["python-pytest"]
 depends = ["python"]
 pkgdesc = "Library for building WebSocket servers and clients in Python"
-maintainer = "Orphaned <orphaned@chimera-linux.org>"
+maintainer = "c7s <c7s@kasku.net>"
 license = "BSD-3-Clause"
 url = "https://github.com/python-websockets/websockets"
 # pypi tarball doesn't ship tests
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "49978ae3f2aedf1c40ce9031c547fb766deaf7e86c3ec9677f0f5991bdc160ec"
+sha256 = "b07a0f5272289d6f02045992d5af427a77af4e74167e26e5c20ed799596802ed"
 # tests require a network connection :^)
 options = ["!check"]
 


### PR DESCRIPTION
I just needed this locally for something, I'm not sure what yt-dlp uses it for but it's the only thing that depends on it, so I haven't tested that beyond just checking yt-dlp still runs.