### PR TITLE
main/lldb: backport python api fix

### DIFF
--- a/main/lldb/patches/fix-python-api.patch
+++ b/main/lldb/patches/fix-python-api.patch
@@ -1,0 +1,75 @@
+From b937713b2733f2da9de4919b3da881ca0ea0aa04 Mon Sep 17 00:00:00 2001
+From: Jonas Devlieghere <jonas@devlieghere.com>
+Date: Fri, 16 Feb 2024 22:56:28 -0800
+Subject: [PATCH] [lldb] Call Import_AppendInittab exactly once before
+ Py_Initialize
+
+The Python documentation [1] says that `PyImport_AppendInittab` should
+be called before `Py_Initialize()`. Starting with Python 3.12, this is
+enforced with a fatal error:
+
+  Fatal Python error: PyImport_AppendInittab: PyImport_AppendInittab()
+  may not be called after Py_Initialize()
+
+This commit ensures we only modify the table of built-in modules if
+Python hasn't been initialized. For Python embedded in LLDB, that means
+this happen exactly once, before the first call to `Py_Initialize`,
+which becomes a NO-OP after. However, when lldb is imported in an
+existing Python interpreter, Python will have already been initialized,
+but by definition, the lldb module will already have been loaded, so
+it's safe to skip adding it (again).
+
+This fixes #70453.
+
+[1] https://docs.python.org/3.12/c-api/import.html#c.PyImport_AppendInittab
+---
+ .../Python/ScriptInterpreterPython.cpp        | 32 +++++++++++--------
+ 1 file changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+index dadcde612614ba..a1ad3f569ec71a 100644
+--- a/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
++++ b/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+@@ -97,24 +97,28 @@ struct InitializePythonRAII {
+   InitializePythonRAII() {
+     InitializePythonHome();
+ 
++    // The table of built-in modules can only be extended before Python is
++    // initialized.
++    if (!Py_IsInitialized()) {
+ #ifdef LLDB_USE_LIBEDIT_READLINE_COMPAT_MODULE
+-    // Python's readline is incompatible with libedit being linked into lldb.
+-    // Provide a patched version local to the embedded interpreter.
+-    bool ReadlinePatched = false;
+-    for (auto *p = PyImport_Inittab; p->name != nullptr; p++) {
+-      if (strcmp(p->name, "readline") == 0) {
+-        p->initfunc = initlldb_readline;
+-        break;
++      // Python's readline is incompatible with libedit being linked into lldb.
++      // Provide a patched version local to the embedded interpreter.
++      bool ReadlinePatched = false;
++      for (auto *p = PyImport_Inittab; p->name != nullptr; p++) {
++        if (strcmp(p->name, "readline") == 0) {
++          p->initfunc = initlldb_readline;
++          break;
++        }
++      }
++      if (!ReadlinePatched) {
++        PyImport_AppendInittab("readline", initlldb_readline);
++        ReadlinePatched = true;
+       }
+-    }
+-    if (!ReadlinePatched) {
+-      PyImport_AppendInittab("readline", initlldb_readline);
+-      ReadlinePatched = true;
+-    }
+ #endif
+ 
+-    // Register _lldb as a built-in module.
+-    PyImport_AppendInittab("_lldb", LLDBSwigPyInit);
++      // Register _lldb as a built-in module.
++      PyImport_AppendInittab("_lldb", LLDBSwigPyInit);
++    }
+ 
+ // Python < 3.2 and Python >= 3.2 reversed the ordering requirements for
+ // calling `Py_Initialize` and `PyEval_InitThreads`.  < 3.2 requires that you

--- a/main/lldb/template.py
+++ b/main/lldb/template.py
@@ -1,6 +1,6 @@
 pkgname = "lldb"
 pkgver = "18.1.8"
-pkgrel = 1
+pkgrel = 2
 build_style = "cmake"
 configure_args = [
     "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
fixes:

```
Python 3.12.5 (main, Aug 23 2024, 00:07:38) [Clang 18.1.8] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import lldb
Fatal Python error: PyImport_AppendInittab: PyImport_AppendInittab() may not be called after Py_Initialize()
Python runtime state: initialized

Current thread 0x000070d3919922c8 (most recent call first):
  File "/usr/lib/python3.12/site-packages/lldb/__init__.py", line 4394 in Initialize
  File "/usr/lib/python3.12/site-packages/lldb/__init__.py", line 16172 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 995 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<stdin>", line 1 in <module>

Extension modules: lldb._lldb (total: 1)
fish: Job 1, 'python' terminated by signal SIGABRT (Abort)
```