### PR TITLE
user/niri: add libEGL as runtime-dependency

### DIFF
--- a/user/niri/template.py
+++ b/user/niri/template.py
@@ -1,6 +1,6 @@
 pkgname = "niri"
 pkgver = "0.1.8"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 make_build_args = [
     "--no-default-features",
@@ -24,6 +24,9 @@ makedepends = [
     "pixman-devel",
     "rust-std",
     "udev-devel",
+]
+depends = [
+    "so:libEGL.so.1!libegl",
 ]
 pkgdesc = "Scrollable-tiling wayland compositor"
 maintainer = "psykose <alice@ayaya.dev>"


### PR DESCRIPTION
Whenever running Niri within a virtual machine with OpenGL capabilities (virgl) or a host with an OpenGL-supported CPU Smithay tries to load `libEGL.so` to provide support for OpenGL functionality. LibEGL is also listed as a runtime dependency in most of niri's official packages. Trying to run it within that context just crashes the program, thus it would be nice to have this as a requirement for the package