### PR TITLE
user/anyrun: new package

### DIFF
--- a/user/anyrun/template.py
+++ b/user/anyrun/template.py
@@ -1,5 +1,5 @@
 pkgname = "anyrun"
-pkgver = "0.0.0"
+pkgver = "0_git20240716"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "pkgconf"]

--- a/user/anyrun/template.py
+++ b/user/anyrun/template.py
@@ -15,8 +15,8 @@ pkgdesc = "Wayland native krunner-like runner"
 maintainer = "tulilirockz <tulilirockz@outlook.com>"
 license = "GPL-3.0-or-later"
 url = "https://github.com/anyrun-org/anyrun"
-source = f"{url}/archive/refs/heads/master.tar.gz"
-sha256 = "bbb80457b32621b2faba708a88f2e0c7339c24d34cdd36026c85c3449ad1f7c6"
+source = f"{url}/archive/c6101a31a80b51e32e96f6a77616b609770172e0.tar.gz"
+sha256 = "1bcbba5301280249966fbcdd9e2d2fdec3586a3bade1c8bd8904e1d77fb1492f"
 # check: no meaningful tests at all
 options = ["!check"]
 

--- a/user/anyrun/template.py
+++ b/user/anyrun/template.py
@@ -1,0 +1,26 @@
+pkgname = "anyrun"
+pkgver = "0.0.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable", "pkgconf"]
+makedepends = [
+    "gdk-pixbuf",
+    "glib-devel",
+    "gtk+3-devel",
+    "gtk-layer-shell-devel",
+    "pango-devel",
+    "rust-std",
+]
+pkgdesc = "Wayland native krunner-like runner"
+maintainer = "tulilirockz <tulilirockz@outlook.com>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/anyrun-org/anyrun"
+source = f"{url}/archive/refs/heads/master.tar.gz"
+sha256 = "bbb80457b32621b2faba708a88f2e0c7339c24d34cdd36026c85c3449ad1f7c6"
+# check: no meaningful tests at all
+options = ["!check"]
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/{pkgname}")
+    self.install_license("LICENSE")


### PR DESCRIPTION
Anyrun is a gtk-based krunner-like application launcher. Everything seems to be building fine, tests are not meaningful (0 tests, 0 succeded, 0 failed). The only issue seems to be with the releases that they have, none! I dont know exactly what to do here, as a workaround I just put the package release as 0.0.0 and pulled off of master