### PR TITLE
user/transmission: new package (4.0.6)

### DIFF
--- a/user/transmission-daemon
+++ b/user/transmission-daemon
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission-devel
+++ b/user/transmission-devel
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission-devel-static
+++ b/user/transmission-devel-static
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission-gtk
+++ b/user/transmission-gtk
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission-progs
+++ b/user/transmission-progs
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission-qt
+++ b/user/transmission-qt
@@ -1,0 +1,1 @@
+transmission

--- a/user/transmission/files/sysusers.conf
+++ b/user/transmission/files/sysusers.conf
@@ -1,0 +1,1 @@
+u _transmission - "transmission daemon" /var/lib/transmission-daemon /usr/bin/nologin

--- a/user/transmission/files/tmpfiles.conf
+++ b/user/transmission/files/tmpfiles.conf
@@ -1,0 +1,2 @@
+d /var/lib/transmission-daemon 0755 _transmission _transmission
+d /etc/transmission-daemon 0755 _transmission _transmission

--- a/user/transmission/files/transmission-daemon
+++ b/user/transmission/files/transmission-daemon
@@ -1,0 +1,6 @@
+type = process
+command = /usr/bin/transmission-daemon --foreground --config-dir /etc/transmission-daemon --download-dir /var/lib/transmission-daemon
+depends-on = network.target
+depends-on = local.target
+logfile = /var/log/transmission-daemon.log
+run-as = _transmission

--- a/user/transmission/patches/miniupnpc.patch
+++ b/user/transmission/patches/miniupnpc.patch
@@ -1,0 +1,18 @@
+--- a/libtransmission/port-forwarding-upnp.cc
++++ b/libtransmission/port-forwarding-upnp.cc
+@@ -261,8 +261,13 @@ tr_port_forwarding_state tr_upnpPulse(
+ 
+         FreeUPNPUrls(&handle->urls);
+         auto lanaddr = std::array<char, TR_ADDRSTRLEN>{};
+-        if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1) ==
+-            UPNP_IGD_VALID_CONNECTED)
++        if (
++#if (MINIUPNPC_API_VERSION >= 18)
++            UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1, nullptr, 0)
++#else
++            UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1)
++#endif
++            == UPNP_IGD_VALID_CONNECTED)
+         {
+             tr_logAddInfo(fmt::format(_("Found Internet Gateway Device '{url}'"), fmt::arg("url", handle->urls.controlURL)));
+             tr_logAddInfo(fmt::format(_("Local Address is '{address}'"), fmt::arg("address", lanaddr.data())));

--- a/user/transmission/template.py
+++ b/user/transmission/template.py
@@ -1,0 +1,111 @@
+pkgname = "transmission"
+pkgver = "4.0.6"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DENABLE_DAEMON=ON",
+    "-DENABLE_GTK=ON",
+    "-DENABLE_QT=ON",
+    "-DENABLE_CLI=ON",
+    "-DINSTALL_LIB=ON",
+    "-DUSE_SYSTEM_DEFLATE=ON",
+    "-DUSE_SYSTEM_EVENT2=ON",
+    "-DUSE_SYSTEM_MINIUPNPC=ON",
+    "-DUSE_SYSTEM_PSL=ON",
+    "-DUSE_SYSTEM_GTEST=ON",
+]
+# needs net
+make_check_args = ["-E", "LT.DhtTest.usesBootstrapFile"]
+hostmakedepends = [
+    "cmake",
+    "gettext",
+    "libxml2-progs",
+    "ninja",
+    "pkgconf",
+]
+makedepends = [
+    "gtest-devel",
+    "gtkmm-devel",
+    "libcurl-devel",
+    "libdeflate-devel",
+    "libevent-devel",
+    "libpsl-devel",
+    "linux-headers",
+    "miniupnpc-devel",
+    "qt6-qtbase-devel",
+    "qt6-qtsvg-devel",
+    "qt6-qttools-devel",
+]
+pkgdesc = "BitTorrent client"
+maintainer = "tulilirockz <tulilirockz@outlook.com>"
+license = "GPL-2.0-or-later"
+url = "https://github.com/transmission/transmission"
+source = f"{url}/releases/download/{pkgver}/transmission-{pkgver}.tar.xz"
+sha256 = "2a38fe6d8a23991680b691c277a335f8875bdeca2b97c6b26b598bc9c7b0c45f"
+
+
+def pre_install(self):
+    self.install_sysusers(self.files_path / "sysusers.conf")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
+    self.install_service(self.files_path / "transmission-daemon")
+
+
+@subpackage("transmission-devel-static")
+def _(self):
+    return ["lib:libtransmission.a"]
+
+
+@subpackage("transmission-devel")
+def _(self):
+    # static-only lib so just pull it
+    self.depends = [self.with_pkgver("transmission-devel-static")]
+    return self.default_devel()
+
+
+@subpackage("transmission-daemon")
+def _(self):
+    self.subdesc = "daemon"
+    return [
+        "cmd:transmission-daemon",
+        "etc/dinit.d/transmission-daemon",
+        "usr/lib/sysusers.d/transmission.conf",
+        "usr/lib/tmpfiles.d/transmission.conf",
+        "usr/share/transmission/public_html",
+    ]
+
+
+@subpackage("transmission-qt")
+def _(self):
+    self.subdesc = "QT client"
+    # icons left in base package
+    self.depends = [self.parent]
+    return [
+        "cmd:transmission-qt",
+        "usr/share/applications/transmission-qt.desktop",
+        "usr/share/transmission/translations",
+    ]
+
+
+@subpackage("transmission-gtk")
+def _(self):
+    self.subdesc = "GTK client"
+    # icons left in base package
+    self.depends = [self.parent]
+    return [
+        "cmd:transmission-gtk",
+        "usr/share/applications/transmission-gtk.desktop",
+        "usr/share/locale",
+        "usr/share/metainfo/transmission-gtk.metainfo.xml",
+    ]
+
+
+@subpackage("transmission-progs")
+def _(self):
+    self.subdesc = "CLI tools"
+    return [
+        "cmd:transmission-cli",
+        "cmd:transmission-edit",
+        "cmd:transmission-show",
+        "cmd:transmission-create",
+        "cmd:transmission-remote",
+    ]


### PR DESCRIPTION
The 4.0.6 version does not have any of the `third-party` submodules fetched, and I was fetching from the wrong tarball when I was trying to build this. It shouldve mostly built but the build process gets halted right at the end due to [this issue](https://bugs.gentoo.org/915804). Also ideally maybe separating the libs, daemon, cli, gtk and qt versions into subpackages seems nice, I havent done that since I havent gotten a proper build yet