### PR TITLE
contrib/yt-dlp: add mutagen as runtime dependency

### DIFF
--- a/contrib/yt-dlp/template.py
+++ b/contrib/yt-dlp/template.py
@@ -9,7 +9,7 @@ hostmakedepends = [
     "python-installer",
     "python-wheel",
 ]
-depends = ["python-certifi"]
+depends = ["mutagen", "python-certifi"]
 checkdepends = [
     "python-brotli",
     "python-pytest-xdist",


### PR DESCRIPTION
This MR adds the mutagen audio processing module to yt-dlp as a runtime package, it is necessary for the `--audio-format` (or any other audio processing) argument to work 