### PR TITLE
contrib/virt-manager: add virglrenderer as runtime dependency

### DIFF
--- a/contrib/virt-manager/template.py
+++ b/contrib/virt-manager/template.py
@@ -52,6 +52,7 @@ depends = [
     "gtksourceview4",
     "libvirt-glib",
     "spice-gtk",
+    "virglrenderer",
     "vte-gtk3",
 ]
 checkdepends = ["python-pytest", *_deps]


### PR DESCRIPTION
VirglRenderer is a renderer for OpenGL in virtual machines, providing hardware-accelerated GPU processing to the virtual machines through OpenGL using the SPICE protocol, although it is not strictly required for virt-manager, it is required for the "use OpenGL" functionality in SPICE for the virtual machines.