### PR TITLE
user/newsflash: new package (3.3.4)

### DIFF
--- a/user/newsflash/patches/meson-cargo.patch
+++ b/user/newsflash/patches/meson-cargo.patch
@@ -1,0 +1,25 @@
+--- a/src/meson.build	2024-07-29 18:41:10.000000000 -0300
++++ b/src/meson.build	2024-09-05 12:47:17.284826436 -0300
+@@ -31,7 +31,6 @@
+   message('Building in debug mode')
+ endif
+ 
+-cargo_env = [ 'CARGO_HOME=' + meson.project_build_root() / 'cargo-home' ]
+ 
+ cargo_build = custom_target(
+   'cargo-build',
+@@ -39,14 +38,8 @@
+   build_always_stale: true,
+   output: base_id,
+   console: true,
+-  install: true,
+-  install_dir: bindir,
+   command: [
+-    'env',
+-    cargo_env,
+     cargo, 'build',
+     cargo_options,
+-    '&&',
+-    'cp', 'src' / rust_target / 'news_flash_gtk', '@OUTPUT@',
+   ]
+ )

--- a/user/newsflash/template.py
+++ b/user/newsflash/template.py
@@ -1,0 +1,46 @@
+pkgname = "newsflash"
+pkgver = "3.3.4"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = [
+    "blueprint-compiler",
+    "cargo-auditable",
+    "desktop-file-utils",
+    "gettext",
+    "meson",
+    "pkgconf",
+]
+makedepends = [
+    "clapper-devel",
+    "libadwaita-devel",
+    "libxml2-devel",
+    "openssl-devel",
+    "rust-std",
+    "webkitgtk4-devel",
+]
+pkgdesc = "Feed reader designed for the GNOME desktop"
+maintainer = "tulilirockz <tulilirockz@outlook.com>"
+license = "GPL-3.0-or-later"
+url = "https://gitlab.com/news-flash/news_flash_gtk"
+source = f"{url}/-/archive/v.{pkgver}/news_flash_gtk-v.{pkgver}.tar.gz"
+sha256 = "f408f4c2d1e1507008ef583868b8482708d13269b86b8e22d2ba73da9c93a0ae"
+
+
+def post_patch(self):
+    from cbuild.util import cargo
+
+    cargo.Cargo(self, wrksrc=".").vendor()
+
+
+def init_build(self):
+    from cbuild.util import cargo
+
+    renv = cargo.get_environment(self)
+    self.make_env.update(renv)
+
+
+def post_install(self):
+    self.install_bin(
+        f"build/src/{self.profile().triplet}/release/news_flash_gtk",
+        name="io.gitlab.news_flash.NewsFlash",
+    )

--- a/user/newsflash/update.py
+++ b/user/newsflash/update.py
@@ -1,0 +1,2 @@
+url = "https://gitlab.com/news-flash/news_flash_gtk/-/tags"
+pattern = r"news_flash_gtk-v.([\d.]+).tar"


### PR DESCRIPTION
Had to do a workaround because the last part of the build tried to copy a non-existent file over to usr/bin, making a stub then installing it properly seems to work fine!