### PR TITLE
contrib/swtpm: create state dir with propper permissions

### DIFF
--- a/contrib/swtpm/files/tmpfiles.conf
+++ b/contrib/swtpm/files/tmpfiles.conf
@@ -1,0 +1,11 @@
+# Create swtpm state directory
+
+d /var/lib/swtpm-localca 0750 tss root
+
+# ensure correct permissions
+z /var/lib/swtpm-localca/certserial 644 tss tss
+z /var/lib/swtpm-localca/issuercert.pem 644 tss tss
+z /var/lib/swtpm-localca/signkey.pem 640 tss tss
+z /var/lib/swtpm-localca/swtpm-localca-rootca-cert.pem 644 tss tss
+z /var/lib/swtpm-localca/swtpm-localca-rootca-privkey.pem 640 tss tss
+z /var/lib/swtpm-localca/.lock.swtpm-localca 644 tss tss

--- a/contrib/swtpm/template.py
+++ b/contrib/swtpm/template.py
@@ -1,6 +1,6 @@
 pkgname = "swtpm"
 pkgver = "0.9.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--with-gnutls",
@@ -38,6 +38,7 @@ sha256 = "9679ca171e8aaa3c4e4053e8bc1d10c8dabf0220bd4b16aba78743511c25f731"
 
 def post_install(self):
     self.install_license("LICENSE")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
 
 
 @subpackage("swtpm-libs")


### PR DESCRIPTION
When creating vm with tpm with libvirt `/var/lib/swtpm-localca` is created with root ownership, this modifies the directory and files in it to have propper permissions.