### PR TITLE
cargo auditable wrapper and riscv64 fix

### DIFF
--- a/contrib/amberol/template.py
+++ b/contrib/amberol/template.py
@@ -1,9 +1,9 @@
 pkgname = "amberol"
 pkgver = "0.10.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gettext",
     "meson",

--- a/contrib/bcachefs-tools/template.py
+++ b/contrib/bcachefs-tools/template.py
@@ -1,13 +1,13 @@
 pkgname = "bcachefs-tools"
 pkgver = "1.11.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_install_args = [
     "ROOT_SBINDIR=/usr/bin",
     "TRIPLET=" + self.profile().triplet,
 ]
 make_use_env = True
-hostmakedepends = ["cargo", "pkgconf"]
+hostmakedepends = ["cargo-auditable", "pkgconf"]
 makedepends = [
     "clang-devel",
     "keyutils-devel",

--- a/contrib/flare/template.py
+++ b/contrib/flare/template.py
@@ -1,10 +1,10 @@
 pkgname = "flare"
 pkgver = "0.15.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = [
     "blueprint-compiler",
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gettext",
     "meson",

--- a/contrib/glycin-loaders/template.py
+++ b/contrib/glycin-loaders/template.py
@@ -1,9 +1,9 @@
 pkgname = "glycin-loaders"
 pkgver = "1.0.1"
-pkgrel = 2
+pkgrel = 3
 build_style = "meson"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "gettext",
     "meson",
     "pkgconf",

--- a/contrib/helvum/template.py
+++ b/contrib/helvum/template.py
@@ -1,10 +1,10 @@
 pkgname = "helvum"
 pkgver = "0.5.1"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 configure_args = ["--buildtype=release"]
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gtk-update-icon-cache",
     "meson",

--- a/contrib/kdepim-addons/template.py
+++ b/contrib/kdepim-addons/template.py
@@ -1,6 +1,6 @@
 pkgname = "kdepim-addons"
 pkgver = "24.08.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 make_check_wrapper = [
     "dbus-run-session",
@@ -9,7 +9,7 @@ make_check_wrapper = [
     "--",
 ]
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "cmake",
     "corrosion",
     "extra-cmake-modules",

--- a/contrib/key-rack/template.py
+++ b/contrib/key-rack/template.py
@@ -1,9 +1,9 @@
 pkgname = "key-rack"
 pkgver = "0.4.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "gettext",
     "meson",
     "pkgconf",

--- a/contrib/loupe/template.py
+++ b/contrib/loupe/template.py
@@ -1,9 +1,9 @@
 pkgname = "loupe"
 pkgver = "46.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gettext",
     "glib",

--- a/contrib/python-maturin/template.py
+++ b/contrib/python-maturin/template.py
@@ -1,12 +1,12 @@
 pkgname = "python-maturin"
 pkgver = "1.7.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "python_pep517"
 make_build_env = {
     "MATURIN_SETUP_ARGS": "--features=full,native-tls,password-storage"
 }
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "pkgconf",
     "python-build",
     "python-installer",

--- a/contrib/ruff/template.py
+++ b/contrib/ruff/template.py
@@ -3,7 +3,7 @@ pkgver = "0.6.4"
 pkgrel = 1
 build_style = "python_pep517"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "pkgconf",
     "python-build",
     "python-installer",

--- a/contrib/uv/template.py
+++ b/contrib/uv/template.py
@@ -1,9 +1,9 @@
 pkgname = "uv"
 pkgver = "0.4.7"
-pkgrel = 0
+pkgrel = 1
 build_style = "python_pep517"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "pkgconf",
     "python-build",
     "python-installer",

--- a/main/cargo-auditable-bootstrap/template.py
+++ b/main/cargo-auditable-bootstrap/template.py
@@ -1,7 +1,7 @@
 # Keep in sync with cargo-auditable
 pkgname = "cargo-auditable-bootstrap"
 pkgver = "0.6.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 make_build_args = ["-p", "cargo-auditable"]
 make_check_args = [

--- a/main/cargo-auditable/patches/0001-Fix-detection-of-riscv64-linux-android-target-featur.patch
+++ b/main/cargo-auditable/patches/0001-Fix-detection-of-riscv64-linux-android-target-featur.patch
@@ -1,0 +1,41 @@
+From 999656a574c2bf9db2a0aed1c7ad245f5de8926a Mon Sep 17 00:00:00 2001
+From: "Sergey \"Shnatsel\" Davidoff" <shnatsel@gmail.com>
+Date: Sat, 7 Sep 2024 22:39:00 +0100
+Subject: [PATCH] Fix detection of `riscv64-linux-android` target features
+
+---
+ cargo-auditable/src/object_file.rs | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/cargo-auditable/src/object_file.rs b/cargo-auditable/src/object_file.rs
+index 6dcb9bc..5d4808f 100644
+--- a/cargo-auditable/src/object_file.rs
++++ b/cargo-auditable/src/object_file.rs
+@@ -194,6 +194,12 @@ fn riscv_features(target_triple: &str) -> String {
+     if extensions.contains('g') {
+         extensions.push_str("imadf");
+     }
++    // Most but not all riscv targets declare target features.
++    // A notable exception is `riscv64-linux-android`.
++    // We assume that all Linux-capable targets are -gc.
++    if target_triple.contains("linux") {
++        extensions.push_str("imadfc");
++    }
+     extensions
+ }
+ 
+@@ -234,6 +240,11 @@ mod tests {
+         assert!(!features.contains('c'));
+         assert!(!features.contains('d'));
+         assert!(features.contains('f'));
++        // real-world Android riscv target
++        let features = riscv_features("riscv64-linux-android");
++        assert!(features.contains('c'));
++        assert!(features.contains('d'));
++        assert!(features.contains('f'));
+     }
+ 
+     #[test]
+-- 
+2.46.0
+

--- a/main/cargo-auditable/template.py
+++ b/main/cargo-auditable/template.py
@@ -1,7 +1,7 @@
 # Keep in sync with cargo-auditable-bootstrap
 pkgname = "cargo-auditable"
 pkgver = "0.6.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 make_build_args = ["-p", "cargo-auditable"]
 make_check_args = [

--- a/main/gnome-tour/template.py
+++ b/main/gnome-tour/template.py
@@ -1,9 +1,9 @@
 pkgname = "gnome-tour"
 pkgver = "46.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 hostmakedepends = [
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gettext",
     "glib-devel",

--- a/main/snapshot/template.py
+++ b/main/snapshot/template.py
@@ -1,10 +1,10 @@
 pkgname = "snapshot"
 pkgver = "46.3"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 hostmakedepends = [
     "appstream",
-    "cargo",
+    "cargo-auditable",
     "desktop-file-utils",
     "gettext",
     "glib-devel",

--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -136,10 +136,6 @@ class Cargo:
             self.template.bldroot_path / "usr/bin/cargo-auditable"
         ).exists()
 
-        # fails to link
-        if tmpl.profile().arch == "riscv64":
-            auditable = False
-
         cargo = ["cargo", "auditable"] if auditable else ["cargo"]
         return self.template.do(
             *wrapper,

--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -132,15 +132,10 @@ class Cargo:
                 hint="ensure .cargo/config.toml is used instead",
             )
 
-        auditable = (
-            self.template.bldroot_path / "usr/bin/cargo-auditable"
-        ).exists()
-
-        cargo = ["cargo", "auditable"] if auditable else ["cargo"]
         return self.template.do(
             *wrapper,
             *ewrapper,
-            *cargo,
+            "cargo",
             command,
             *bargs,
             *args,

--- a/src/cbuild/wrappers/cargo.sh
+++ b/src/cbuild/wrappers/cargo.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -n "$CBUILD_NO_CARGO_AUDITABLE" ]; then
+    exec /usr/bin/cargo "$@"
+elif command -v cargo-auditable >/dev/null; then
+    exec /usr/bin/cargo auditable "$@"
+else
+    exec /usr/bin/cargo "$@"
+fi


### PR DESCRIPTION
- **main/cargo-auditable: fix usage on riscv64**: This problem came up in https://github.com/chimera-linux/cports/pull/2879. The patch is already merged upstream, but we're picking it here because it's not clear yet when a new release will be cut.
- **cbuild: reenable cargo-auditable on riscv64**: With the problem fixed above, it should be possible to reenable cargo-auditable on riscv64.
- **cbuild: use wrapper to enable cargo-auditable**: As suggested in https://github.com/chimera-linux/cports/pull/2879#issuecomment-2336414310, using a wrapper improves this more because we don't have to patch meson builds to get auditable builds.
