### PR TITLE
cbuild: use chunked iteration of hash calculation

### DIFF
--- a/src/cbuild/hooks/fetch/000_sources.py
+++ b/src/cbuild/hooks/fetch/000_sources.py
@@ -11,7 +11,14 @@ from multiprocessing.pool import ThreadPool
 
 
 def get_cksum(dfile, pkg):
-    return hashlib.sha256(dfile.read_bytes()).hexdigest()
+    hash = hashlib.sha256()
+    with open(dfile, "rb") as f:
+        while True:
+            data = f.read(65536)  # 64 KiB chunks
+            if not data:
+                break
+            hash.update(data)
+    return hash.hexdigest()
 
 
 def make_link(dfile, cksum):


### PR DESCRIPTION
the current method buffers the entire file in memory- so for 6gb chromium tarballs, it takes 6gb of memory.

incidentally, doing it this way is also like 30-40% faster for the same chromium tarball, so that's nice