### PR TITLE
main/libdbi: disable docs and fix build

### DIFF
--- a/main/libdbi/template.py
+++ b/main/libdbi/template.py
@@ -1,8 +1,9 @@
 pkgname = "libdbi"
 pkgver = "0.9.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
-hostmakedepends = ["pkgconf"]
+configure_args = ["--disable-docs"]
+hostmakedepends = ["automake", "libtool", "pkgconf"]
 pkgdesc = "Database-independent abstraction layer for C"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "LGPL-2.0-or-later"
@@ -16,6 +17,3 @@ sha256 = "dafb6cdca524c628df832b6dd0bf8fabceb103248edb21762c02d3068fca4503"
 @subpackage("libdbi-devel")
 def _(self):
     return self.default_devel()
-
-
-configure_gen = []


### PR DESCRIPTION
Disable docs building since it requires openjade.  While here, add
automake and libtool dependencies and remove empty configure_gen.
