### PR TITLE
cbuild: disable gnu_configure dependency tracking by default

### DIFF
--- a/src/cbuild/util/gnu_configure.py
+++ b/src/cbuild/util/gnu_configure.py
@@ -89,6 +89,7 @@ def configure(
         "--mandir=/usr/share/man",
         "--infodir=/usr/share/info",
         "--localstatedir=/var",
+        "--disable-dependency-tracking",
     ]
 
     # autoconf cache


### PR DESCRIPTION
based on the documentation at
https://www.gnu.org/software/automake/manual/html_node/Dependency-Tracking.html 
this is only useful to help incremental rebuilds when e.g. editing a header post-build and then re-running make. we never do this in normal build, so it's a free speedup to always skip this.

(and if it breaks some template it's easy to toggle it back on, but i think it doesn't break anything currently)