### PR TITLE
main/libcxx-mingw-w64: disable scp hardening

### DIFF
--- a/main/libcxx-mingw-w64/template.py
+++ b/main/libcxx-mingw-w64/template.py
@@ -43,6 +43,8 @@ license = "Apache-2.0 WITH LLVM-exception AND NCSA"
 url = "https://llvm.org"
 source = f"https://github.com/llvm/llvm-project/releases/download/llvmorg-{pkgver}/llvm-project-{pkgver}.src.tar.xz"
 sha256 = "0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
+# scp: irrelevant for windows
+hardening = ["!scp"]
 # crosstoolchain
 options = ["!check", "empty", "!relr"]
 


### PR DESCRIPTION
silences the following warning:

```
clang: warning: argument unused during compilation: '-fstack-clash-protection' [-Wunused-command-line-argument]
```