### PR TITLE
user/papers: update to 47.0

### DIFF
--- a/user/papers/template.py
+++ b/user/papers/template.py
@@ -1,5 +1,5 @@
 pkgname = "papers"
-pkgver = "46.2"
+pkgver = "47.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -37,7 +37,7 @@ maintainer = "tulilirockz <tulilirockz@outlook.com>"
 license = "GPL-2.0-or-later"
 url = "https://gitlab.gnome.org/GNOME/Incubator/papers"
 source = f"{url}/-/archive/{pkgver}.tar.gz"
-sha256 = "675fc379c3758bfd95438131497c23320df90c7f7e86ba8648927fe586cdbafe"
+sha256 = "6bcb1c352909f6179b6e9d71a6a3607ebba616826ab5a4113f28fc97aeadab96"
 
 
 def post_patch(self):


### PR DESCRIPTION
This is technically not a GNOME core app, should it even be updated separately right now? - I had sent a PR updating epiphany and @q66 said that they would update GNOME in its entirety
