### PR TITLE
user/openttd: new package

### DIFF
--- a/user/openttd-locale
+++ b/user/openttd-locale
@@ -1,0 +1,1 @@
+openttd

--- a/user/openttd/patches/musl-random.patch
+++ b/user/openttd/patches/musl-random.patch
@@ -1,0 +1,20 @@
+--- a/src/core/random_func.cpp
++++ b/src/core/random_func.cpp
+@@ -26,7 +26,7 @@
+ #	include <bcrypt.h>
+ #elif defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
+ // No includes required.
+-#elif defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 25)))
++#elif defined(__linux__)
+ #	include <sys/random.h>
+ #elif defined(__EMSCRIPTEN__)
+ #	include <emscripten.h>
+@@ -100,7 +100,7 @@
+ #elif defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+ 	arc4random_buf(buf.data(), buf.size());
+ 	return;
+-#elif defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 25)))
++#elif defined(__linux__)
+ 	auto res = getrandom(buf.data(), buf.size(), 0);
+ 	if (res > 0 && static_cast<size_t>(res) == buf.size()) return;
+ #elif defined(__EMSCRIPTEN__)

--- a/user/openttd/patches/no-sse4.patch
+++ b/user/openttd/patches/no-sse4.patch
@@ -1,0 +1,14 @@
+Patch-Source: https://git.alpinelinux.org/aports/tree/testing/openttd/no-sse4.patch?id=631059433ebe8b46a288746a64d4ab1699be1558
+this sets the sources to use sse4 instructions, which is above our baseline.
+it also enables sse4 on pure-x86 with our builds, so best to disable
+--- a/cmake/FindSSE.cmake
++++ b/cmake/FindSSE.cmake
+@@ -12,6 +12,7 @@
+     #include <xmmintrin.h>
+     #include <smmintrin.h>
+     #include <tmmintrin.h>
+-    int main() { return 0; }"
++    # die!
++    int main() { *(int *)0 = 0; }"
+     SSE_FOUND
+ )

--- a/user/openttd/patches/redefs-fix.patch
+++ b/user/openttd/patches/redefs-fix.patch
@@ -1,0 +1,10 @@
+--- a/cmake/CompileFlags.cmake
++++ b/cmake/CompileFlags.cmake
+@@ -30,7 +30,6 @@
+     # it does not appear to support the $<> tags.
+     add_compile_options(
+         "$<$<CONFIG:Debug>:-D_DEBUG>"
+-        "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>" # FORTIFY_SOURCE should only be used in non-debug builds (requires -O1+)
+     )
+     if(MINGW)
+         add_link_options(

--- a/user/openttd/template.py
+++ b/user/openttd/template.py
@@ -1,0 +1,38 @@
+pkgname = "openttd"
+pkgver = "14.1"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = [
+    "fluidsynth-devel",
+    "fontconfig-devel",
+    "freetype-devel",
+    "harfbuzz-devel",
+    "libcurl-devel",
+    "libpng-devel",
+    "lzo-devel",
+    "icu-devel",
+    "sdl-devel",
+    "xz-devel",
+    "zlib-ng-devel",
+]
+pkgdesc = "Simulation game based upon Transport Tycoon Deluxe"
+maintainer = "breakgimme <adam@plock.com>"
+license = "GPL-2.0-or-later"
+url = "https://openttd.org"
+source = f"https://cdn.openttd.org/openttd-releases/{pkgver}/openttd-{pkgver}-source.tar.xz"
+sha256 = "2c14c8f01f44148c4f2c88c169a30abcdb002eb128a92b9adb76baa76b013494"
+# SetBitIterator tests (src/tests/bitmath_func.cpp) fail with int enabled (and the game crashes when the tests are skipped)
+hardening = ["!int"]
+# can't cross compile due to https://github.com/OpenTTD/OpenTTD/issues/8249
+options = ["!cross"]
+
+
+def check(self):
+    self.do("./build/openttd_test")
+
+
+@subpackage("openttd-locale")
+def _(self):
+    self.install_if = [self.parent, "base-locale"]
+    return ["usr/share/games/openttd/lang/*[!english]*.lng"]

--- a/user/openttd/update.py
+++ b/user/openttd/update.py
@@ -1,0 +1,2 @@
+url = "https://cdn.openttd.org/openttd-releases/latest.yaml"
+pattern = r"version:\s*([\d.]+)"


### PR DESCRIPTION
i've disabled cross-compilation for this package because binaries that are compiled are used later in the build process and i don't see a way to do this (or do this sensibly at least) in cbuild with the upstream solution (https://github.com/OpenTTD/OpenTTD/pull/8350)
please correct me if i'm wrong though