### PR TITLE
user/opentabletdriver-udev: new package

### DIFF
--- a/user/opentabletdriver-udev/patches/git.patch
+++ b/user/opentabletdriver-udev/patches/git.patch
@@ -1,0 +1,20 @@
+--- generate-rules.sh	2024-09-22 02:10:25.521129020 -0300
++++ generate-rules.sh	2024-09-22 02:11:43.889844039 -0300
+@@ -8,7 +8,7 @@
+   echo "  -h, --help                              Print this help message"
+ }
+ 
+-for c in git jq tr awk sed; do
++for c in jq tr awk sed; do
+   command -v $c > /dev/null
+   if [[ $? > 0 ]]; then
+     echo "Error: Command $c not found in \$PATH." >&2
+@@ -23,7 +23,7 @@
+ shopt -s globstar
+ set -eu
+ 
+-OTD_CONFIGURATIONS="${OTD_CONFIGURATIONS:="$(git rev-parse --show-toplevel)/OpenTabletDriver.Configurations/Configurations"}"
++OTD_CONFIGURATIONS="./OpenTabletDriver.Configurations/Configurations"
+ 
+ while [ $# -gt 0 ]; do
+   case "$1" in

--- a/user/opentabletdriver-udev/patches/uinput.patch
+++ b/user/opentabletdriver-udev/patches/uinput.patch
@@ -1,0 +1,11 @@
+--- generate-rules.sh	2024-09-22 03:37:18.488334658 -0300
++++ generate-rules.sh	2024-09-22 03:37:26.436277278 -0300
+@@ -55,7 +55,6 @@
+ }
+ 
+ echo \# OpenTabletDriver udev rules \(https://github.com/OpenTabletDriver/OpenTabletDriver\)
+-echo KERNEL==\"uinput\", SUBSYSTEM==\"misc\", OPTIONS+=\"static_node=uinput\", TAG+=\"uaccess\", TAG+=\"udev-acl\"
+ echo KERNEL==\"js[0-9]*\", SUBSYSTEM==\"input\", ATTRS{name}==\"OpenTabletDriver Virtual Tablet\", RUN+=\"/usr/bin/env rm %E{DEVNAME}\"
+ 
+ IFS=':'
+

--- a/user/opentabletdriver-udev/template.py
+++ b/user/opentabletdriver-udev/template.py
@@ -1,0 +1,23 @@
+pkgname = "opentabletdriver-udev"
+pkgver = "0.6.4.0"
+pkgrel = 0
+hostmakedepends = ["bash", "jq"]
+pkgdesc = "Udev rules for OpenTabletDriver"
+maintainer = "tulilirockz <tulilirockz@outlook.com>"
+license = "LGPL-3.0-or-later"
+url = "https://opentabletdriver.net"
+source = f"https://github.com/OpenTabletDriver/OpenTabletDriver/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "1ad04f4a32b54b9b62bd944b0196abb6613873b19c269abcc9f9e94c1dc3027f"
+
+
+def build(self):
+    with open(f"{self.cwd}/99-opentabletdriver.rules", "w") as o:
+        self.do("./generate-rules.sh", stdout=o)
+
+
+def install(self):
+    self.install_file("99-opentabletdriver.rules", "usr/lib/udev/rules.d")
+    self.install_file(
+        "eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf",
+        "usr/lib/modprobe.d",
+    )


### PR DESCRIPTION
This adds some Udev rules so that the flatpak version of OpenTabletDriver works fine, just needed to create a group to share the rules to any user, but thats all
