### PR TITLE
user/forgejo-runner: new package

### DIFF
--- a/user/forgejo-runner/files/docker_host.env
+++ b/user/forgejo-runner/files/docker_host.env
@@ -1,0 +1,1 @@
+DOCKER_HOST=unix:///run/podman/podman.sock

--- a/user/forgejo-runner/files/forgejo-runner
+++ b/user/forgejo-runner/files/forgejo-runner
@@ -1,0 +1,7 @@
+type = process
+command = /usr/bin/forgejo-runner daemon
+working-dir = /var/lib/forgejo-runner/$1
+env-file = /usr/share/forgejo-runner/docker_host.env
+depends-on = podman
+logfile = /var/log/forgejo-runner.log
+smooth-recovery = true

--- a/user/forgejo-runner/files/tmpfiles.conf
+++ b/user/forgejo-runner/files/tmpfiles.conf
@@ -1,0 +1,3 @@
+# Create forgejo-runner home directory
+
+d /var/lib/forgejo-runner 0750 root root -

--- a/user/forgejo-runner/template.py
+++ b/user/forgejo-runner/template.py
@@ -1,0 +1,32 @@
+pkgname = "forgejo-runner"
+pkgver = "3.5.1"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    f"-ldflags=-X gitea.com/gitea/act_runner/internal/pkg/ver.version=v{pkgver}"
+]
+make_check_args = [
+    "-skip",
+    "Test_runCreateRunnerFile|Test_ping",
+    "./...",
+]
+hostmakedepends = ["go"]
+depends = ["podman"]
+pkgdesc = "Daemon that runs CI jobs for Forgejo"
+maintainer = "Gnarwhal <git.aspect893@passmail.net>"
+license = "MIT"
+url = "https://code.forgejo.org/forgejo/runner"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "0c53e5ee6ea57eadcc3ebbb4fbe203478500f78b058b13d8ccc3b63b775955c0"
+
+
+def install(self):
+    self.install_bin(
+        f"{self.cwd}/{self.make_dir}/act_runner", name="forgejo-runner"
+    )
+    self.install_file(
+        self.files_path / "docker_host.env", "usr/share/forgejo-runner"
+    )
+    self.install_service(self.files_path / "forgejo-runner")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
+    self.install_license("LICENSE")

--- a/user/forgejo-runner/update.py
+++ b/user/forgejo-runner/update.py
@@ -1,0 +1,2 @@
+url = "https://code.forgejo.org/forgejo/runner/tags"
+pattern = r"/archive/v([\d.]+).tar.gz"


### PR DESCRIPTION
The setup instructions for forgejo-runner have it run as a separate user, but I don't know how to get forgejo-runner access to the podman socket when not run as root. Would it be possible to have podman create the socket with rw access for an `_podman` (or whatever it should be called) group? Or maybe running it as root is not a concern. 