### PR TITLE
main/lowdown: actually update to 1.1.2

### DIFF
--- a/main/lowdown/template.py
+++ b/main/lowdown/template.py
@@ -1,6 +1,6 @@
 pkgname = "lowdown"
 pkgver = "1.1.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "configure"
 configure_args = [
     "PREFIX=/usr",
@@ -14,7 +14,7 @@ maintainer = "ttyyls <contact@behri.org>"
 license = "ISC"
 url = "https://kristaps.bsd.lv/lowdown"
 source = f"{url}/snapshots/lowdown.tar.gz"
-sha256 = "3b1a4a9db44b0ea621189f107ff0dd6dff305c35209f46c17382b71555a3567e"
+sha256 = "844c6b090729aa45c6459dd63cb1faaf8d9945ed59ea46387778cd91c67033b0"
 hardening = ["vis", "cfi"]
 
 


### PR DESCRIPTION
Only version was updated with 00eccb1 and not the checksum resulting on 1.1.1 being rebuilt: https://build.chimera-linux.org/#/builders/6/builds/1468/steps/5/logs/pkg_main_lowdown_1_1_2-r0