### PR TITLE
main/ansible-core: depend on python-passlib

### DIFF
--- a/main/ansible-core/template.py
+++ b/main/ansible-core/template.py
@@ -1,6 +1,6 @@
 pkgname = "ansible-core"
 pkgver = "2.17.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "python_pep517"
 hostmakedepends = [
     "python-build",
@@ -11,6 +11,7 @@ depends = [
     "python-cryptography",
     "python-jinja2",
     "python-packaging",
+    "python-passlib",
     "python-pyyaml",
     "python-resolvelib",
 ]

--- a/main/python-bcrypt/template.py
+++ b/main/python-bcrypt/template.py
@@ -1,0 +1,32 @@
+pkgname = "python-bcrypt"
+pkgver = "4.2.0"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "cargo",
+    "python-build",
+    "python-installer",
+    "python-setuptools-rust",
+]
+makedepends = ["python-devel", "rust-std"]
+checkdepends = ["python-pytest"]
+depends = ["python"]
+pkgdesc = "Bcrypt password hashing for python"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "Apache-2.0"
+url = "https://github.com/pyca/bcrypt"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "36c757ad7a317627256b7f0be570b16ee1639c6faf398f9f7a7bd4f21bd289ee"
+
+
+def prepare(self):
+    from cbuild.util import cargo
+
+    cargo.Cargo(self, wrksrc="src/_bcrypt").vendor()
+
+
+def init_build(self):
+    from cbuild.util import cargo
+
+    renv = cargo.get_environment(self)
+    self.make_env.update(renv)

--- a/main/python-passlib/template.py
+++ b/main/python-passlib/template.py
@@ -1,0 +1,21 @@
+pkgname = "python-passlib"
+pkgver = "1.7.4"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = ["python-build", "python-installer", "python-setuptools"]
+depends = ["python"]
+checkdepends = ["python-bcrypt", "python-pytest-xdist"]
+pkgdesc = "Password hashing library for Python"
+maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license = "BSD-3-Clause"
+url = "https://passlib.readthedocs.io"
+source = f"https://foss.heptapod.net/python-libs/passlib/-/archive/{pkgver}/passlib-{pkgver}.tar.gz"
+sha256 = "ea541419716d6011a3ca6f6804d6a0d3f7fecdce0aad2aa655d4ee0d5448edff"
+
+
+def init_check(self):
+    self.make_check_args = [f"--numprocesses={self.make_jobs}"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/main/python-passlib/update.py
+++ b/main/python-passlib/update.py
@@ -1,0 +1,2 @@
+url = "https://foss.heptapod.net/python-libs/passlib/-/tags?format=atom"
+pattern = "<title>([0-9.]+)</title>"


### PR DESCRIPTION
Packages python-passlib and makes ansible-core depend on it. While ansible-core does somewhat work without passlib, most things around hashing don't work without it.
