### PR TITLE
contrib/plasma-desktop: make most -meta subpkgs easily maskable

### DIFF
--- a/main/plasma-desktop/template.py
+++ b/main/plasma-desktop/template.py
@@ -177,7 +177,7 @@ def _(self):
 @subpackage("plasma-desktop-apps-meta")
 def _(self):
     self.subdesc = "apps recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         # - core
         "discover",  # extra app management
@@ -253,7 +253,7 @@ def _(self):
 @subpackage("plasma-desktop-multimedia-meta")
 def _(self):
     self.subdesc = "multimedia recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "audiocd-kio",  # kio plugin for audio cds
         "audiotube",  # youtube music client
@@ -272,7 +272,7 @@ def _(self):
 @subpackage("plasma-desktop-devtools-meta")
 def _(self):
     self.subdesc = "devtools recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "heaptrack",
         "kcachegrind",
@@ -285,7 +285,7 @@ def _(self):
 @subpackage("plasma-desktop-games-meta")
 def _(self):
     self.subdesc = "games recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "kpat",
     ]
@@ -296,7 +296,7 @@ def _(self):
 @subpackage("plasma-desktop-accessibility-meta")
 def _(self):
     self.subdesc = "accessibility recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "accessibility-inspector",  # accesibility tree inspector
         # "kmag",  # magnifier TODO: broken?
@@ -313,7 +313,7 @@ def _(self):
 def _(self):
     # contact/calendar/etc
     self.subdesc = "kdepim recommends package"
-    self.install_if = [self.parent]
+    self.install_if = [self.with_pkgver("plasma-desktop-meta")]
     self.depends = [
         "akonadi-calendar-tools",
         "akonadi-import-wizard",


### PR DESCRIPTION
Now one can just add !plasma-desktop-meta instead of having to do the same for each of these individually when not wanting all of them around (which is arguably often the case due to just how much things get installed by default when adding plasma-desktop).

@nekopsykose Mostly making this so you're aware and may roll this into the v6.2.0 mega-bump, just wanting to separate this change from https://github.com/chimera-linux/cports/pull/2500 since that'll prob still be stuck for a while as a draft while this change is ready.