### PR TITLE
user/libgbinder: also build test progs

### DIFF
--- a/user/libgbinder-progs
+++ b/user/libgbinder-progs
@@ -1,0 +1,1 @@
+libgbinder

--- a/user/libgbinder/template.py
+++ b/user/libgbinder/template.py
@@ -1,11 +1,11 @@
 pkgname = "libgbinder"
 pkgver = "1.1.40"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_install_target = "install-dev"
 make_check_target = "test"
 make_use_env = True
-hostmakedepends = ["pkgconf"]
+hostmakedepends = ["bison", "flex", "pkgconf"]
 makedepends = ["libglibutil-devel", "linux-headers"]
 pkgdesc = "GLib-style interface to binder"
 maintainer = "tulilirockz <tulilirockz@outlook.com>"
@@ -15,8 +15,20 @@ source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
 sha256 = "9e86243df6502ffd0a68ee8384c5c36b9cd4093733ea620313f1947f312abbd1"
 
 
+def post_build(self):
+    self.make.invoke(["-C", "test"])
+
+
 def post_install(self):
+    self.make.invoke(
+        ["-C", "test", f"DESTDIR={self.chroot_destdir}", "install"]
+    )
     self.install_license("LICENSE")
+
+
+@subpackage("libgbinder-progs")
+def _(self):
+    return self.default_progs()
 
 
 @subpackage("libgbinder-devel")


### PR DESCRIPTION
These may be of use for debugging Waydroid issues for example via the likes of:
```sh
mkdir /etc/gbinder.d
cat <<'EOF' > /etc/gbinder.d/waydroid-a11.conf
[General]
ApiLevel = 30

[Protocol]
/dev/anbox-binder = aidl3
/dev/anbox-vndbinder = aidl3
/dev/anbox-hwbinder = hidl

[ServiceManager]
/dev/anbox-binder = aidl3
/dev/anbox-vndbinder = aidl3
/dev/anbox-hwbinder = hidl
EOF
binder-list -d /dev/anbox-hwbinder -v
```