### PR TITLE
main/nyagetty: switch libexecdir, fix ACTIVE_CONSOLES for new dinit.d

### DIFF
--- a/main/nyagetty/files/agetty
+++ b/main/nyagetty/files/agetty
@@ -1,4 +1,4 @@
 # start agetty services for active consoles
 type = scripted
-command = /usr/libexec/dinit-agetty
+command = /usr/lib/dinit-agetty
 depends-on = login.target

--- a/main/nyagetty/files/agetty-serial
+++ b/main/nyagetty/files/agetty-serial
@@ -19,4 +19,4 @@ shift
 [ -n "$GETTY_TERM" ] || GETTY_TERM=vt100
 [ -n "$GETTY_BAUD" ] || GETTY_BAUD=115200
 
-exec /usr/libexec/agetty-default "$GETTY" "$GETTY_BAUD" "$GETTY_TERM" -8 -L --noclear "$@"
+exec /usr/lib/agetty-default "$GETTY" "$GETTY_BAUD" "$GETTY_TERM" -8 -L --noclear "$@"

--- a/main/nyagetty/files/dinit-agetty
+++ b/main/nyagetty/files/dinit-agetty
@@ -22,7 +22,7 @@ PREV_CONSOLES=
 ACTIVE_SERVICES=$(
     for tty in $ACTIVE_CONSOLES; do
         tty=${tty##*/}
-        [ -f /etc/dinit.d/agetty-$tty ] || continue
+        [ -f /usr/lib/dinit.d/agetty-$tty ] || continue
         dinitctl add-dep milestone agetty agetty-$tty > /dev/null
         echo $tty
     done

--- a/main/nyagetty/template.py
+++ b/main/nyagetty/template.py
@@ -1,6 +1,6 @@
 pkgname = "nyagetty"
 pkgver = "2.38.99"
-pkgrel = 4
+pkgrel = 5
 build_style = "meson"
 hostmakedepends = ["meson"]
 makedepends = ["linux-headers"]
@@ -54,16 +54,10 @@ _ttys = [
 
 def post_install(self):
     # agetty dinit helper
-    self.install_file(
-        self.files_path / "dinit-agetty", "usr/libexec", mode=0o755
-    )
+    self.install_file(self.files_path / "dinit-agetty", "usr/lib", mode=0o755)
     # agetty conf wrapper
-    self.install_file(
-        self.files_path / "agetty-default", "usr/libexec", mode=0o755
-    )
-    self.install_file(
-        self.files_path / "agetty-serial", "usr/libexec", mode=0o755
-    )
+    self.install_file(self.files_path / "agetty-default", "usr/lib", mode=0o755)
+    self.install_file(self.files_path / "agetty-serial", "usr/lib", mode=0o755)
     # core service
     self.install_service(self.files_path / "agetty", enable=True)
     # generate services for individual gettys
@@ -79,7 +73,7 @@ def post_install(self):
             sv.write(
                 f"""# agetty service for {name}
 type            = process
-command         = /usr/libexec/{cmd}
+command         = /usr/lib/{cmd}
 restart         = true
 depends-on      = login.target
 termsignal      = HUP
@@ -99,4 +93,4 @@ def _(self):
     self.depends = [self.parent, "dinit-chimera"]
     self.install_if = [self.parent, "dinit-chimera"]
 
-    return ["usr/lib/dinit.d/agetty*", "usr/libexec/dinit-agetty"]
+    return ["usr/lib/dinit.d/agetty*", "usr/lib/dinit-agetty"]


### PR DESCRIPTION
Perhaps `dinit-agetty` should consider both `/usr/lib/dinit.d/agetty-$tty` and `/etc/dinit.d/agetty-$tty` for custom things? Either way this already works on my end and I have some local configuration plans of my own around this which is why I already submitted this specifically instead of waiting for an eventual transition/rebuild.

I also assume the files are wanted under `/usr/lib` now instead of e.g. `/usr/lib/nyagetty` or similar.