### PR TITLE
main/*: declare libusb-bootstrap

### DIFF
--- a/main/chrony/template.py
+++ b/main/chrony/template.py
@@ -16,6 +16,7 @@ makedepends = [
     "libcap-devel",
     "libedit-devel",
     "libseccomp-devel",
+    "libusb-bootstrap",
     "linux-headers",
     "nettle-devel",
 ]

--- a/main/elfutils/template.py
+++ b/main/elfutils/template.py
@@ -26,6 +26,7 @@ makedepends = [
     "libarchive-devel",
     "libcurl-devel",
     "libmicrohttpd-devel",
+    "libusb-bootstrap",
     "linux-headers",
     "musl-bsd-headers",
     "musl-obstack-devel",

--- a/main/gnutls/template.py
+++ b/main/gnutls/template.py
@@ -28,6 +28,7 @@ makedepends = [
     "libidn2-devel",
     "libtasn1-devel",
     "libunistring-devel",
+    "libusb-bootstrap",
     "linux-headers",
     "nettle-devel",
     "p11-kit-devel",

--- a/main/u-boot-tools/template.py
+++ b/main/u-boot-tools/template.py
@@ -19,11 +19,12 @@ hostmakedepends = [
     "python-setuptools",
 ]
 makedepends = [
-    "openssl-devel",
-    "linux-headers",
-    "libuuid-devel",
     "gnutls-devel",
+    "libusb-bootstrap",
+    "libuuid-devel",
+    "linux-headers",
     "ncurses-libtinfo-devel",
+    "openssl-devel",
     "python-devel",
 ]
 pkgdesc = "Das U-Boot tools"

--- a/main/udev/template.py
+++ b/main/udev/template.py
@@ -111,6 +111,7 @@ makedepends = [
     "libmount-devel",
     "libcap-devel",
     "libkmod-devel",
+    "libusb-bootstrap",
     "linux-headers",
 ]
 checkdepends = ["xz", "perl"]


### PR DESCRIPTION
It's not a dependency per se but it's installed indirectly which
will break when real libusb is not yet built.
