### PR TITLE
main/cryptsetup-scripts: restore patch hook

### DIFF
--- a/main/cryptsetup-scripts/patches/0001-general-portability-fixes-for-chimera-busyboxless-in.patch
+++ b/main/cryptsetup-scripts/patches/0001-general-portability-fixes-for-chimera-busyboxless-in.patch
@@ -1,15 +1,15 @@
-From 6dbd56e677dfdcce69e46e3a16a3bfc85c6a8dad Mon Sep 17 00:00:00 2001
+From 79dfd521f663e3318612f199089b9221e172ee1a Mon Sep 17 00:00:00 2001
 From: q66 <q66@chimera-linux.org>
 Date: Mon, 30 Sep 2024 22:46:33 +0200
-Subject: [PATCH 1/4] general portability fixes for chimera/busyboxless
- initramfs
+Subject: [PATCH] general portability fixes for chimera/busyboxless initramfs
 
 ---
- debian/functions                   | 16 ++++++++--------
- debian/initramfs/cryptroot-unlock  | 18 ++++++++++--------
- debian/initramfs/hooks/cryptopensc |  9 +++++----
- debian/initramfs/hooks/cryptroot   | 23 ++++++-----------------
- 4 files changed, 29 insertions(+), 37 deletions(-)
+ debian/functions                         | 16 ++++++++--------
+ debian/initramfs/conf-hooks.d/cryptsetup |  3 ---
+ debian/initramfs/cryptroot-unlock        | 18 ++++++++++--------
+ debian/initramfs/hooks/cryptopensc       |  9 +++++----
+ debian/initramfs/hooks/cryptroot         | 23 ++++++-----------------
+ 5 files changed, 29 insertions(+), 40 deletions(-)
 
 diff --git a/debian/functions b/debian/functions
 index 63ecf5d..8fbfdc4 100644
@@ -59,6 +59,19 @@ index 63ecf5d..8fbfdc4 100644
              _foreach_cryptdev "$d2"
          fi
      done
+diff --git a/debian/initramfs/conf-hooks.d/cryptsetup b/debian/initramfs/conf-hooks.d/cryptsetup
+index 883c1ba..f858920 100644
+--- a/debian/initramfs/conf-hooks.d/cryptsetup
++++ b/debian/initramfs/conf-hooks.d/cryptsetup
+@@ -2,8 +2,5 @@
+ # necessary for punching in passphrases.
+ KEYMAP=y
+ 
+-# force busybox on initramfs
+-BUSYBOX=y
+-
+ # and for systems using plymouth instead, use the new option
+ FRAMEBUFFER=y
 diff --git a/debian/initramfs/cryptroot-unlock b/debian/initramfs/cryptroot-unlock
 index dbc2ad0..1e9cf69 100644
 --- a/debian/initramfs/cryptroot-unlock
@@ -212,5 +225,5 @@ index 9ae9b8c..b824ccd 100644
  # detect whether the host CPU has AES-NI support
  if grep -Eq '^flags\s*:(.*\s)?aes(\s.*)?$' /proc/cpuinfo; then
 -- 
-2.46.2
+2.47.0
 


### PR DESCRIPTION
Restore patch hook accidentally removed at dad7d80bc probably because
cryptsetup file is listed at project's .gitignore

[update skip]