### PR TITLE
user/zrepl-dsh2dsh: new package

### DIFF
--- a/user/zrepl/files/tmpfiles.conf
+++ b/user/zrepl/files/tmpfiles.conf
@@ -1,0 +1,3 @@
+# Directory for control socket
+
+d /run/zrepl 0755 root root -

--- a/user/zrepl/files/zrepl
+++ b/user/zrepl/files/zrepl
@@ -1,0 +1,4 @@
+type = process
+command = /usr/bin/zrepl --config /etc/zrepl/zrepl.yml daemon
+depends-on = local.target
+logfile = /var/log/zrepl.log

--- a/user/zrepl/template.py
+++ b/user/zrepl/template.py
@@ -1,0 +1,27 @@
+pkgname = "zrepl"
+pkgver = "0.9.2"
+pkgrel = 0
+build_style = "go"
+hostmakedepends = ["go"]
+depends = ["zfs"]
+pkgdesc = "ZFS backup and replication tool - dsh2dsh's enhanced fork"
+maintainer = "Robert David <robert.david@posteo.net>"
+license = "MIT"
+url = "https://github.com/dsh2dsh/zrepl"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "1262c854c32e66cf67dd1d8c2ca6e546b6d42100c9bca9857ba37b6a16a5b1d1"
+# check needs to run zfs command
+options = ["!check"]
+
+
+def install(self):
+    self.install_bin("build/zrepl")
+    self.install_files(
+        "internal/config/samples", "usr/share/examples", name="zrepl"
+    )
+    self.install_file(
+        "dist/freebsd/etc/zrepl/zrepl.yml", "usr/share/examples/zrepl"
+    )
+    self.install_service(self.files_path / "zrepl")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
+    self.install_license("LICENSE")


### PR DESCRIPTION
This is an enhanced fork of the original zrepl ZFS snapshot and replication daemon.

The package builds and works as expected on x86_64 and it contains everything that is needed to properly use on Chimera.