### PR TITLE
main/nyagetty: fix syntax error in agetty-service.sh

### DIFF
--- a/main/nyagetty/files/agetty-service.sh
+++ b/main/nyagetty/files/agetty-service.sh
@@ -4,4 +4,4 @@ case "$1" in
     tty[0-9]*|console) exec /usr/lib/agetty-default "$@" ;;
 esac
 
-exec /usr/lib/agetty-serial "$@" ;;
+exec /usr/lib/agetty-serial "$@"

--- a/main/nyagetty/template.py
+++ b/main/nyagetty/template.py
@@ -1,6 +1,6 @@
 pkgname = "nyagetty"
 pkgver = "2.38.99"
-pkgrel = 5
+pkgrel = 6
 build_style = "meson"
 hostmakedepends = ["meson"]
 makedepends = ["linux-headers"]


### PR DESCRIPTION
When starting a serial getty by specifying it in `/etc/default/agetty` or running `dinitctl start agetty-service@ttyS0`, the service would crash because of a syntax error in the helper script `/usr/lib/agetty-service`.