### PR TITLE
cbuild: only clear world before cross sysroot setup in non-dirty builds

### DIFF
--- a/src/cbuild/core/chroot.py
+++ b/src/cbuild/core/chroot.py
@@ -462,7 +462,8 @@ def _prepare_arch(prof, dirty):
 
     # clear world so cross sysroot gets set up from scratch
     # this is a slow path but nobody cares about cross so whatever
-    cleanup_world(False)
+    if not dirty:
+        cleanup_world(False)
 
     logger.get().out(f"setting up sysroot for {prof.arch}...")
     initdb(rootp)


### PR DESCRIPTION
Otherwise `-D`/`--dirty-build` doesn't work for cross-builds as the build deps are always removed on reruns. Test:
```
./cbuild -a aarch64 patch main/openssl
./cbuild -a aarch64 -D configure main/openssl
```