### PR TITLE
main/sddm: fix broken 10-breeze-theme.conf location

### DIFF
--- a/main/sddm/template.py
+++ b/main/sddm/template.py
@@ -1,6 +1,6 @@
 pkgname = "sddm"
 pkgver = "0.21.0"
-pkgrel = 2
+pkgrel = 3
 build_style = "cmake"
 configure_args = [
     "-DBUILD_MAN_PAGES=ON",
@@ -59,7 +59,7 @@ def post_install(self):
     # and breeze just looks way better
     self.install_file(
         self.files_path / "10-breeze-theme.conf",
-        "usr/lib/sddm/sddm.conf.d/10-breeze-theme.conf",
+        "usr/lib/sddm/sddm.conf.d",
     )
     # all unusable
     self.uninstall("usr/share/sddm/themes")


### PR DESCRIPTION
`/usr/lib/sddm/sddm.conf.d/10-breeze-theme.conf/10-breeze-theme.conf` used to exist which was obviously broken, though I still wasn't able to test this successfully on an already booted install where I saw the fallback theme already once despite e.g. `dinitctl stop sddm && rm -r /var/lib/sddm/{.{cache,config,local},state.conf} && dinitctl start sddm` so this may need further confirmation it actually fixes the issue..