### PR TITLE
user/e16: new package

### DIFF
--- a/user/e16/template.py
+++ b/user/e16/template.py
@@ -1,0 +1,52 @@
+pkgname = "e16"
+pkgver = "1.0.30"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = [
+    "--enable-sound",
+    "--enable-sound-pulse",
+]
+hostmakedepends = ["automake", "slibtool", "pkgconf"]
+makedepends = [
+    "alsa-lib-devel",
+    "audiofile-devel",
+    "dbus-devel",
+    "fontconfig-devel",
+    "freetype-devel",
+    "gdk-pixbuf-devel",
+    "gettext-devel",
+    "glib-devel",
+    "imlib2-devel",
+    "libice-devel",
+    "libpulse-devel",
+    "libsm-devel",
+    "libsndfile-devel",
+    "libx11-devel",
+    "libxcomposite-devel",
+    "libxcursor-devel",
+    "libxdamage-devel",
+    "libxext-devel",
+    "libxfixes-devel",
+    "libxft-devel",
+    "libxinerama-devel",
+    "libxpm-devel",
+    "libxpresent-devel",
+    "libxrandr-devel",
+    "libxrender-devel",
+    "libxres-devel",
+    "libxxf86vm-devel",
+    "pango-devel",
+    "xbitmaps",
+    "xorgproto",
+]
+depends = ["desktop-file-utils", "python"]
+pkgdesc = "Themed window manager for X11"
+maintainer = "rane <rane+chimera@junkyard.systems>"
+license = "BSD-2-Clause"
+url = "https://enlightenment.org/e16"
+source = f"$(SOURCEFORGE_SITE)/enlightenment/e16/{pkgver}/e16-{pkgver}.tar.xz"
+sha256 = "24a0660600b970de173b4debd0d47bf0bcbdb6923bdf7fec5043cbd062d4e41d"
+
+
+def post_install(self):
+    self.install_license("COPYING")

--- a/user/e16/update.py
+++ b/user/e16/update.py
@@ -1,0 +1,1 @@
+url = "https://sourceforge.net/projects/enlightenment/rss?path=/e16"


### PR DESCRIPTION
This MR adds the enlightenment X11 window manager, DR16 version 1.0.30, which is still actively maintained upstream and the latest stable version. This is maintained and still developed as and alternative to newer versions of enlightenment.

I have built and tested this locally, including launching and interacting with various applications, enabling compositing mode, and switching themes and all works well. I have tested it using `emptty` as a display manager and can confirm the session files upstream E16 provides are correctly registered when the package is installed.

This is my first contribution to cports so if there is any feedback or tips on how to contribute changes better please let me know!