### PR TITLE
main/linux-rpi: add Home Assistant Yellow device trees

### DIFF
--- a/main/linux-rpi/patches/home-assistant-yellow.patch
+++ b/main/linux-rpi/patches/home-assistant-yellow.patch
@@ -1,0 +1,1837 @@
+From e6cc32a85f77f12b67ee3047f5c03fead396843b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Sun, 17 Nov 2024 15:14:06 +0100
+Subject: [PATCH] ARM: dts: bcm2711: Add device trees for Home Assistant Yellow
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add device trees for Home Assistant Yellow, a Raspberry Pi Compute
+Module based I/O board. The two device trees are for the CM4 and CM5
+respectively.
+
+This commit has been squashed from the patches in https://github.com/home-assistant/operating-system/tree/180c9ada3f6ad24b4b254a5547cbca0848c9d2d2/buildroot-external/board/raspberrypi/yellow/patches/linux
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ .../broadcom/bcm2711-rpi-cm4-ha-yellow.dts    |  712 +++++++++++
+ arch/arm64/boot/dts/broadcom/Makefile         |    2 +
+ .../broadcom/bcm2711-rpi-cm4-ha-yellow.dts    |    1 +
+ .../broadcom/bcm2712-rpi-cm5-ha-yellow.dts    | 1063 +++++++++++++++++
+ 4 files changed, 1778 insertions(+)
+ create mode 100644 arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+ create mode 100644 arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+ create mode 100644 arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+new file mode 100644
+index 000000000000..b3d57a53d222
+--- /dev/null
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+@@ -0,0 +1,712 @@
++// SPDX-License-Identifier: GPL-2.0
++/dts-v1/;
++#define BCM2711
++#define i2c0 i2c0if
++#include "bcm2711.dtsi"
++#include "bcm283x-rpi-wifi-bt.dtsi"
++#undef i2c0
++#include "bcm270x.dtsi"
++#define i2c0 i2c0mux
++#include "bcm2711-rpi.dtsi"
++#undef i2c0
++//#include "bcm283x-rpi-usb-peripheral.dtsi"
++
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "raspberrypi,4-compute-module-ha-yellow", "raspberrypi,4-compute-module", "brcm,bcm2711";
++	model = "Raspberry Pi Compute Module 4 on Home Assistant Yellow";
++
++	chosen {
++		/* 8250 auxiliary UART instead of pl011 */
++		stdout-path = "serial1:115200n8";
++	};
++
++	keys: gpio-keys {
++		compatible = "gpio-keys";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_button_pins>;
++
++		status = "okay";
++
++		power {
++			label = "Blue Button";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
++			debounce-interval = <100>; // ms
++		};
++
++		user {
++			label = "Red Button";
++			linux,code = <BTN_1>;
++			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
++			debounce-interval = <100>; // ms
++		};
++	};
++
++	leds: leds {
++		compatible = "gpio-leds";
++
++		led-act {
++			label = "ACT";
++			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
++			default-state = "keep";
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-pwr {
++			label = "PWR";
++			gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
++			default-state = "keep";
++			linux,default-trigger = "default-on";
++		};
++	};
++
++	sd_io_1v8_reg: sd_io_1v8_reg {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-sd-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-settling-time-us = <5000>;
++		gpios = <&expgpio 4 GPIO_ACTIVE_HIGH>;
++		states = <1800000 0x1>,
++			 <3300000 0x0>;
++		status = "okay";
++	};
++
++	sd_vcc_reg: sd_vcc_reg {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		enable-active-high;
++		gpio = <&expgpio 6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&bt {
++	shutdown-gpios = <&expgpio 0 GPIO_ACTIVE_HIGH>;
++};
++
++&ddc0 {
++	status = "okay";
++};
++
++&ddc1 {
++	status = "okay";
++};
++
++&expgpio {
++	gpio-line-names = "BT_ON",
++			  "WL_ON",
++			  "PWR_LED_OFF",
++			  "ANT1",
++			  "VDD_SD_IO_SEL",
++			  "CAM_GPIO",
++			  "SD_PWR_ON",
++			  "ANT2";
++
++	ant1: ant1 {
++		gpio-hog;
++		gpios = <3 GPIO_ACTIVE_HIGH>;
++		output-high;
++	};
++
++	ant2: ant2 {
++		gpio-hog;
++		gpios = <7 GPIO_ACTIVE_HIGH>;
++		output-low;
++	};
++};
++
++&gpio {
++	/*
++	 * Parts taken from rpi_SCH_4b_4p0_reduced.pdf and
++	 * the official GPU firmware DT blob.
++	 *
++	 * Legend:
++	 * "FOO" = GPIO line named "FOO" on the schematic
++	 * "FOO_N" = GPIO line named "FOO" on schematic, active low
++	 */
++	gpio-line-names = "ID_SDA",
++			  "ID_SCL",
++			  "SDA1",
++			  "SCL1",
++			  "GPIO_GCLK",
++			  "GPIO5",
++			  "GPIO6",
++			  "SPI_CE1_N",
++			  "SPI_CE0_N",
++			  "SPI_MISO",
++			  "SPI_MOSI",
++			  "SPI_SCLK",
++			  "GPIO12",
++			  "GPIO13",
++			  /* Serial port */
++			  "TXD1",
++			  "RXD1",
++			  "GPIO16",
++			  "GPIO17",
++			  "GPIO18",
++			  "GPIO19",
++			  "GPIO20",
++			  "GPIO21",
++			  "GPIO22",
++			  "GPIO23",
++			  "GPIO24",
++			  "GPIO25",
++			  "GPIO26",
++			  "GPIO27",
++			  "RGMII_MDIO",
++			  "RGMIO_MDC",
++			  /* Used by BT module */
++			  "CTS0",
++			  "RTS0",
++			  "TXD0",
++			  "RXD0",
++			  /* Used by Wifi */
++			  "SD1_CLK",
++			  "SD1_CMD",
++			  "SD1_DATA0",
++			  "SD1_DATA1",
++			  "SD1_DATA2",
++			  "SD1_DATA3",
++			  /* Shared with SPI flash */
++			  "PWM0_MISO",
++			  "PWM1_MOSI",
++			  "STATUS_LED_G_CLK",
++			  "SPIFLASH_CE_N",
++			  "SDA0",
++			  "SCL0",
++			  "RGMII_RXCLK",
++			  "RGMII_RXCTL",
++			  "RGMII_RXD0",
++			  "RGMII_RXD1",
++			  "RGMII_RXD2",
++			  "RGMII_RXD3",
++			  "RGMII_TXCLK",
++			  "RGMII_TXCTL",
++			  "RGMII_TXD0",
++			  "RGMII_TXD1",
++			  "RGMII_TXD2",
++			  "RGMII_TXD3";
++};
++
++&hdmi0 {
++	status = "okay";
++};
++
++&hdmi1 {
++	status = "okay";
++};
++
++&pixelvalve0 {
++	status = "okay";
++};
++
++&pixelvalve1 {
++	status = "okay";
++};
++
++&pixelvalve2 {
++	status = "okay";
++};
++
++&pixelvalve4 {
++	status = "okay";
++};
++
++&pwm1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm1_0_gpio40 &pwm1_1_gpio41>;
++	status = "okay";
++};
++
++/* EMMC2 is used to drive the EMMC card */
++&emmc2 {
++	bus-width = <8>;
++	vqmmc-supply = <&sd_io_1v8_reg>;
++	vmmc-supply = <&sd_vcc_reg>;
++	broken-cd;
++	status = "okay";
++};
++
++&genet {
++	phy-handle = <&phy1>;
++	phy-mode = "rgmii-rxid";
++	status = "okay";
++};
++
++&genet_mdio {
++	phy1: ethernet-phy@0 {
++		/* No PHY interrupt */
++		reg = <0x0>;
++	};
++};
++
++&pcie0 {
++	pci@0,0 {
++		device_type = "pci";
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		reg = <0 0 0 0 0>;
++	};
++};
++
++/* uart0 communicates with the BT module */
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ctsrts_gpio30 &uart0_gpio32>;
++	uart-has-rtscts;
++};
++
++/* uart1 is mapped to the pin header */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_gpio14>;
++	status = "okay";
++};
++
++/* uart4 for Zigbee */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pins>;
++	uart-has-rtscts;
++	status = "okay";
++};
++
++/* uart5 default Debug UART */
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_pins>;
++	status = "okay";
++};
++
++&vc4 {
++	status = "okay";
++};
++
++&vec {
++	status = "disabled";
++};
++
++&wifi_pwrseq {
++	reset-gpios = <&expgpio 1 GPIO_ACTIVE_LOW>;
++};
++
++// =============================================
++// Downstream rpi- changes
++
++#include "bcm271x-rpi-bt.dtsi"
++
++/ {
++	soc {
++		/delete-node/ pixelvalve@7e807000;
++		/delete-node/ hdmi@7e902000;
++	};
++};
++
++#include "bcm2711-rpi-ds.dtsi"
++#include "bcm283x-rpi-csi0-2lane.dtsi"
++#include "bcm283x-rpi-csi1-4lane.dtsi"
++
++/ {
++	chosen {
++		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
++		stdout-path = "serial5:115200n8";
++	};
++
++	aliases {
++		serial0 = &uart0;
++		serial1 = &uart4;
++		serial2 = &uart5;
++		mmc0 = &emmc2;
++		mmc1 = &mmcnr;
++		mmc2 = &sdhost;
++		i2c3 = &i2c3;
++		i2c4 = &i2c4;
++		i2c5 = &i2c5;
++		i2c6 = &i2c6;
++		i2c20 = &ddc0;
++		i2c21 = &ddc1;
++		spi3 = &spi3;
++		spi4 = &spi4;
++		spi5 = &spi5;
++		spi6 = &spi6;
++		bluetooth = &uart1;
++
++		/delete-property/ intc;
++	};
++
++	/delete-node/ wifi-pwrseq;
++};
++
++&mmcnr {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio_pins>;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-0 = <&uart0_pins>;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_bt_pins>;
++	status = "okay";
++};
++
++&bt {
++	status = "disabled";
++};
++
++&minibt {
++	status = "okay";
++};
++
++&spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
++	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++
++	spidev0: spidev@0{
++		compatible = "spidev";
++		reg = <0>;	/* CE0 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <125000000>;
++	};
++
++	spidev1: spidev@1{
++		compatible = "spidev";
++		reg = <1>;	/* CE1 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <125000000>;
++	};
++};
++
++&gpio {
++	gpio_button_pins: gpio_button_pins {
++		brcm,pins = <26 27>;
++		brcm,function = <BCM2835_FSEL_GPIO_IN>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	spi0_pins: spi0_pins {
++		brcm,pins = <9 10 11>;
++		brcm,function = <BCM2835_FSEL_ALT0>;
++	};
++
++	spi0_cs_pins: spi0_cs_pins {
++		brcm,pins = <8 7>;
++		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
++	};
++
++	spi3_pins: spi3_pins {
++		brcm,pins = <1 2 3>;
++		brcm,function = <BCM2835_FSEL_ALT3>;
++	};
++
++	spi3_cs_pins: spi3_cs_pins {
++		brcm,pins = <0 24>;
++		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
++	};
++
++	spi4_pins: spi4_pins {
++		brcm,pins = <5 6 7>;
++		brcm,function = <BCM2835_FSEL_ALT3>;
++	};
++
++	spi4_cs_pins: spi4_cs_pins {
++		brcm,pins = <4 25>;
++		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
++	};
++
++	spi5_pins: spi5_pins {
++		brcm,pins = <13 14 15>;
++		brcm,function = <BCM2835_FSEL_ALT3>;
++	};
++
++	spi5_cs_pins: spi5_cs_pins {
++		brcm,pins = <12 26>;
++		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
++	};
++
++	spi6_pins: spi6_pins {
++		brcm,pins = <19 20 21>;
++		brcm,function = <BCM2835_FSEL_ALT3>;
++	};
++
++	spi6_cs_pins: spi6_cs_pins {
++		brcm,pins = <18 27>;
++		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
++	};
++
++	i2c0_pins: i2c0 {
++		brcm,pins = <0 1>;
++		brcm,function = <BCM2835_FSEL_ALT0>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2c1_pins: i2c1 {
++		brcm,pins = <2 3>;
++		brcm,function = <BCM2835_FSEL_ALT0>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2c3_pins: i2c3 {
++		brcm,pins = <4 5>;
++		brcm,function = <BCM2835_FSEL_ALT5>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2c4_pins: i2c4 {
++		brcm,pins = <8 9>;
++		brcm,function = <BCM2835_FSEL_ALT5>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2c5_pins: i2c5 {
++		brcm,pins = <12 13>;
++		brcm,function = <BCM2835_FSEL_ALT5>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2c6_pins: i2c6 {
++		brcm,pins = <22 23>;
++		brcm,function = <BCM2835_FSEL_ALT5>;
++		brcm,pull = <BCM2835_PUD_UP>;
++	};
++
++	i2s_pins: i2s {
++		brcm,pins = <18 19 20 21>;
++		brcm,function = <BCM2835_FSEL_ALT0>;
++	};
++
++	sdio_pins: sdio_pins {
++		brcm,pins =     <34 35 36 37 38 39>;
++		brcm,function = <BCM2835_FSEL_ALT3>; // alt3 = SD1
++		brcm,pull =     <0 2 2 2 2 2>;
++	};
++
++	bt_pins: bt_pins {
++		brcm,pins = "-"; // non-empty to keep btuart happy, //4 = 0
++				 // to fool pinctrl
++		brcm,function = <0>;
++		brcm,pull = <2>;
++	};
++
++	uart0_pins: uart0_pins {
++		brcm,pins;
++		brcm,function;
++		brcm,pull;
++	};
++
++	uart1_pins: uart1_pins {
++		brcm,pins = <32 33>;
++		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
++		brcm,pull = <0 2>;
++	};
++
++	uart1_bt_pins: uart1_bt_pins {
++		brcm,pins = <32 33 30 31>;
++		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
++		brcm,pull = <0 2 2 0>;
++	};
++
++	uart2_pins: uart2_pins {
++		brcm,pins = <0 1>;
++		brcm,function = <BCM2835_FSEL_ALT4>;
++		brcm,pull = <0 2>;
++	};
++
++	uart3_pins: uart3_pins {
++		brcm,pins = <4 5>;
++		brcm,function = <BCM2835_FSEL_ALT4>;
++		brcm,pull = <0 2>;
++	};
++
++	uart4_pins: uart4_pins {
++		brcm,pins = <8 9 10 11>;
++		brcm,function = <BCM2835_FSEL_ALT4>;
++		brcm,pull = <0 2 2 0>;
++	};
++
++	uart5_pins: uart5_pins {
++		brcm,pins = <12 13>;
++		brcm,function = <BCM2835_FSEL_ALT4>;
++		brcm,pull = <0 2>;
++	};
++};
++
++&i2c0if {
++	clock-frequency = <100000>;
++};
++
++&i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c1_pins>;
++	clock-frequency = <100000>;
++};
++
++&i2c6 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c6_pins>;
++	status = "okay";
++
++	card_codec: pcm5121@4c {
++		#sound-dai-cells = <0>;
++		compatible = "ti,pcm5121";
++		reg = <0x4c>;
++		AVDD-supply = <&vdd_3v3_reg>;
++		DVDD-supply = <&vdd_3v3_reg>;
++		CPVDD-supply = <&vdd_3v3_reg>;
++		status = "okay";
++	};
++
++	pcf85063a: rtc@51 {
++		compatible = "nxp,pcf85063a";
++		reg = <0x51>;
++	};
++};
++
++&i2s {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s_pins>;
++	status = "okay";
++};
++
++// =============================================
++// Board specific stuff here
++
++&pcie0 {
++       brcm,enable-l1ss;
++};
++
++&sdhost {
++	status = "disabled";
++};
++
++&usb {
++	compatible = "brcm,bcm2835-usb";
++	dr_mode = "otg";
++	g-np-tx-fifo-size = <32>;
++	g-rx-fifo-size = <558>;
++	g-tx-fifo-size = <512 512 512 512 512 256 256>;
++	status = "okay";
++};
++
++&phy1 {
++	led-modes = <0x00 0x08>; /* link/activity link */
++};
++
++&gpio {
++	audio_pins: audio_pins {
++		brcm,pins = <>;
++		brcm,function = <>;
++	};
++};
++
++&leds {
++	act_led: led-act {
++		label = "act";
++		default-state = "off";
++		linux,default-trigger = "activity";
++		gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
++	};
++
++	pwr_led: led-pwr {
++		label = "pwr";
++		default-state = "off";
++		linux,default-trigger = "default-on";
++		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
++	};
++
++	usr_led: led-usr {
++		label = "usr";
++		linux,default-trigger = "heartbeat";
++		default-state = "off";
++		panic-indicator;
++		gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&pwm1 {
++	status = "disabled";
++};
++
++&sound {
++	compatible = "simple-audio-card";
++	simple-audio-card,format = "i2s";
++	simple-audio-card,name = "pcm5121-sound";
++	status = "okay";
++
++	simple-audio-card,cpu {
++		sound-dai = <&i2s>;
++	};
++
++	dailink0_slave: simple-audio-card,codec {
++		sound-dai = <&card_codec>;
++	};
++};
++
++&vchiq {
++	pinctrl-names = "default";
++	pinctrl-0 = <&audio_pins>;
++};
++
++cam0_reg: &cam1_reg {
++	gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
++};
++
++/ {
++	__overrides__ {
++		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_hdmi=0'}";
++
++		act_led_trigger = <&act_led>,"linux,default-trigger";
++
++		pwr_led_activelow = <&pwr_led>,"gpios:8";
++		pwr_led_trigger = <&pwr_led>,"linux,default-trigger";
++
++		usr_led_trigger = <&usr_led>,"linux,default-trigger";
++
++		eth_led0 = <&phy1>,"led-modes:0";
++		eth_led1 = <&phy1>,"led-modes:4";
++
++		ant1 =  <&ant1>,"output-high?=on",
++			<&ant1>, "output-low?=off",
++			<&ant2>, "output-high?=off",
++			<&ant2>, "output-low?=on";
++		ant2 =  <&ant1>,"output-high?=off",
++			<&ant1>, "output-low?=on",
++			<&ant2>, "output-high?=on",
++			<&ant2>, "output-low?=off";
++		noant = <&ant1>,"output-high?=off",
++			<&ant1>, "output-low?=on",
++			<&ant2>, "output-high?=off",
++			<&ant2>, "output-low?=on";
++
++		sd_poll_once = <&emmc2>, "non-removable?";
++		spi_dma4 = <&spi0>, "dmas:0=", <&dma40>,
++			   <&spi0>, "dmas:8=", <&dma40>;
++
++		cam0_reg = <&cam0_reg>,"status";
++		cam0_reg_gpio = <&cam0_reg>,"gpio:4",
++				  <&cam0_reg>,"gpio:0=", <&gpio>;
++		cam1_reg = <&cam1_reg>,"status";
++		cam1_reg_gpio = <&cam1_reg>,"gpio:4",
++				  <&cam1_reg>,"gpio:0=", <&gpio>;
++
++		krnbt = <&minibt>,"status";
++	};
++};
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index 5dd4c5c77e2f..bf4d26ee0774 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -19,6 +19,8 @@ dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b-plus.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-cm3.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-cm4.dtb
++dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-cm4-ha-yellow.dtb
++dtb-$(CONFIG_ARCH_BCM2835) += bcm2712-rpi-cm5-ha-yellow.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-cm4s.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2712-rpi-5-b.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2712d0-rpi-5-b.dtb
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+new file mode 100644
+index 000000000000..97ff67ade14d
+--- /dev/null
++++ b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts
+@@ -0,0 +1 @@
++#include "../../../../arm/boot/dts/broadcom/bcm2711-rpi-cm4-ha-yellow.dts"
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+new file mode 100644
+index 000000000000..4b130f42b235
+--- /dev/null
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+@@ -0,0 +1,1063 @@
++// SPDX-License-Identifier: GPL-2.0
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/clock/rp1.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/mfd/rp1.h>
++#include <dt-bindings/pwm/pwm.h>
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
++
++#define i2c0 _i2c0
++#define i2c3 _i2c3
++#define i2c4 _i2c4
++#define i2c5 _i2c5
++#define i2c6 _i2c6
++#define i2c8 _i2c8
++#define i2s _i2s
++#define pwm0 _pwm0
++#define pwm1 _pwm1
++#define spi0 _spi0
++#define spi3 _spi3
++#define spi4 _spi4
++#define spi5 _spi5
++#define spi6 _spi6
++#define uart0 _uart0
++#define uart2 _uart2
++#define uart5 _uart5
++
++#include "bcm2712.dtsi"
++
++#undef i2c0
++#undef i2c3
++#undef i2c4
++#undef i2c5
++#undef i2c6
++#undef i2c8
++#undef i2s
++#undef pwm0
++#undef pwm1
++#undef spi0
++#undef spi3
++#undef spi4
++#undef spi5
++#undef spi6
++#undef uart0
++#undef uart2
++#undef uart3
++#undef uart4
++#undef uart5
++
++/ {
++	compatible = "raspberrypi,5-compute-module-ha-yellow", "raspberrypi,5-compute-module", "brcm,bcm2712";
++	model = "Raspberry Pi Compute Module 5 on Home Assistant Yellow";
++
++	/* Will be filled by the bootloader */
++	memory@0 {
++		device_type = "memory";
++		reg = <0 0 0x28000000>;
++	};
++
++	leds: leds {
++		compatible = "gpio-leds";
++
++		led_pwr: led-pwr {
++			label = "PWR";
++			gpios = <&rp1_gpio 44 GPIO_ACTIVE_LOW>;
++			default-state = "off";
++			linux,default-trigger = "none";
++		};
++
++		led_act: led-act {
++			label = "ACT";
++			gpios = <&gio_aon 9 GPIO_ACTIVE_LOW>;
++			default-state = "off";
++			linux,default-trigger = "mmc0";
++		};
++	};
++
++	sd_io_1v8_reg: sd_io_1v8_reg {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-sd-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-settling-time-us = <5000>;
++		gpios = <&gio_aon 3 GPIO_ACTIVE_HIGH>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		status = "okay";
++	};
++
++	sd_vcc_reg: sd_vcc_reg {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		enable-active-high;
++		gpios = <&gio_aon 4 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wl_on_reg: wl_on_reg {
++		compatible = "regulator-fixed";
++		regulator-name = "wl-on-regulator";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		pinctrl-0 = <&wl_on_pins>;
++		pinctrl-names = "default";
++
++		gpio = <&gio 28 GPIO_ACTIVE_HIGH>;
++
++		startup-delay-us = <150000>;
++		enable-active-high;
++	};
++
++	clocks: clocks {
++	};
++
++	cam1_clk: cam1_clk {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		status = "disabled";
++	};
++
++	cam0_clk: cam0_clk {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		status = "disabled";
++	};
++
++	cam0_reg: cam0_reg {
++		compatible = "regulator-fixed";
++		regulator-name = "cam0_reg";
++		enable-active-high;
++		status = "okay";
++		gpio = <&rp1_gpio 34 0>; // CD0_IO0_MICCLK, to CAM_GPIO on connector
++	};
++
++	cam_dummy_reg: cam_dummy_reg {
++		compatible = "regulator-fixed";
++		regulator-name = "cam-dummy-reg";
++		status = "okay";
++	};
++
++	dummy: dummy {
++		// A target for unwanted overlay fragments
++	};
++
++
++	// A few extra labels to keep overlays happy
++
++	i2c0if: i2c0if {};
++	i2c0mux: i2c0mux {};
++};
++
++rp1_target: &pcie2 {
++	brcm,enable-mps-rcb;
++	brcm,vdm-qos-map = <0xbbaa9888>;
++	aspm-no-l0s;
++	status = "okay";
++};
++
++// Add some labels to 2712 device
++
++// The system UART
++uart10: &_uart0 { status = "okay"; };
++
++// The system SPI for the bootloader EEPROM
++spi10: &_spi0 { status = "okay"; };
++
++i2c_rp1boot: &_i2c3 { };
++
++#include "rp1.dtsi"
++
++&rp1 {
++	// PCIe address space layout:
++	// 00_00000000-00_00xxxxxx = RP1 peripherals
++	// 10_00000000-1x_xxxxxxxx = up to 64GB system RAM
++
++	// outbound access aimed at PCIe 0_00xxxxxx -> RP1 c0_40xxxxxx
++	// This is the RP1 peripheral space
++	ranges = <0xc0 0x40000000
++		  0x02000000 0x00 0x00000000
++		  0x00 0x00400000>;
++
++	dma-ranges =
++	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
++		     <0x10 0x00000000
++		      0x43000000 0x10 0x00000000
++		      0x10 0x00000000>,
++
++	// inbound RP1 c0_40xxxxxx -> PCIe 00_00xxxxxx
++	// This allows the RP1 DMA controller to address RP1 hardware
++		     <0xc0 0x40000000
++		      0x02000000 0x0 0x00000000
++		      0x0 0x00400000>,
++
++	// inbound RP1 0x_xxxxxxxx -> PCIe 1x_xxxxxxxx
++		     <0x00 0x00000000
++		      0x02000000 0x10 0x00000000
++		      0x10 0x00000000>;
++};
++
++// Expose RP1 nodes as system nodes with labels
++
++&rp1_dma  {
++	status = "okay";
++};
++
++&rp1_eth {
++	status = "okay";
++	phy-handle = <&phy1>;
++	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
++	phy-reset-duration = <5>;
++
++	phy1: ethernet-phy@1 {
++		reg = <0x1>;
++		brcm,powerdown-enable;
++		interrupt-parent = <&gpio>;
++		interrupts = <37 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++gpio: &rp1_gpio {
++	status = "okay";
++};
++
++aux: &dummy {};
++
++&rp1_usb0 {
++	pinctrl-0 = <&usb_vbus_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&rp1_usb1 {
++	status = "okay";
++};
++
++#include "bcm2712-rpi.dtsi"
++
++i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
++	pinctrl-0 = <&rp1_i2c6_38_39>;
++	pinctrl-names = "default";
++	clock-frequency = <100000>;
++};
++
++i2c_csi_dsi1: &i2c0 { // Note: This is for MIPI1 connector
++};
++
++i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility
++
++cam1_reg: &cam0_reg { // Shares CAM_GPIO with cam0_reg
++};
++
++csi0: &rp1_csi0 { };
++csi1: &rp1_csi1 { };
++dsi0: &rp1_dsi0 { };
++dsi1: &rp1_dsi1 { };
++dpi: &rp1_dpi { };
++vec: &rp1_vec { };
++dpi_gpio0:              &rp1_dpi_24bit_gpio0        { };
++dpi_gpio1:              &rp1_dpi_24bit_gpio2        { };
++dpi_18bit_cpadhi_gpio0: &rp1_dpi_18bit_cpadhi_gpio0 { };
++dpi_18bit_cpadhi_gpio2: &rp1_dpi_18bit_cpadhi_gpio2 { };
++dpi_18bit_gpio0:        &rp1_dpi_18bit_gpio0        { };
++dpi_18bit_gpio2:        &rp1_dpi_18bit_gpio2        { };
++dpi_16bit_cpadhi_gpio0: &rp1_dpi_16bit_cpadhi_gpio0 { };
++dpi_16bit_cpadhi_gpio2: &rp1_dpi_16bit_cpadhi_gpio2 { };
++dpi_16bit_gpio0:        &rp1_dpi_16bit_gpio0        { };
++dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
++
++/* Add the IOMMUs for some RP1 bus masters */
++
++&csi0 {
++	iommus = <&iommu5>;
++};
++
++&csi1 {
++	iommus = <&iommu5>;
++};
++
++&dsi0 {
++	iommus = <&iommu5>;
++};
++
++&dsi1 {
++	iommus = <&iommu5>;
++};
++
++&dpi {
++	iommus = <&iommu5>;
++};
++
++&vec {
++	iommus = <&iommu5>;
++};
++
++&ddc0 {
++	status = "disabled";
++};
++
++&ddc1 {
++	status = "disabled";
++};
++
++&hdmi0 {
++	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 0>, <&clk_27MHz>;
++	clock-names = "hdmi", "bvb", "audio", "cec";
++	status = "disabled";
++};
++
++&hdmi1 {
++	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 1>, <&clk_27MHz>;
++	clock-names = "hdmi", "bvb", "audio", "cec";
++	status = "disabled";
++};
++
++&hvs {
++	clocks = <&firmware_clocks 4>, <&firmware_clocks 16>;
++	clock-names = "core", "disp";
++};
++
++&mop {
++	status = "disabled";
++};
++
++&moplet {
++	status = "disabled";
++};
++
++&pixelvalve0 {
++	status = "disabled";
++};
++
++&pixelvalve1 {
++	status = "disabled";
++};
++
++&disp_intr {
++	status = "disabled";
++};
++
++/* SDIO1 is used to drive the eMMC/SD card */
++&sdio1 {
++	pinctrl-0 = <&emmc_cmddat_pulls>, <&emmc_ds_pull>;
++	pinctrl-names = "default";
++	vqmmc-supply = <&sd_io_1v8_reg>;
++	vmmc-supply = <&sd_vcc_reg>;
++	bus-width = <8>;
++	sd-uhs-sdr50;
++	sd-uhs-ddr50;
++	sd-uhs-sdr104;
++	mmc-hs200-1_8v;
++	broken-cd;
++	supports-cqe;
++	status = "okay";
++};
++
++&pinctrl_aon {
++	ant_pins: ant_pins {
++		function = "gpio";
++		pins = "aon_gpio5", "aon_gpio6";
++	};
++
++	/* Slight hack - only one PWM pin (status LED) is usable */
++	aon_pwm_1pin: aon_pwm_1pin {
++		function = "aon_pwm";
++		pins = "aon_gpio9";
++	};
++};
++
++&pinctrl {
++	pwr_button_pins: pwr_button_pins {
++		function = "gpio";
++		pins = "gpio20";
++		bias-pull-up;
++	};
++
++	wl_on_pins: wl_on_pins {
++		function = "gpio";
++		pins = "gpio28";
++	};
++
++	bt_shutdown_pins: bt_shutdown_pins {
++		function = "gpio";
++		pins = "gpio29";
++	};
++
++	emmc_ds_pull: emmc_ds_pull {
++		pins = "emmc_ds";
++		bias-pull-down;
++	};
++
++	emmc_cmddat_pulls: emmc_cmddat_pulls {
++		pins = "emmc_cmd", "emmc_dat0", "emmc_dat1", "emmc_dat2", "emmc_dat3",
++		       "emmc_dat4", "emmc_dat5", "emmc_dat6", "emmc_dat7";
++		bias-pull-up;
++	};
++};
++
++/* uarta communicates with the BT module */
++&uarta {
++	uart-has-rtscts;
++	auto-flow-control;
++	status = "okay";
++	clock-frequency = <96000000>;
++	pinctrl-0 = <&uarta_24_pins &bt_shutdown_pins>;
++	pinctrl-names = "default";
++
++	bluetooth: bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		max-speed = <3000000>;
++		shutdown-gpios = <&gio 29 GPIO_ACTIVE_HIGH>;
++		local-bd-address = [ 00 00 00 00 00 00 ];
++	};
++};
++
++&i2c_rp1boot {
++	clock-frequency = <400000>;
++	pinctrl-0 = <&i2c3_m4_agpio0_pins>;
++	pinctrl-names = "default";
++};
++
++/ {
++	chosen: chosen {
++		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe";
++		stdout-path = "serial10:115200n8";
++	};
++
++	fan: cooling_fan {
++		status = "disabled";
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-min-state = <0>;
++		cooling-max-state = <3>;
++		cooling-levels = <0 75 125 175 250>;
++		pwms = <&rp1_pwm1 3 41566 PWM_POLARITY_INVERTED>;
++		rpm-regmap = <&rp1_pwm1>;
++		rpm-offset = <0x3c>;
++	};
++
++	pwr_button {
++		compatible = "gpio-keys";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pwr_button_pins>;
++		status = "okay";
++
++		pwr_key: pwr {
++			label = "pwr_button";
++			// linux,code = <205>; // KEY_SUSPEND
++			linux,code = <116>; // KEY_POWER
++			gpios = <&gio 20 GPIO_ACTIVE_LOW>;
++			debounce-interval = <50>; // ms
++		};
++	};
++};
++
++&usb {
++	power-domains = <&power RPI_POWER_DOMAIN_USB>;
++};
++
++/* SDIO2 drives the WLAN interface */
++&sdio2 {
++	pinctrl-0 = <&sdio2_30_pins>, <&ant_pins>;
++	pinctrl-names = "default";
++	bus-width = <4>;
++	vmmc-supply = <&wl_on_reg>;
++	sd-uhs-ddr50;
++	non-removable;
++	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	wifi: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		local-mac-address = [00 00 00 00 00 00];
++	};
++};
++
++&rpivid {
++	status = "okay";
++};
++
++&pinctrl {
++	spi10_gpio2: spi10_gpio2 {
++		function = "vc_spi0";
++		pins = "gpio2", "gpio3", "gpio4";
++		bias-disable;
++	};
++
++	spi10_cs_gpio1: spi10_cs_gpio1 {
++		function = "gpio";
++		pins = "gpio1";
++		bias-pull-up;
++	};
++};
++
++spi10_pins: &spi10_gpio2 {};
++spi10_cs_pins: &spi10_cs_gpio1 {};
++
++&spi10 {
++	pinctrl-names = "default";
++	cs-gpios = <&gio 1 1>;
++	pinctrl-0 = <&spi10_pins &spi10_cs_pins>;
++
++	spidev10: spidev@0 {
++		compatible = "spidev";
++		reg = <0>;	/* CE0 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <20000000>;
++		status = "okay";
++	};
++};
++
++// =============================================
++// bcm2712-rpi-cm5.dtsi board specific stuff
++
++&gio_aon {
++	// Don't use GIO_AON as an interrupt controller because it will
++	// clash with the firmware monitoring the PMIC interrupt via the VPU.
++
++	/delete-property/ interrupt-controller;
++};
++
++&main_aon_irq {
++	// Don't use the MAIN_AON_IRQ interrupt controller because it will
++	// clash with the firmware monitoring the PMIC interrupt via the VPU.
++
++	status = "disabled";
++};
++
++&rp1_pwm1 {
++	status = "disabled";
++	pinctrl-0 = <&rp1_pwm1_gpio45>;
++	pinctrl-names = "default";
++};
++
++&thermal_trips {
++	cpu_tepid: cpu-tepid {
++		temperature = <50000>;
++		hysteresis = <5000>;
++		type = "active";
++	};
++
++	cpu_warm: cpu-warm {
++		temperature = <60000>;
++		hysteresis = <5000>;
++		type = "active";
++	};
++
++	cpu_hot: cpu-hot {
++		temperature = <67500>;
++		hysteresis = <5000>;
++		type = "active";
++	};
++
++	cpu_vhot: cpu-vhot {
++		temperature = <75000>;
++		hysteresis = <5000>;
++		type = "active";
++	};
++};
++
++&cooling_maps {
++	tepid {
++		trip = <&cpu_tepid>;
++		cooling-device = <&fan 1 1>;
++	};
++
++	warm {
++		trip = <&cpu_warm>;
++		cooling-device = <&fan 2 2>;
++	};
++
++	hot {
++		trip = <&cpu_hot>;
++		cooling-device = <&fan 3 3>;
++	};
++
++	vhot {
++		trip = <&cpu_vhot>;
++		cooling-device = <&fan 4 4>;
++	};
++
++	melt {
++		trip = <&cpu_crit>;
++		cooling-device = <&fan 4 4>;
++	};
++};
++
++&gio {
++	// The GPIOs above 35 are not used on Pi 5, so shrink the upper bank
++	// to reduce the clutter in gpioinfo/pinctrl
++	brcm,gpio-bank-widths = <32 4>;
++
++	gpio-line-names =
++		"-", // GPIO_000
++		"2712_BOOT_CS_N", // GPIO_001
++		"2712_BOOT_MISO", // GPIO_002
++		"2712_BOOT_MOSI", // GPIO_003
++		"2712_BOOT_SCLK", // GPIO_004
++		"-", // GPIO_005
++		"-", // GPIO_006
++		"-", // GPIO_007
++		"-", // GPIO_008
++		"-", // GPIO_009
++		"-", // GPIO_010
++		"-", // GPIO_011
++		"-", // GPIO_012
++		"-", // GPIO_013
++		"-", // GPIO_014
++		"-", // GPIO_015
++		"-", // GPIO_016
++		"-", // GPIO_017
++		"-", // GPIO_018
++		"-", // GPIO_019
++		"PWR_GPIO", // GPIO_020
++		"2712_G21_FS", // GPIO_021
++		"-", // GPIO_022
++		"-", // GPIO_023
++		"BT_RTS", // GPIO_024
++		"BT_CTS", // GPIO_025
++		"BT_TXD", // GPIO_026
++		"BT_RXD", // GPIO_027
++		"WL_ON", // GPIO_028
++		"BT_ON", // GPIO_029
++		"WIFI_SDIO_CLK", // GPIO_030
++		"WIFI_SDIO_CMD", // GPIO_031
++		"WIFI_SDIO_D0", // GPIO_032
++		"WIFI_SDIO_D1", // GPIO_033
++		"WIFI_SDIO_D2", // GPIO_034
++		"WIFI_SDIO_D3"; // GPIO_035
++};
++
++&gio_aon {
++	gpio-line-names =
++		"RP1_SDA", // AON_GPIO_00
++		"RP1_SCL", // AON_GPIO_01
++		"RP1_RUN", // AON_GPIO_02
++		"SD_IOVDD_SEL", // AON_GPIO_03
++		"SD_PWR_ON", // AON_GPIO_04
++		"ANT1", // AON_GPIO_05
++		"ANT2", // AON_GPIO_06
++		"-", // AON_GPIO_07
++		"2712_WAKE", // AON_GPIO_08
++		"2712_STAT_LED", // AON_GPIO_09
++		"-", // AON_GPIO_10
++		"-", // AON_GPIO_11
++		"PMIC_INT", // AON_GPIO_12
++		"UART_TX_FS", // AON_GPIO_13
++		"UART_RX_FS", // AON_GPIO_14
++		"-", // AON_GPIO_15
++		"-", // AON_GPIO_16
++
++		// Pad bank0 out to 32 entries
++		"", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
++
++		"HDMI0_SCL", // AON_SGPIO_00
++		"HDMI0_SDA", // AON_SGPIO_01
++		"HDMI1_SCL", // AON_SGPIO_02
++		"HDMI1_SDA", // AON_SGPIO_03
++		"PMIC_SCL", // AON_SGPIO_04
++		"PMIC_SDA"; // AON_SGPIO_05
++
++	rp1_run_hog {
++		gpio-hog;
++		gpios = <2 GPIO_ACTIVE_HIGH>;
++		output-high;
++		line-name = "RP1 RUN pin";
++	};
++
++	ant1: ant1-hog {
++		gpio-hog;
++		gpios = <5 GPIO_ACTIVE_HIGH>;
++		/* internal antenna enabled */
++		output-high;
++		line-name = "ant1";
++	};
++
++	ant2: ant2-hog {
++		gpio-hog;
++		gpios = <6 GPIO_ACTIVE_HIGH>;
++		/* external antenna disabled */
++		output-low;
++		line-name = "ant2";
++	};
++};
++
++&rp1_gpio {
++	gpio-line-names =
++		"ID_SDA", // GPIO0
++		"ID_SCL", // GPIO1
++		"GPIO2", // GPIO2
++		"GPIO3", // GPIO3
++		"GPIO4", // GPIO4
++		"GPIO5", // GPIO5
++		"GPIO6", // GPIO6
++		"GPIO7", // GPIO7
++		"GPIO8", // GPIO8
++		"GPIO9", // GPIO9
++		"GPIO10", // GPIO10
++		"GPIO11", // GPIO11
++		"GPIO12", // GPIO12
++		"GPIO13", // GPIO13
++		"GPIO14", // GPIO14
++		"GPIO15", // GPIO15
++		"GPIO16", // GPIO16
++		"GPIO17", // GPIO17
++		"GPIO18", // GPIO18
++		"GPIO19", // GPIO19
++		"GPIO20", // GPIO20
++		"GPIO21", // GPIO21
++		"GPIO22", // GPIO22
++		"GPIO23", // GPIO23
++		"GPIO24", // GPIO24
++		"GPIO25", // GPIO25
++		"GPIO26", // GPIO26
++		"GPIO27", // GPIO27
++
++		"PCIE_PWR_EN", // GPIO28
++		"FAN_TACH", // GPIO29
++		"HOST_SDA", // GPIO30
++		"HOST_SCL", // GPIO31
++		"ETH_RST_N", // GPIO32
++		"PCIE_DET_WAKE", // GPIO33
++
++		"CD0_IO0_MICCLK", // GPIO34
++		"CD0_IO0_MICDAT0", // GPIO35
++		"RP1_PCIE_CLKREQ_N", // GPIO36
++		"ETH_IRQ_N", // GPIO37
++		"SDA0", // GPIO38
++		"SCL0", // GPIO39
++		"-", // GPIO40
++		"-", // GPIO41
++		"USB_VBUS_EN", // GPIO42
++		"USB_OC_N", // GPIO43
++		"RP1_STAT_LED", // GPIO44
++		"FAN_PWM", // GPIO45
++		"-", // GPIO46
++		"2712_WAKE", // GPIO47
++		"-", // GPIO48
++		"-", // GPIO49
++		"-", // GPIO50
++		"-", // GPIO51
++		"-", // GPIO52
++		"-"; // GPIO53
++
++	usb_vbus_pins: usb_vbus_pins {
++		function = "vbus1";
++		pins = "gpio42", "gpio43";
++	};
++};
++
++// =============================================
++// BCM2712D0 overrides
++
++&gio_aon {
++	brcm,gpio-bank-widths = <15 6>;
++};
++
++&pinctrl {
++	compatible = "brcm,bcm2712d0-pinctrl";
++	reg = <0x7d504100 0x20>;
++};
++
++&pinctrl_aon {
++	compatible = "brcm,bcm2712d0-aon-pinctrl";
++	reg = <0x7d510700 0x1c>;
++};
++
++&vc4 {
++	compatible = "brcm,bcm2712d0-vc6";
++};
++
++&uart10 {
++	interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
++};
++
++&spi10 {
++	dmas = <&dma40 3>, <&dma40 4>;
++};
++
++&hdmi0 {
++	dmas = <&dma40 (12|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
++};
++
++&hdmi1 {
++	dmas = <&dma40 (13|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
++};
++
++// =============================================
++// HA Yellow Board-specific stuff
++
++/ {
++	chosen: chosen {
++		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
++		stdout-path = "serial2:115200n8";
++	};
++
++	keys: gpio-keys {
++		compatible = "gpio-keys";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_button_pins>;
++
++		status = "okay";
++
++		power {
++			label = "Blue Button";
++			linux,code = <KEY_POWER>;
++			gpios = <&rp1_gpio 26 GPIO_ACTIVE_LOW>;
++			debounce-interval = <100>; // ms
++		};
++
++		user {
++			label = "Red Button";
++			linux,code = <BTN_1>;
++			gpios = <&rp1_gpio 27 GPIO_ACTIVE_LOW>;
++			debounce-interval = <100>; // ms
++		};
++	};
++};
++
++/* Always enable the NVMe slot. */
++&pcie1 {
++	status = "okay";
++};
++
++/* Avoid probing pcie2 in U-Boot for now, it breaks RP1. */
++&rp1_target {
++	u-boot,no-probe;
++};
++
++/* 
++ * Skip init of debug UART to fix garbled U-Boot output, it's not explicitly
++ * skipped in BCM2712 device tree like in BCM2711's ones.
++ */
++&uart10 {
++	skip-init;
++};
++
++/* RP1 USB ports are not connected on Yellow. */
++&rp1_usb0 {
++	status = "disabled";
++};
++
++&rp1_usb1 {
++	status = "disabled";
++};
++
++&leds {
++	led_act: led-act {
++		label = "act";
++		default-state = "off";
++		linux,default-trigger = "activity";
++		gpios = <&gio_aon 9 GPIO_ACTIVE_HIGH>;
++	};
++
++	led_pwr: led-pwr {
++		label = "pwr";
++		default-state = "off";
++		linux,default-trigger = "default-on";
++		gpios = <&rp1_gpio 44 GPIO_ACTIVE_LOW>;
++	};
++
++	led_usr: led-usr {
++		label = "usr";
++		linux,default-trigger = "heartbeat";
++		default-state = "off";
++		panic-indicator;
++		gpios = <&rp1_gpio 38 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&gpio {
++	gpio_button_pins: gpio_button_pins {
++		function = "gpio";
++		pins = "gpio26", "gpio27";
++		bias-pull-up;
++	};
++};
++
++/* UART on pin header */
++&uart0 {
++	status = "okay";
++	pinctrl-0 = <&rp1_uart0_14_15>;
++};
++
++/* UART for Zigbee */
++&uart3 {
++	status = "okay";
++	pinctrl-0 = <&rp1_uart3_8_9 &rp1_uart3_ctsrts_10_11>;
++	uart-has-rtscts;
++};
++
++/* UART for USB console */
++&uart4 {
++	status = "okay";
++	pinctrl-0 = <&rp1_uart4_12_13>;
++};
++
++&usb {
++	compatible = "brcm,bcm2835-usb";
++	dr_mode = "host";
++	g-np-tx-fifo-size = <32>;
++	g-rx-fifo-size = <558>;
++	g-tx-fifo-size = <512 512 512 512 512 256 256>;
++	status = "okay";
++};
++
++/* I2C pins on pin header */
++&i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rp1_i2c1_2_3>;
++	clock-frequency = <100000>;
++};
++
++/* Board-level I2C (RTC and I2S audio) */
++&rp1_i2c3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rp1_i2c3_22_23>;
++	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	card_codec: pcm5121@4c {
++		#sound-dai-cells = <0>;
++		compatible = "ti,pcm5121";
++		reg = <0x4c>;
++		AVDD-supply = <&vdd_3v3_reg>;
++		DVDD-supply = <&vdd_3v3_reg>;
++		CPVDD-supply = <&vdd_3v3_reg>;
++		status = "okay";
++	};
++
++	pcf85063a: rtc@51 {
++		compatible = "nxp,pcf85063a";
++		reg = <0x51>;
++	};
++};
++
++&rp1_i2s0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rp1_i2s0_18_21>;
++	status = "okay";
++};
++
++&sound {
++	compatible = "simple-audio-card";
++	simple-audio-card,format = "i2s";
++	simple-audio-card,name = "pcm5121-sound";
++	status = "okay";
++
++	simple-audio-card,cpu {
++		sound-dai = <&rp1_i2s0>;
++	};
++
++	dailink0_slave: simple-audio-card,codec {
++		sound-dai = <&card_codec>;
++	};
++};
++
++/ {
++	aliases: aliases {
++		blconfig = &blconfig;
++		blpubkey = &blpubkey;
++		bluetooth = &bluetooth;
++		console = &uart10;
++		ethernet0 = &rp1_eth;
++		wifi0 = &wifi;
++		fb = &fb;
++		mailbox = &mailbox;
++		mmc0 = &sdio1;
++		uart10 = &uart10;
++		serial0 = &uart0;
++		serial1 = &uart3;
++		serial2 = &uart4;
++		serial10 = &uart10;
++		i2c = &i2c_arm;
++		i2c0 = &i2c0;
++		i2c1 = &i2c1;
++		i2c2 = &i2c2;
++		i2c3 = &i2c3;
++		i2c4 = &i2c4;
++		i2c5 = &i2c5;
++		i2c6 = &i2c6;
++		i2c10 = &i2c_rp1boot;
++		// Bit-bashed i2c_gpios start at 10
++		spi0 = &spi0;
++		spi1 = &spi1;
++		spi2 = &spi2;
++		spi3 = &spi3;
++		spi4 = &spi4;
++		spi5 = &spi5;
++		spi10 = &spi10;
++		gpio0 = &gpio;
++		gpio1 = &gio;
++		gpio2 = &gio_aon;
++		gpio3 = &pinctrl;
++		gpio4 = &pinctrl_aon;
++		usb0 = &rp1_usb0;
++		usb1 = &rp1_usb1;
++		drm-dsi1 = &dsi0;
++		drm-dsi2 = &dsi1;
++	};
++
++	__overrides__ {
++		bdaddr = <&bluetooth>, "local-bd-address[";
++		button_debounce = <&pwr_key>, "debounce-interval:0";
++		uart0_console = <&uart0>,"status", <&aliases>, "console=",&uart0;
++		i2c1 = <&i2c1>, "status";
++		i2c = <&i2c1>, "status";
++		i2c_arm = <&i2c_arm>, "status";
++		i2c_vc = <&i2c_vc>, "status";
++		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
++		i2c_csi_dsi0 = <&i2c_csi_dsi0>, "status";
++		i2c_csi_dsi1 = <&i2c_csi_dsi1>, "status";
++		i2c1_baudrate = <&i2c1>, "clock-frequency:0";
++		i2c_baudrate = <&i2c_arm>, "clock-frequency:0";
++		i2c_arm_baudrate = <&i2c_arm>, "clock-frequency:0";
++		i2c_vc_baudrate = <&i2c_vc>, "clock-frequency:0";
++		krnbt = <&bluetooth>, "status";
++		nvme = <&pciex1>, "status";
++		pciex1 = <&pciex1>, "status";
++		pciex1_gen = <&pciex1> , "max-link-speed:0";
++		pciex1_no_l0s = <&pciex1>, "aspm-no-l0s?";
++		pciex1_tperst_clk_ms = <&pciex1>, "brcm,tperst-clk-ms:0";
++		pcie_tperst_clk_ms = <&pciex1>, "brcm,tperst-clk-ms:0";
++		random = <&random>, "status";
++		spi = <&spi0>, "status";
++		suspend = <&pwr_key>, "linux,code:0=205";
++		uart0 = <&uart0>, "status";
++		wifiaddr = <&wifi>, "local-mac-address[";
++
++		act_led_activelow = <&led_act>, "active-low?";
++		act_led_trigger = <&led_act>, "linux,default-trigger";
++		pwr_led_activelow = <&led_pwr>, "gpios:8";
++		pwr_led_trigger = <&led_pwr>, "linux,default-trigger";
++		usr_led_trigger = <&led_usr>, "linux,default-trigger";
++		eth_led0 = <&phy1>,"led-modes:0";
++		eth_led1 = <&phy1>,"led-modes:4";
++
++		ant1 =  <&ant1>,"output-high?=on",
++			<&ant1>, "output-low?=off",
++			<&ant2>, "output-high?=off",
++			<&ant2>, "output-low?=on";
++		ant2 =  <&ant1>,"output-high?=off",
++			<&ant1>, "output-low?=on",
++			<&ant2>, "output-high?=on",
++			<&ant2>, "output-low?=off";
++		noant = <&ant1>,"output-high?=off",
++			<&ant1>, "output-low?=on",
++			<&ant2>, "output-high?=off",
++			<&ant2>, "output-low?=on";
++	};
++};
+-- 
+2.47.0
+


### PR DESCRIPTION
I've cross built this after commenting out the `broken = [...]` section, and have set `device_tree=bcm2711-rpi-cm4-ha-yellow.dtb` in my `config.txt`. With those in place, the zigbee radio works in home-assistant, without further adjustments of the `config.txt`. I have reverted the rest to be like what `base-rpi` ships.