### PR TITLE
cbuild: fix prepare-upgrade only updating one sha256

### DIFF
--- a/src/cbuild/hooks/fetch/000_sources.py
+++ b/src/cbuild/hooks/fetch/000_sources.py
@@ -30,16 +30,15 @@ def make_link(dfile, cksum):
             linkpath.hardlink_to(dfile)
 
 
-def verify_cksum(dfile, cksum, pkg):
+def verify_cksum(dfile, idx, pkg):
+    cksum = pkg.sha256[idx]
     pkg.log(f"verifying sha256sums for source '{dfile.name}'... ", "")
     filesum = get_cksum(dfile, pkg)
     if cksum != filesum:
         if pkg.accept_checksums:
             pkg.logger.out_plain("")
             pkg.logger.out(f"\f[orange]SHA256 UPDATED: {cksum} -> {filesum}")
-            for i in range(len(pkg.sha256)):
-                if pkg.sha256[i] == cksum:
-                    pkg.sha256[i] = filesum
+            pkg.sha256[idx] = filesum
             return True
         else:
             pkg.logger.out_plain("")
@@ -326,10 +325,10 @@ def invoke(pkg):
     if ferrs > 0:
         pkg.error(f"failed to fetch {ferrs} sources")
     # verify the sources
-    for dfile, ck in dfiles:
+    for idx, [dfile, _] in enumerate(dfiles):
         if not dfile.is_file():
             pkg.error(f"source '{dfile}' does not exist")
-        if not verify_cksum(dfile, ck, pkg):
+        if not verify_cksum(dfile, idx, pkg):
             errors += 1
     # error if something failed to verify
     if errors > 0:


### PR DESCRIPTION
If multiple sha256 strings in a template start as the same initial value (i.e. all the empty string) before prepare-upgrade is run, prepare-upgrade will only update the first source's checksum. 

Example of old behaviour:
```
sha256 = [
    "",
    "",
]
```
`./cbuild prepare-upgrade user/foo`
```
sha256 = [
    "2bdb2943db86338fdfcb452fbb6d84e7a4ad05712492dd564d4e5c84a4c8d750",
    "",
]
```
`./cbuild prepare-upgrade user/foo`
```
sha256 = [
    "2bdb2943db86338fdfcb452fbb6d84e7a4ad05712492dd564d4e5c84a4c8d750",
    "8fa3b0b66914ae2dd4ddef9a954f614c5b3eb6ac9d80ee61ae2d08e3178507ec",
]
```