### PR TITLE
user/incus: Add gtar as dependency

### DIFF
--- a/user/incus/template.py
+++ b/user/incus/template.py
@@ -27,6 +27,7 @@ depends = [
     "acl-progs",
     "attr-progs",
     "dnsmasq",
+    "gtar",
     "iptables",
     "libvirt",
     "lxc",

--- a/user/incus/template.py
+++ b/user/incus/template.py
@@ -1,6 +1,6 @@
 pkgname = "incus"
 pkgver = "6.7.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["./cmd/..."]
 make_check_args = ["-skip", "TestConvertNetworkConfig", "./..."]


### PR DESCRIPTION
So happy to see incus on Chimera!

When I gave it a try, I noticed that after a base system install, gtar was missing, and was necessary for incus to launch a container. It wasn't installed as a dependency, hence this pull request.