### PR TITLE
user/incus: Add gtar as dependency

### DIFF
--- a/user/incus/template.py
+++ b/user/incus/template.py
@@ -1,6 +1,6 @@
 pkgname = "incus"
 pkgver = "6.7.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["./cmd/..."]
 make_check_args = ["-skip", "TestConvertNetworkConfig", "./..."]
@@ -27,6 +27,7 @@ depends = [
     "acl-progs",
     "attr-progs",
     "dnsmasq",
+    "gtar",
     "iptables",
     "libvirt",
     "lxc",


### PR DESCRIPTION
gtar is necessary for incus to launch containers but not included as a dependency, and not installed in the base install.