### PR TITLE
Update amdgpu_top, perl-image-exiftool, rust-analyzer, tio, wasm-component-ld

### DIFF
--- a/main/amdgpu_top/template.py
+++ b/main/amdgpu_top/template.py
@@ -1,5 +1,5 @@
 pkgname = "amdgpu_top"
-pkgver = "0.9.2"
+pkgver = "0.10.0"
 pkgrel = 0
 build_style = "cargo"
 make_build_args = ["--no-default-features", "--features=package"]
@@ -16,7 +16,7 @@ maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "MIT"
 url = "https://github.com/Umio-Yasuno/amdgpu_top"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "df447ff5cb4bd3ba70e80b6c180eb4f7b5b6aefc23a0436b194c3edc55c43e81"
+sha256 = "116020dcd15d0390ed55a0dffea6e110e658926d6bfa444bf1c23edc2cb794ad"
 # no tests
 options = ["!check"]
 

--- a/main/perl-image-exiftool/template.py
+++ b/main/perl-image-exiftool/template.py
@@ -1,5 +1,5 @@
 pkgname = "perl-image-exiftool"
-pkgver = "13.03"
+pkgver = "13.04"
 pkgrel = 0
 build_style = "perl_module"
 hostmakedepends = ["perl"]
@@ -10,7 +10,7 @@ maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "Artistic-1.0-Perl OR GPL-1.0-or-later"
 url = "https://exiftool.org"
 source = f"https://exiftool.org/Image-ExifTool-{pkgver}.tar.gz"
-sha256 = "0912e1315318889574f355e5832340632c556a14d30711e94d801085ad0a8e4f"
+sha256 = "bd14e06a3f2cf167999675e78cbaff396929ec442be0ab86c5cd0599223e6c3a"
 
 
 @subpackage("exiftool")

--- a/main/rust-analyzer/template.py
+++ b/main/rust-analyzer/template.py
@@ -1,5 +1,5 @@
 pkgname = "rust-analyzer"
-pkgver = "2024.11.25"
+pkgver = "2024.12.02"
 pkgrel = 0
 build_style = "cargo"
 make_env = {"CARGO_PROFILE_RELEASE_PANIC": "unwind"}
@@ -10,7 +10,7 @@ maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "Apache-2.0 OR MIT"
 url = "https://github.com/rust-lang/rust-analyzer"
 source = f"{url}/archive/refs/tags/{pkgver.replace('.', '-')}.tar.gz"
-sha256 = "e131f4ff85b1e234fbaaf3bef8cf6b86baab5aeeb994a9020811d6ba5fc027d5"
+sha256 = "2fc8ac52f7c14566d905cd096da970750117c3214ac0875777fdab4fd77933fb"
 # invokes rustfmt via rustup arg, also take longer to build than the actual
 # build..
 options = ["!check"]

--- a/main/tio/template.py
+++ b/main/tio/template.py
@@ -1,5 +1,5 @@
 pkgname = "tio"
-pkgver = "3.7"
+pkgver = "3.8"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -17,4 +17,4 @@ maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "GPL-2.0-or-later"
 url = "https://github.com/tio/tio"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "9e39b57f38a5648b87b436e66edc54103e1deee23d78a8c5a097f314967cc326"
+sha256 = "c0e68c96f28a5b4daaf94eba31b066853efd1f1ea396c75a6cc168f2e95cdea3"

--- a/main/wasm-component-ld/template.py
+++ b/main/wasm-component-ld/template.py
@@ -1,5 +1,5 @@
 pkgname = "wasm-component-ld"
-pkgver = "0.5.10"
+pkgver = "0.5.11"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable"]
@@ -11,7 +11,7 @@ maintainer = "Orphaned <orphaned@chimera-linux.org>"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 url = "https://github.com/bytecodealliance/wasm-component-ld"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "aa049a93da595e4dacf742865f13e7fb1cec1ab47de9258f0a11d81ad6c7a77b"
+sha256 = "323328b18a1e13e35e36339ce59c6e7c4d1800b4fbdd78ba6fa83f3358324414"
 
 
 def post_install(self):


### PR DESCRIPTION
After @nekopsykose left the Chimera Linux project, I decided to update some orphaned packages. I chose these 5 packages randomly. I will not adopt those packages.

Updated packages:
* main/amdgpu_top (0.10.0)
* main/perl-image-exiftool (13.04)
* main/rust-analyzer (2024.12.02)
* main/tio (3.8)
* main/wasm-component-ld (0.5.11)