### PR TITLE
main/oksh: update to 7.6

### DIFF
--- a/main/oksh/template.py
+++ b/main/oksh/template.py
@@ -1,6 +1,6 @@
 pkgname = "oksh"
-pkgver = "7.5"
-pkgrel = 1
+pkgver = "7.6"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_gen = []
 make_dir = "."
@@ -9,8 +9,8 @@ pkgdesc = "Portable OpenBSD ksh, based on pdksh"
 maintainer = "ttyyls <contact@behri.org>"
 license = "custom:none"
 url = "https://github.com/ibara/oksh"
-source = f"{url}/releases/download/oksh-{pkgver}/oksh-{pkgver}.tar.gz"
-sha256 = "40b895c3f8e9311bfe2b230e9b3786712550ef488ced33bfd7cd3f89fceeed5d"
+source = f"{url}/archive/refs/tags/oksh-{pkgver}.tar.gz"
+sha256 = "159fb914694d6f14d23eb87ecb551b42d4356907820e5cc1cc8c327dc5c24c6a"
 hardening = ["vis", "cfi"]
 # There are no tests
 options = ["!check"]


### PR DESCRIPTION
## Description

~~While this update builds and runs fine, a (hacky) change of build_wrksrc was required
due to what seems like a faulty tarball generation script adding unecessary symlinks
to stuff... weird~~
tarball was changed silently fixing the issue

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
