### PR TITLE
main/power-profiles-daemon: fix tlp conflict

### DIFF
--- a/main/power-profiles-daemon/template.py
+++ b/main/power-profiles-daemon/template.py
@@ -1,6 +1,6 @@
 pkgname = "power-profiles-daemon"
 pkgver = "0.23"
-pkgrel = 2
+pkgrel = 3
 build_style = "meson"
 configure_args = [
     "--libexecdir=/usr/lib",  # XXX drop libexec
@@ -19,7 +19,7 @@ makedepends = [
     "polkit-devel",
     "upower-devel",
 ]
-depends = ["dinit-dbus", "!tlp", "python-gobject"]
+depends = ["dinit-dbus", "!tlp-dinit", "python-gobject"]
 checkdepends = ["python-dbusmock", "umockdev"]
 install_if = [self.with_pkgver("power-profiles-daemon-meta")]
 pkgdesc = "D-Bus daemon for power management control"


### PR DESCRIPTION
## Description
tlp is also used independently to set battery charging limits on supported hardware.  
That functionality does not clash with power-profiles-daemon.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
