### PR TITLE
cbuild: add cargo update function to cargo.py

### DIFF
--- a/src/cbuild/util/cargo.py
+++ b/src/cbuild/util/cargo.py
@@ -117,7 +117,7 @@ class Cargo:
             wrksrc = tmpl.make_dir
 
         bargs = []
-        if command != "vendor":
+        if command != "vendor" and command != "update":
             bargs += ["--target", tmpl.profile().triplet]
 
         if offline:
@@ -321,6 +321,28 @@ class Cargo:
             tmpl.make_check_args + args,
             jobs,
             True,
+            tmpl.make_check_env,
+            env,
+            wrksrc,
+            tmpl.make_check_wrapper,
+            wrapper,
+        )
+
+    def update(
+        self,
+        args=[],
+        command="update",
+        jobs=None,
+        env={},
+        wrksrc=None,
+        wrapper=[],
+    ):
+        tmpl = self.template
+        return self._invoke(
+            command,
+            tmpl.make_check_args + args,
+            jobs,
+            False,
             tmpl.make_check_env,
             env,
             wrksrc,


### PR DESCRIPTION
## Description

Add `update` function into cargo.py to easily launch `cargo update <arg>` if needed for some Rust packages. Sometimes, due to an old configuration and a more recent rust version, it may be needed to update the dependencies of a package as recorded in the local lock file.
## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
