### PR TITLE
user/openttd: make update check only match stable versions

### DIFF
--- a/user/openttd/update.py
+++ b/user/openttd/update.py
@@ -1,2 +1,2 @@
 url = "https://cdn.openttd.org/openttd-releases/latest.yaml"
-pattern = r"version:\s*([\d.]+)"
+pattern = r"version:\s*([\d.]+)(?=\n.*stable)"


### PR DESCRIPTION
## Description

the original update check matched the last version in the file, regardless of what channel it was
the updated pattern only matches if the version is stable
i'm not sure whether i need to bump the pkgrel for a change like this, if yes please let me know and i'll do

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine