### PR TITLE
main/openpgp-card-tool-git: update to 0.1.5

### DIFF
--- a/main/openpgp-card-tool-git/patches/0001-Update-stderr-of-test-case-to-match-new-expected-out.patch
+++ b/main/openpgp-card-tool-git/patches/0001-Update-stderr-of-test-case-to-match-new-expected-out.patch
@@ -1,0 +1,27 @@
+From 651c8eef8570be3223ff1807bf1b17868ab8af58 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Tue, 31 Dec 2024 18:44:01 +0100
+Subject: [PATCH] Update stderr of test case to match new expected output of
+ updated rpgp
+
+---
+ tests/test-cases/message/stderr | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/test-cases/message/stderr b/tests/test-cases/message/stderr
+index 000d201..af1f4bb 100644
+--- a/tests/test-cases/message/stderr
++++ b/tests/test-cases/message/stderr
+@@ -1,5 +1,5 @@
+ oct-git: Signature created 2024-03-22 09:09:50 UTC
+-oct-git:      by EdDSA key 0c7c54912fd932bcdf13726a767ce224db311b3c
+-oct-git: Good signature by 0c7c54912fd932bcdf13726a767ce224db311b3c
+-oct-git: Certificate 653909a2f0e37c106f5faf546c8857e0d8e8f074
++oct-git:      by EdDSALegacy key 0c7c54912fd932bcdf13726a767ce224db311b3c
++oct-git: Good signature by 0c7c54912fd932bcdf13726a767ce224db311b3c [expired]
++oct-git: Certificate 653909a2f0e37c106f5faf546c8857e0d8e8f074 [expired]
+ oct-git: Signer User ID "Wiktor Kwapisiewicz <wiktor@metacode.biz>"
+-- 
+2.47.1
+

--- a/main/openpgp-card-tool-git/template.py
+++ b/main/openpgp-card-tool-git/template.py
@@ -1,5 +1,5 @@
 pkgname = "openpgp-card-tool-git"
-pkgver = "0.1.4"
+pkgver = "0.1.5"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "pkgconf"]
@@ -16,7 +16,7 @@ maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license = "Apache-2.0 OR MIT"
 url = "https://codeberg.org/openpgp-card/tool-git"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "1bf653e40f6ceea03e0dad3c6e8b89c2c099ec580b249a5e2936904388e49507"
+sha256 = "4d8bba39568c5bdad36cc987f4acd5faa958fde595693a049182eb88b9821d01"
 
 
 def post_install(self):


### PR DESCRIPTION
Bump oct-git to 0.1.5. The patch was discussed with upstream, this is caused by an update of a dep and updating the test case was missed.
