### PR TITLE
main/corrosion: update to 0.5.1

### DIFF
--- a/main/corrosion/template.py
+++ b/main/corrosion/template.py
@@ -1,5 +1,5 @@
 pkgname = "corrosion"
-pkgver = "0.5.0"
+pkgver = "0.5.1"
 pkgrel = 0
 build_style = "cmake"
 hostmakedepends = ["cmake", "ninja", "cargo-auditable"]
@@ -9,7 +9,7 @@ maintainer = "Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license = "MIT"
 url = "https://github.com/corrosion-rs/corrosion"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "bbe0d4a31cef91b890134af82789fb6e8ecc33270472beea9cecb8f2b7b7ed65"
+sha256 = "843334a9f0f5efbc225dccfa88031fe0f2ec6fd787ca1e7d55ed27b2c25d9c97"
 # Checks require rustup, because they support specifying specific toolchains
 options = ["!check"]
 


### PR DESCRIPTION
## Description

Bump corrosion to 0.5.1. I have built all packages depending on corrosion with the new version, seems to still work.

