### PR TITLE
main/foot: update to 1.20.0

### DIFF
--- a/main/foot/template.py
+++ b/main/foot/template.py
@@ -1,5 +1,5 @@
 pkgname = "foot"
-pkgver = "1.19.0"
+pkgver = "1.20.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dterminfo-base-name=foot-extra"]
@@ -27,7 +27,7 @@ maintainer = "flukey <flukey@vapourmail.eu>"
 license = "MIT"
 url = "https://codeberg.org/dnkl/foot"
 source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "148b0b545ca37e15b877ff9f6a768a4ce6feb0ed256f8a5f853cb2e16e3323c1"
+sha256 = "e3d2fd87ff3a8d5b849b6766374d1e660256c3194916e4ef75ab7382d8756fc5"
 hardening = ["vis", "cfi"]
 
 

--- a/main/utf8proc/patches/nostatic.patch
+++ b/main/utf8proc/patches/nostatic.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 94f76e3..0e516c1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -51,7 +51,7 @@ pkgincludedir=$(includedir:$(prefix)/%=%)
+ 
+ .PHONY: all clean data update manifest install
+ 
+-all: libutf8proc.a libutf8proc.$(SHLIB_EXT)
++all: libutf8proc.$(SHLIB_EXT)
+ 
+ clean:
+ 	rm -f utf8proc.o libutf8proc.a libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.$(SHLIB_EXT)
+@@ -105,11 +105,10 @@ libutf8proc.pc: libutf8proc.pc.in
+ 		-e 's#VERSION#$(MAJOR).$(MINOR).$(PATCH)#' \
+ 		libutf8proc.pc.in > libutf8proc.pc
+ 
+-install: libutf8proc.a libutf8proc.$(SHLIB_EXT) libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.pc
++install: libutf8proc.$(SHLIB_EXT) libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.pc
+ 	mkdir -m 755 -p $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 644 utf8proc.h $(DESTDIR)$(includedir)
+ 	mkdir -m 755 -p $(DESTDIR)$(libdir)
+-	$(INSTALL) -m 644 libutf8proc.a $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)
+ 	mkdir -m 755 -p $(DESTDIR)$(pkgconfigdir)
+ 	$(INSTALL) -m 644 libutf8proc.pc $(DESTDIR)$(pkgconfigdir)/libutf8proc.pc

--- a/main/utf8proc/template.py
+++ b/main/utf8proc/template.py
@@ -1,5 +1,5 @@
 pkgname = "utf8proc"
-pkgver = "2.9.0"
+pkgver = "2.10.0"
 pkgrel = 0
 build_style = "makefile"
 make_install_args = ["prefix=/usr"]
@@ -9,7 +9,7 @@ maintainer = "flukey <flukey@vapourmail.eu>"
 license = "MIT"
 url = "https://github.com/JuliaStrings/utf8proc"
 source = f"{url}/archive/v{pkgver}/utf8proc-{pkgver}.tar.gz"
-sha256 = "18c1626e9fc5a2e192311e36b3010bfc698078f692888940f1fa150547abb0c1"
+sha256 = "6f4f1b639daa6dca9f80bc5db1233e9cbaa31a67790887106160b33ef743f136"
 hardening = ["vis", "cfi"]
 # cannot run check because Julia isn't packaged
 options = ["!check"]


### PR DESCRIPTION
## Description
as part of the ut8proc update also disables the build/install of the static library
since the whole library is built with cfi.
the patch could be reverted in favor of disabling cfi, but it remains unclear which option is better.

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
