### PR TITLE
user/b43-fwcutter: new package

### DIFF
--- a/user/b43-fwcutter/template.py
+++ b/user/b43-fwcutter/template.py
@@ -1,0 +1,18 @@
+pkgname = "b43-fwcutter"
+pkgver = "019"
+pkgrel = 0
+build_style = "makefile"
+pkgdesc = "Tool to extract firmware for Broadcom 43xx wireless chips"
+maintainer = "breakgimme <adam@plock.com>"
+license = "BSD-2-Clause"
+url = "https://wireless.docs.kernel.org/en/latest/en/users/drivers/b43.html"
+source = f"https://bues.ch/b43/fwcutter/b43-fwcutter-{pkgver}.tar.bz2"
+sha256 = "d6ea85310df6ae08e7f7e46d8b975e17fc867145ee249307413cfbe15d7121ce"
+# no tests
+options = ["!check"]
+
+
+def install(self):
+    self.install_license("COPYING")
+    self.install_bin("b43-fwcutter")
+    self.install_man("b43-fwcutter.1")


### PR DESCRIPTION
## Description

this package adds a tool that extracts firmware for broadcomm 43xx from proprietary drivers (notably needed to get wifi working on some powerpc macs)
i haven't packaged the firmware itself as there's no license so it probably can't be legally redistributed by itself

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
