### PR TITLE
user/go-task: new package

### DIFF
--- a/user/go-task/template.py
+++ b/user/go-task/template.py
@@ -1,0 +1,23 @@
+pkgname = "go-task"
+pkgver = "3.40.1"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    f"-ldflags=-X github.com/go-task/task/v3/internal/version.version=v{pkgver}",
+    "./cmd/task",
+]
+hostmakedepends = ["go"]
+pkgdesc = "Task runner / simpler Make alternative written in Go"
+maintainer = "Mathijs Rietbergen <mathijs.rietbergen@proton.me>"
+license = "MIT"
+url = "https://taskfile.dev"
+source = f"https://github.com/go-task/task/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "e80cdfa2afefa69238e5078960d50a8e703de1043740b277946629ca5f3bde85"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+    self.install_completion("completion/fish/task.fish", "fish", "task")
+    self.install_completion("completion/bash/task.bash", "bash", "task")
+    self.install_completion("completion/zsh/_task", "zsh", "task")


### PR DESCRIPTION
## Description
Cool tool, much like a modernized version of Makefiles with a focus towards running commands rather than compiling software.
The naming is not very consistent though; the project itself seems to call it `task` most of the time, but in other places, `go-task` is used more often. This is of course because it is such a generic name. To avoid conflict, it seemed wise to name the package go-task. What do you think of this?

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
