### PR TITLE
main/editline: new package

### DIFF
--- a/main/editline-devel
+++ b/main/editline-devel
@@ -1,0 +1,1 @@
+editline

--- a/main/editline/template.py
+++ b/main/editline/template.py
@@ -1,0 +1,21 @@
+pkgname = "editline"
+pkgver = "1.17.1"
+pkgrel = 0
+build_style = "configure"
+configure_args = ["--prefix=/usr"]
+hostmakedepends = ["pkgconf"]
+pkgdesc = "Small replacement for GNU readline() for UNIX"
+maintainer = "Mathijs Rietbergen <mathijs.rietbergen@proton.me>"
+license = "custom:editline"
+url = "https://troglobit.com/projects/editline"
+source = f"https://github.com/troglobit/editline/releases/download/{pkgver}/editline-{pkgver}.tar.xz"
+sha256 = "df223b3333a545fddbc67b49ded3d242c66fadf7a04beb3ada20957fcd1ffc0e"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+@subpackage("editline-devel")
+def _(self):
+    return self.default_devel()


### PR DESCRIPTION
## Description
Simple, small readline alternative. It is claims to be call-compatible with gnu readline, but only a fraction of the size.

What I wasn't sure of is if this should go in `main` or in `user`, as it is a really simple system library on which a lot of programs could depend (I came across it when trying to package nix for chimera btw). The software has been around for ages (1992) and the build completes cleanly with no parts skipped, so stability is not really a problem I would say.
But then on the other hand, it is a new contribution, so then it should go in `user`.
Any thoughts on this?

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
