### PR TITLE
main/easyeffects: rebuild for fmt

### DIFF
--- a/main/easyeffects/template.py
+++ b/main/easyeffects/template.py
@@ -1,6 +1,6 @@
 pkgname = "easyeffects"
 pkgver = "7.2.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = ["-Denable-libcpp-workarounds=true"]
 hostmakedepends = [


### PR DESCRIPTION
fixes `Error relocating /usr/bin/easyeffects: _ZN3fmt3v116detail10locale_refC1INSt3__16localeETnNS4_9enable_ifIXneszsrT_7collateLi0EEiE4typeELi0EEERKS7_: symbol not found`