### PR TITLE
main/python-numpy: make tests depend on pytest

### DIFF
--- a/main/python-numpy/template.py
+++ b/main/python-numpy/template.py
@@ -1,6 +1,6 @@
 pkgname = "python-numpy"
 pkgver = "2.2.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "python_pep517"
 make_build_args = []
 hostmakedepends = [
@@ -101,7 +101,10 @@ def post_install(self):
 @subpackage("python-numpy-tests")
 def _(self):
     self.subdesc = "tests"
-    self.depends += ["python"]
+    self.depends += [
+        "python-pytest",
+        self.parent,
+    ]
     return [
         "usr/lib/python*/site-packages/numpy/*/tests/",
         "usr/lib/python*/site-packages/numpy/tests/",


### PR DESCRIPTION
maybe this doesn't need a relbump?