### PR TITLE
main/playerctl: add user service, adopt

### DIFF
--- a/main/playerctl/files/playerctld.user
+++ b/main/playerctl/files/playerctld.user
@@ -1,0 +1,5 @@
+type = process
+command = /usr/bin/playerctld
+depends-on = dbus
+depends-on = graphical.target
+log-type = buffer

--- a/main/playerctl/template.py
+++ b/main/playerctl/template.py
@@ -1,6 +1,6 @@
 pkgname = "playerctl"
 pkgver = "2.4.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = ["-Dgtk-doc=false"]
 hostmakedepends = [
@@ -10,7 +10,7 @@ hostmakedepends = [
 ]
 makedepends = ["glib-devel"]
 pkgdesc = "MPRIS media player CLI tool"
-maintainer = "Orphaned <orphaned@chimera-linux.org>"
+maintainer = "ttyyls <contact@behri.org>"
 license = "LGPL-3.0-or-later"
 url = "https://github.com/altdesktop/playerctl"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
@@ -25,3 +25,7 @@ def _(self):
 @subpackage("playerctl-libs")
 def _(self):
     return self.default_libs()
+
+
+def post_install(self):
+    self.install_service(self.files_path / "playerctld.user")


### PR DESCRIPTION
## Description

quoting the manpage

```
     Playerctl also comes with a daemon called playerctld which keeps track of
     media player activity. When playerctld is running, playerctl commands
     will act on the media player with the most recent activity.  Run the
     command playerctld daemon to start the daemon.

```

on systemd based distributions the dbus activation is tied to $DISPLAY, although
I don't see why not set it at a login.target since mpris is still usable and
thus potentially controllable on non-graphical environments.

regardless, the service depends on graphical.target and dbus to remain inline
with upstream expectations see:
https://github.com/altdesktop/playerctl#playerctld-autostart-issues

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
