### PR TITLE
main/python-referencing: make compatible with python3.12

### DIFF
--- a/main/python-referencing/patches/python-3.12-support.patch
+++ b/main/python-referencing/patches/python-3.12-support.patch
@@ -1,0 +1,38 @@
+diff --git a/referencing/_core.py b/referencing/_core.py
+index ec2d51b..f72a292 100644
+--- a/referencing/_core.py
++++ b/referencing/_core.py
+@@ -599,7 +599,6 @@ AnchorOrResource = TypeVar(
+     "AnchorOrResource",
+     AnchorType[Any],
+     Resource[Any],
+-    default=Resource[Any],
+ )
+ 
+ 
+diff --git a/referencing/retrieval.py b/referencing/retrieval.py
+index 53e0512..ea52ddb 100644
+--- a/referencing/retrieval.py
++++ b/referencing/retrieval.py
+@@ -19,7 +19,7 @@ if TYPE_CHECKING:
+     from referencing.typing import URI, D, Retrieve
+ 
+ #: A serialized document (e.g. a JSON string)
+-_T = TypeVar("_T", default=str)
++_T = TypeVar("_T")
+ 
+ 
+ def to_cached_resource(
+diff --git a/referencing/typing.py b/referencing/typing.py
+index a614464..7b50b87 100644
+--- a/referencing/typing.py
++++ b/referencing/typing.py
+@@ -19,7 +19,7 @@ if TYPE_CHECKING:
+ URI = str
+ 
+ #: The type of documents within a registry.
+-D = TypeVar("D", default=Any)
++D = TypeVar("D")
+ 
+ 
+ class Retrieve(Protocol[D]):

--- a/main/python-referencing/template.py
+++ b/main/python-referencing/template.py
@@ -1,6 +1,6 @@
 pkgname = "python-referencing"
 pkgver = "0.36.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "python_pep517"
 # the tests in suite/ depend on jsonschema
 make_check_args = ["referencing"]


### PR DESCRIPTION
## Description

The current `python-referencing` package uses a Python 3.13 feature, this patch is needed until we upgrade Python.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
