### PR TITLE
user/python-hid: new package

### DIFF
--- a/user/python-hid/template.py
+++ b/user/python-hid/template.py
@@ -1,0 +1,22 @@
+pkgname = "python-hid"
+pkgver = "1.0.6"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+]
+depends = ["python", "hidapi"]
+pkgdesc = "Python bindings for hidapi"
+maintainer = "Julie Koubova <julie@koubova.net>"
+license = "MIT"
+url = "https://github.com/apmorton/pyhidapi"
+source = f"$(PYPI_SITE)/h/hid/hid-{pkgver}.tar.gz"
+sha256 = "48d764d7ae9746ba123b96dbf457893ca80268b7791c4b1d2e051310eeb83860"
+# no tests
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Adds the `hidapi` python wrapper, needed for qmk-cli keyboard firmware build tool


## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
