### PR TITLE
user/python-dotty-dict: new package

### DIFF
--- a/user/python-dotty-dict/template.py
+++ b/user/python-dotty-dict/template.py
@@ -1,0 +1,22 @@
+pkgname = "python-dotty-dict"
+pkgver = "1.3.1"
+pkgrel = 0
+build_style = "python_pep517"
+hostmakedepends = [
+    "python-build",
+    "python-installer",
+    "python-setuptools",
+    "python-poetry-core",
+]
+depends = ["python"]
+checkdepends = ["python-pytest"]
+pkgdesc = "Dictionary wrapper for quick access to deeply nested keys"
+maintainer = "Julie Koubova <julie@koubova.net>"
+license = "MIT"
+url = "https://github.com/pawelzny/dotty_dict"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "62d981357fae93a6133ae5788eb6d76b0c250d5af3cdbdb12914c78d85f6e535"
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Adds `dotty-dict` PyPI package (needed for qmk-cli keyboard firmware tool)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
