### PR TITLE
user/fcitx5-rime: new package

### DIFF
--- a/user/fcitx5-rime/template.py
+++ b/user/fcitx5-rime/template.py
@@ -1,0 +1,22 @@
+pkgname = "fcitx5-rime"
+pkgver = "5.1.10"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DRIME_DATA_DIR=/usr/share/rime-data"]
+hostmakedepends = [
+    "cmake",
+    "extra-cmake-modules",
+    "ninja",
+    "pkgconf",
+]
+makedepends = [
+    "fcitx5-devel",
+    "gettext-devel",
+    "librime-devel",
+]
+depends = ["librime-data"]
+pkgdesc = "RIME support for Fcitx5"
+license = "LGPL-2.1-or-later"
+url = "https://github.com/fcitx/fcitx5-rime"
+source = f"{url}/archive/{pkgver}.tar.gz"
+sha256 = "187bab094b553517b18148b8be1878b63dd2d7e6509fb5ef031a75604f147170"

--- a/user/leveldb-devel
+++ b/user/leveldb-devel
@@ -1,0 +1,1 @@
+leveldb

--- a/user/leveldb/patches/unbundle-gtest-and-benchmark.patch
+++ b/user/leveldb/patches/unbundle-gtest-and-benchmark.patch
@@ -1,0 +1,34 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -296,20 +296,12 @@ if(LEVELDB_BUILD_TESTS)
+   set(build_gmock ON)
+ 
+   # This project is tested using GoogleTest.
+-  add_subdirectory("third_party/googletest")
++  find_package(GTest)
+ 
+   # This project uses Google benchmark for benchmarking.
+   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+   set(BENCHMARK_ENABLE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
+-  add_subdirectory("third_party/benchmark")
+-
+-  # GoogleTest triggers a missing field initializers warning.
+-  if(LEVELDB_HAVE_NO_MISSING_FIELD_INITIALIZERS)
+-    set_property(TARGET gtest
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-    set_property(TARGET gmock
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-  endif(LEVELDB_HAVE_NO_MISSING_FIELD_INITIALIZERS)
++  find_package(benchmark)
+ 
+   function(leveldb_test test_file)
+     get_filename_component(test_target_name "${test_file}" NAME_WE)
+@@ -400,7 +392,7 @@ if(LEVELDB_BUILD_BENCHMARKS)
+ 
+         "${bench_file}"
+     )
+-    target_link_libraries("${bench_target_name}" leveldb gmock gtest)
++    target_link_libraries("${bench_target_name}" leveldb GTest::gtest)
+     target_compile_definitions("${bench_target_name}"
+       PRIVATE
+         ${LEVELDB_PLATFORM_NAME}=1

--- a/user/leveldb/template.py
+++ b/user/leveldb/template.py
@@ -1,0 +1,27 @@
+pkgname = "leveldb"
+pkgver = "1.23"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DBUILD_SHARED_LIBS=ON",
+    "-DCMAKE_CXX_STANDARD=17",
+    "-DLEVELDB_BUILD_BENCHMARKS=ON",
+    "-DLEVELDB_BUILD_TESTS=ON",
+]
+hostmakedepends = ["cmake", "ninja"]
+makedepends = ["snappy-devel"]
+checkdepends = ["benchmark-devel", "gtest-devel"]
+pkgdesc = "Key/value database library"
+license = "BSD-3-Clause"
+url = "https://github.com/google/leveldb"
+source = f"{url}/archive/{pkgver}.tar.gz"
+sha256 = "9a37f8a6174f09bd622bc723b55881dc541cd50747cbd08831c2a82d620f6d76"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+@subpackage("leveldb-devel")
+def _(self):
+    return self.default_devel()

--- a/user/librime-data/template.py
+++ b/user/librime-data/template.py
@@ -1,0 +1,49 @@
+pkgname = "librime-data"
+pkgver = "0_git20250318"
+pkgrel = 0
+build_style = "makefile"
+make_build_target = "preset-bin"
+hostmakedepends = ["bash", "librime-progs"]
+pkgdesc = "Rime input schema"
+license = "LGPL-3.0-or-later"
+_plum = "4c28f11f451facef809b380502874a48ba964ddb"  # r126.20240417
+_bopomofo = "c7618f4f5728e1634417e9d02ea50d82b71956ab"  # r59.20210131
+_cangjie = "0ac8452eeb4abbcd8dd1f9e7314012310743285f"  # r73.20240325
+_essay = "13674aadebc482e418067c1980c7f69bf4a30f90"  # r292.20250314
+_luna_pinyin = "c5d3863062910a02d29761d0228ced3809afc0ac"  # r308.20250318
+_prelude = "3803f09458072e03b9ed396692ce7e1d35c88c95"  # r154.20240519
+_stroke = "7c9874c6b2e0b94947653e9a7de6f99623ff27e4"  # r56.20250118
+_terra_pinyin = "333ec4128fa1f93924a0707da3c623ccd92a73f0"  # r270.20241225
+url = "https://github.com/rime/plum"
+source = [
+    f"https://github.com/rime/plum/archive/{_plum}.tar.gz",
+    f"https://github.com/rime/rime-bopomofo/archive/{_bopomofo}.tar.gz",
+    f"https://github.com/rime/rime-cangjie/archive/{_cangjie}.tar.gz",
+    f"https://github.com/rime/rime-essay/archive/{_essay}.tar.gz",
+    f"https://github.com/rime/rime-luna-pinyin/archive/{_luna_pinyin}.tar.gz",
+    f"https://github.com/rime/rime-prelude/archive/{_prelude}.tar.gz",
+    f"https://github.com/rime/rime-stroke/archive/{_stroke}.tar.gz",
+    f"https://github.com/rime/rime-terra-pinyin/archive/{_terra_pinyin}.tar.gz",
+]
+source_paths = [
+    ".",
+    "package/rime/bopomofo",
+    "package/rime/cangjie",
+    "package/rime/essay",
+    "package/rime/luna-pinyin",
+    "package/rime/prelude",
+    "package/rime/stroke",
+    "package/rime/terra-pinyin",
+]
+sha256 = [
+    "121d5a405dd1457582609d2a4cc0c6c55f9ada8750e524b5c0b6585dbc5268c8",
+    "37bc156bca8bca93b001b112ee440fc498207a4f6fbcaa2d2c306cfdd4560577",
+    "7fea467b08aeb38b0ebc6260a086f11578615549b1ac423bd4a5c6734ccf1ea8",
+    "9369c21dcdb250a63d445190b1bdea92bbc689577e7b1910c9472254d0873fa6",
+    "17785639b719f35bf2f0c97aeeabd68803be938a0d00df3cf659407bd8d6a3dd",
+    "afa07cd98c540a0ac2d1d6e98ffa776549c535e617d3e41eb6ef80806df806f2",
+    "9728b1123640a699b9032855a8b261928077278fa1870407c50f53c71cb82f74",
+    "5f94ac60a156ee45c7a01598af3a1bdc7b829e2c1d75da590a9ae024bb3c49dd",
+]
+# No tests are available.
+options = ["!check"]

--- a/user/librime-data/update.py
+++ b/user/librime-data/update.py
@@ -1,0 +1,1 @@
+ignore = True

--- a/user/librime-devel
+++ b/user/librime-devel
@@ -1,0 +1,1 @@
+librime

--- a/user/librime-progs
+++ b/user/librime-progs
@@ -1,0 +1,1 @@
+librime

--- a/user/librime/template.py
+++ b/user/librime/template.py
@@ -1,0 +1,33 @@
+pkgname = "librime"
+pkgver = "1.13.1"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = [
+    "boost-devel",
+    "glog-devel",
+    "leveldb-devel",
+    "marisa-trie-devel",
+    "opencc-devel",
+    "yaml-cpp-devel",
+]
+checkdepends = ["gtest-devel"]
+pkgdesc = "Rime Input Method Engine"
+license = "BSD-3-Clause"
+url = "https://github.com/rime/librime"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "ae7eb6335139c044e438299b2ab9a0f630e665e8f5fe1f30a9416a2d1325b84e"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+@subpackage("librime-devel")
+def _(self):
+    return self.default_devel()
+
+
+@subpackage("librime-progs")
+def _(self):
+    return self.default_progs()


### PR DESCRIPTION
## Description

This PR adds four packages to user repo. It adds rime Chinese input method library and fcitx5-rime for its use in fcitx5 input method frontend.

This is my first contribution to cports, so please tell if something is not handled properly. Here are things I have done:
1. Verify the package content (only list of filenames) against the alpine packages, and the result matches in general.
2. Install on my local machine and verify that these package work properly. 
3. Format with black code formatter.
4. Enabled "vis" and "cfi" hardening options by trial-and-error.

Among these four packages, the most controversial one is probably "rime-data".  This package contains the input method schema data for rime. But there is no official release for it, as it contains multiple git repositories, and each one is user contributed and updating on a daily base.

1. I choose to package all these schema in single package, this makes template cleaner.
2. I choose to use date as the pkgver (which the latest commit date of all git repositories being tracked).
3. I choose to not package the plum tool (the (rime-install)[https://github.com/rime/plum/blob/master/rime-install]) since the script is mostly written to work in a working git repository.

Also, fcitx5-rime 5.1.10 was released two days ago but it [requires a newer version](https://github.com/fcitx/fcitx5-rime/commit/88d3e39655f41660a8abb8fbf1e82c13db1a0cf1) of fcitx5 than the one cports ships. Since the fcitx5 package is in main repo, I plan to open another PR to upgrade both package (and all dependents) after this PR is merged.

## Checklist


Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
