### PR TITLE
user/opencc: enable tests

### DIFF
--- a/user/opencc/template.py
+++ b/user/opencc/template.py
@@ -1,8 +1,17 @@
 pkgname = "opencc"
 pkgver = "1.1.9"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
+configure_args = [
+    "-DENABLE_GTEST=ON",
+    "-DUSE_SYSTEM_GTEST=ON",
+    "-DUSE_SYSTEM_MARISA=ON",
+    "-DUSE_SYSTEM_RAPIDJSON=ON",
+    "-DUSE_SYSTEM_TCLAP=ON",
+]
 hostmakedepends = ["pkgconf", "cmake", "ninja", "python"]
+makedepends = ["marisa-trie-devel", "rapidjson", "tclap"]
+checkdepends = ["gtest-devel"]
 pkgdesc = "Open Chinese conversion library"
 maintainer = "metalparade <comer@live.cn>"
 license = "Apache-2.0"

--- a/user/tclap/patches/fix-tests-shebang.patch
+++ b/user/tclap/patches/fix-tests-shebang.patch
@@ -1,0 +1,36 @@
+diff --git a/tests/test88.sh b/tests/test88.sh
+index 1234da7..eecf490 100755
+--- a/tests/test88.sh
++++ b/tests/test88.sh
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ ./test_wrapper $srcdir/test88.out ../examples/test27
+diff --git a/tests/test89.sh b/tests/test89.sh
+index e998b21..2b39396 100755
+--- a/tests/test89.sh
++++ b/tests/test89.sh
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ ./test_wrapper $srcdir/test89.out ../examples/test28
+diff --git a/tests/test90.sh b/tests/test90.sh
+index 07820a3..4921649 100755
+--- a/tests/test90.sh
++++ b/tests/test90.sh
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ ./test_wrapper $srcdir/test90.out ../examples/test29
+diff --git a/tests/test91.sh b/tests/test91.sh
+index 6139ffd..8e5d700 100755
+--- a/tests/test91.sh
++++ b/tests/test91.sh
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ ./test_wrapper $srcdir/test91.out ../examples/test30 '-p "1 2.3"'

--- a/user/tclap/template.py
+++ b/user/tclap/template.py
@@ -1,0 +1,16 @@
+pkgname = "tclap"
+pkgver = "1.2.5"
+pkgrel = 0
+build_style = "gnu_configure"
+make_dir = "."
+hostmakedepends = ["automake", "pkgconf"]
+pkgdesc = "Templatized command line argument parser"
+maintainer = "Bin Jin <bjin@protonmail.com>"
+license = "MIT"
+url = "http://tclap.sourceforge.net"
+source = f"https://downloads.sourceforge.net/sourceforge/{pkgname}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "bb649f76dae35e8d0dcba4b52acfd4e062d787e6a81b43f7a4b01275153165a6"
+
+
+def post_install(self):
+    self.install_license("COPYING")


### PR DESCRIPTION
## Description

This PR updates opencc to use system library (instead of bundled ones in repository), and enable tests for "check" phase. Another package "tclap" was also added with tests enabled.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
