### PR TITLE
user/refine: update to 0.4.2

### DIFF
--- a/user/refine/patches/0001-keep-using-last-blueprint-compiler-version-available.patch
+++ b/user/refine/patches/0001-keep-using-last-blueprint-compiler-version-available.patch
@@ -1,0 +1,25 @@
+From 235bac56a45a14692c6b6eae7187b1b70a1d82cc Mon Sep 17 00:00:00 2001
+From: Guilhem Baccialone <guilhem.baccialone@zaclys.net>
+Date: Mon, 27 Jan 2025 00:09:29 +0100
+Subject: [PATCH 1/1] keep using last blueprint-compiler version available
+
+---
+ refine/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/refine/meson.build b/refine/meson.build
+index e1e77c1..a946fce 100644
+--- a/refine/meson.build
++++ b/refine/meson.build
+@@ -22,7 +22,7 @@ blueprints = custom_target('blueprints',
+   output: '.',
+   command: [
+     find_program('blueprint-compiler',
+-      version: '0.14.0',
++      version: '>=0.14.0',
+       version_argument: '--version',
+     ), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'
+   ],
+-- 
+2.48.1
+

--- a/user/refine/template.py
+++ b/user/refine/template.py
@@ -1,5 +1,5 @@
 pkgname = "refine"
-pkgver = "0.4.0"
+pkgver = "0.4.2"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -24,4 +24,4 @@ maintainer = "Guilhem Baccialone <guilhem.baccialone@zaclys.net>"
 license = "GPL-3.0-or-later"
 url = "https://gitlab.gnome.org/TheEvilSkeleton/Refine"
 source = f"{url}/-/archive/{pkgver}/Refine-{pkgver}.tar.bz2"
-sha256 = "81f9b3435a5df20cca53d8861521339d9e8f192148d50d09e983c061cc8d911b"
+sha256 = "dffaac969c3d571a758e2e1ed5308b200e270ec10f76f0f17b507df27eb3d27d"


### PR DESCRIPTION
## Description

Update Refine package to the last version. Needs to patch `meson.build` to use `blueprint-compiler` v0.16.0 instead of the 0.14.0. According to the Refine main dev, Refine needs at least the v0.14.0.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
