### PR TITLE
user/duperemove: move from main and update to 0.15

### DIFF
--- a/user/duperemove/patches/atomic-globals.patch
+++ b/user/duperemove/patches/atomic-globals.patch
@@ -1,0 +1,11 @@
+--- a/progress.c
++++ b/progress.c
+@@ -66,7 +66,7 @@ static uint64_t files_scanned, bytes_scanned;
+ /*
+  * Used to track the status of our search extents from blocks
+  */
+-static uint64_t search_total, search_processed;
++static _Atomic uint64_t search_total, search_processed;
+ 
+ #define s_save_pos() if (tty) printf("\33[s");
+ #define s_restore_pos() if (tty) printf("\33[u");

--- a/user/duperemove/patches/delete-duplicate-definition.patch
+++ b/user/duperemove/patches/delete-duplicate-definition.patch
@@ -1,0 +1,15 @@
+--- a/results-tree.h
++++ b/results-tree.h
+@@ -20,11 +20,7 @@
+ #include <glib.h>
+ 
+ #include "csum.h"
+-
+-// TODO: delete this
+-struct list_head {
+-	struct list_head *next, *prev;
+-};
++#include "list.h"
+ 
+ struct results_tree {
+ 	struct rb_root	root;

--- a/user/duperemove/patches/fix-cfi.patch
+++ b/user/duperemove/patches/fix-cfi.patch
@@ -1,0 +1,29 @@
+--- a/dbfile.c
++++ b/dbfile.c
+@@ -561,6 +561,17 @@ void dbfile_close_handle(struct dbhandle *db)
+ 	}
+ }
+ 
++/*
++ * dbfile_close_handle takes struct dbhandle*.
++ * we need a function that takes void* so we
++ * can pass it to register_cleanup without
++ * causing UB.
++ */
++static void cleanup_dbhandle(void *db)
++{
++	dbfile_close_handle(db);
++}
++
+ struct dbhandle *dbfile_open_handle_thread(char *filename, struct threads_pool *pool)
+ {
+ 	struct dbhandle *db;
+@@ -569,7 +580,7 @@ struct dbhandle *dbfile_open_handle_thread(char *filename, struct threads_pool *
+ 	dbfile_unlock();
+ 
+ 	if (db)
+-		register_cleanup(pool, (void*)&dbfile_close_handle, db);
++		register_cleanup(pool, (void*)&cleanup_dbhandle, db);
+ 	return db;
+ }
+ 

--- a/user/duperemove/patches/remove-libbsd-dependency.patch
+++ b/user/duperemove/patches/remove-libbsd-dependency.patch
@@ -1,0 +1,33 @@
+--- a/Makefile
++++ b/Makefile
+@@ -23,7 +23,7 @@ DIST=duperemove-$(VERSION)
+ DIST_TARBALL=$(VERSION).tar.gz
+ TEMP_INSTALL_DIR:=$(shell mktemp -du -p .)
+ 
+-EXTRA_CFLAGS=$(shell $(PKG_CONFIG) --cflags glib-2.0,sqlite3,blkid,mount,uuid,libbsd)
++EXTRA_CFLAGS=$(shell $(PKG_CONFIG) --cflags glib-2.0,sqlite3,blkid,mount,uuid)
+ EXTRA_LIBS=$(shell $(PKG_CONFIG) --libs glib-2.0,sqlite3,blkid,mount,uuid)
+ 
+ ifdef DEBUG
+--- a/file_scan.c
++++ b/file_scan.c
+@@ -41,7 +41,7 @@
+ #include <libmount/libmount.h>
+ #include <sys/sysmacros.h>
+ #include <uuid/uuid.h>
+-#include <bsd/sys/queue.h>
++#include <sys/queue.h>
+ 
+ #include <glib.h>
+ 
+--- a/filerec.h
++++ b/filerec.h
+@@ -19,7 +19,7 @@
+ #include <stdint.h>
+ #include <time.h>
+ #include <glib.h>
+-#include <bsd/sys/queue.h>
++#include <sys/queue.h>
+ #include "rbtree.h"
+ #include "results-tree.h"
+ 

--- a/user/duperemove/template.py
+++ b/user/duperemove/template.py
@@ -1,25 +1,26 @@
 pkgname = "duperemove"
-pkgver = "0.14.1"
+pkgver = "0.15"
 pkgrel = 0
 build_style = "makefile"
 make_build_env = {
     "VERSION": f"v{pkgver}",
     "IS_RELEASE": "1",
 }
-make_install_args = ["SBINDIR=/usr/bin"]
 hostmakedepends = ["pkgconf"]
-makedepends = ["glib-devel", "sqlite-devel", "linux-headers"]
+makedepends = [
+    "glib-devel",
+    "musl-bsd-headers",
+    "sqlite-devel",
+    "xxhash-devel",
+    "linux-headers",
+]
 pkgdesc = "Tools for deduplicating extents in filesystems like Btrfs"
 maintainer = "autumnontape <autumn@cyfox.net>"
-license = "GPL-2.0-only AND BSD-2-Clause"
+license = "GPL-2.0-only"
 url = "https://github.com/markfasheh/duperemove"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "5970a68e37c1b509448f6d82278ca21403cc7722f6267f7da27723b0749088ea"
-tool_flags = {"CFLAGS": ["-std=gnu2x"]}
+sha256 = "1dacde51f12ead1da6b067d5520731a83adee3301fbc36eb282cf8362b93d773"
+tool_flags = {"CFLAGS": ["-std=c23"]}
 hardening = ["vis", "cfi"]
 # no test suite exists
 options = ["!check"]
-
-
-def post_install(self):
-    self.install_license("LICENSE.xxhash")


### PR DESCRIPTION
## Description

I've updated duperemove to v0.15, and I've moved it to the user repository as q66 asked on IRC.

It fails to build with clang if `delete-duplicate-definition.patch` isn't applied, but it somehow builds successfully with gcc. I don't know what's going on with this code, if the TODO was left undone by accident or what, but the patched version seems to work fine in practice. There's an issue in the upstream repository: https://github.com/markfasheh/duperemove/issues/367

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine