### PR TITLE
main/ispc: update to 1.26.0

### DIFF
--- a/main/ispc/template.py
+++ b/main/ispc/template.py
@@ -1,6 +1,6 @@
 pkgname = "ispc"
-pkgver = "1.25.3"
-pkgrel = 1
+pkgver = "1.26.0"
+pkgrel = 0
 archs = ["x86_64", "aarch64", "armv7"]
 build_style = "cmake"
 configure_args = ["-DCMAKE_BUILD_TYPE=Release"]
@@ -23,7 +23,7 @@ maintainer = "Erica Z <zerica@callcc.eu>"
 license = "BSD-3-Clause"
 url = "https://ispc.github.io"
 source = f"https://github.com/ispc/ispc/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "6f00038e0e86e90474f3117c3b393f6695a8fbe1b3d8fe3b1a0baf197dfb7557"
+sha256 = "f75b26894af1429a3dc6929ae03e2c9e99bb8c5930eda14add5d2f6674db7afb"
 
 
 def post_install(self):

--- a/main/openimagedenoise/template.py
+++ b/main/openimagedenoise/template.py
@@ -1,6 +1,6 @@
 pkgname = "openimagedenoise"
 pkgver = "2.3.2"
-pkgrel = 0
+pkgrel = 1
 # ispc
 archs = ["x86_64", "aarch64", "armv7"]
 build_style = "cmake"


### PR DESCRIPTION
this update _might_ remove support for armv7, but [i'm not entirely certain](https://github.com/ispc/ispc/releases/tag/v1.26.0):
>- The `--arch=arm` flag, which previously mapped to ARMv7 (32-bit), now maps to ARMv8 (32-bit). There are no changes to `--arch=aarch64`, which continues to map to ARMv8 (64-bit).
>- The CPU definitions for the ARMv7 architecture have been removed: `cortex-a9` and `cortex-a15`.
>- New CPU definitions have been introduced, including `cortex-a55`, `cortex-a78`, `cortex-a510`, and `cortex-a520`, along with support for new Apple devices.