### PR TITLE
user/incus: update to 6.9.0.

### DIFF
--- a/user/incus/template.py
+++ b/user/incus/template.py
@@ -1,6 +1,6 @@
 pkgname = "incus"
-pkgver = "6.7.0"
-pkgrel = 4
+pkgver = "6.9.0"
+pkgrel = 0
 build_style = "go"
 make_build_args = ["./cmd/..."]
 make_check_args = ["-skip", "TestConvertNetworkConfig", "./..."]
@@ -44,7 +44,7 @@ maintainer = "tj <tjheeta@gmail.com>"
 license = "Apache-2.0"
 url = "https://github.com/lxc/incus"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "bbf12c30fc8eb090779706ddc26b60c2618c2c129ff585d46c949f01d12719dc"
+sha256 = "7c50d4eb2ae5a33eab27821c95e01fc9a5d977c9b6b594a51571e6fefd4119d2"
 # fail to link because of post_build overrides
 options = ["!check"]
 


### PR DESCRIPTION
## Description

Update to v6.9.0, required for compatibility with qemu 9.2.

## Checklist

- [ X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [ X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ X] I have built and tested my changes on my machine

Pkg builds and executes without issue on x86_64.

Note, cross build `./cbuild -a aarch64 pkg user/incus` fails with:

```
0:00:12.369 => incus-6.7.0-r4: golang: go build -p 8 -v -trimpath -tags libsqlite3 -o /builddir/incus-6.7.0/build/ ./cmd/...
package github.com/lxc/incus/v6/cmd/incusd
	imports github.com/lxc/incus/v6/internal/server/db/warningtype: build constraints exclude all Go files in /builddir/incus-6.7.0/internal/server/db/warningtype
package github.com/lxc/incus/v6/cmd/incusd
	imports github.com/lxc/incus/v6/internal/server/apparmor
	imports github.com/lxc/incus/v6/internal/server/storage/drivers
	imports github.com/lxc/incus/v6/internal/server/storage/quota: build constraints exclude all Go files in /builddir/incus-6.7.0/internal/server/storage/quota
0:00:12.589 => A failure has occurred!
0:00:12.589 => Stack trace:
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/build.py:534: in function 'build'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/build.py:664: in function '_build'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/build.py:762: in function '_build_locked'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/build.py:314: in function 'invoke_build'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/build.py:168: in function 'run_pkg_func'
0:00:12.592 =>   /home/mw/cports/src/cbuild/build_style/go.py:9: in function 'build'
0:00:12.592 =>   /home/mw/cports/src/cbuild/util/golang.py:111: in function 'build'
0:00:12.592 =>   /home/mw/cports/src/cbuild/util/golang.py:68: in function '_invoke'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/template.py:1843: in function 'do'
0:00:12.592 =>   /home/mw/cports/src/cbuild/core/chroot.py:851: in function 'enter'
0:00:12.592 => Raised exception:
0:00:12.592 =>   CalledProcessError: command '/usr/bin/bwrap --unshare-all --hostname cbuild --ro-bind /home/mw/cports/bldroot / --bind /home/mw/cports/bldroot/builddir /builddir --ro-bind /home/mw/cports/bldroot/destdir /destdir --ro-bind /home/mw/cports/sources /sources --dev /dev --proc /proc --tmpfs /run --tmpfs /tmp --tmpfs /var/tmp --new-session --die-with-parent --bind /home/mw/cports/cbuild_cache /cbuild_cache --uid 1337 --gid 1337 --chdir /builddir/incus-6.7.0 --ro-bind-data 6 /tmp/cbuild-lld-args linux64 -- go build -p 8 -v -trimpath -tags libsqlite3 -o /builddir/incus-6.7.0/build/ ./cmd/...' failed with exit code 1
0:00:12.592 => Phase 'build' failed for package 'incus'.
```
