### PR TITLE
user/clight: new package

### DIFF
--- a/user/clight/files/clight.user
+++ b/user/clight/files/clight.user
@@ -1,0 +1,4 @@
+type = process
+command = /usr/bin/clight
+depends-on = dbus
+log-type = buffer

--- a/user/clight/patches/add_missing_header.patch
+++ b/user/clight/patches/add_missing_header.patch
@@ -1,0 +1,9 @@
+diff --git a/src/utils/log.c b/src/utils/log.c
+index 0ec38a5..8d46b90 100644
+--- a/src/utils/log.c
++++ b/src/utils/log.c
+@@ -1,3 +1,4 @@
++#include <fcntl.h>
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ #include "utils.h"

--- a/user/clight/template.py
+++ b/user/clight/template.py
@@ -1,0 +1,36 @@
+pkgname = "clight"
+pkgver = "4.11"
+pkgrel = 0
+build_style = "cmake"
+hostmakedepends = [
+    "cmake",
+    "dbus-devel",
+    "elogind-devel",
+    "gsl-devel",
+    "libconfig-devel",
+    "libmodule-devel",
+    "linux-headers",
+    "ninja",
+    "pkgconf",
+    "popt-devel",
+]
+makedepends = [
+    "bash-completion",
+    "fish-shell",
+]
+depends = [
+    "clightd",
+]
+install_if = [
+    "clightd>=5",
+]
+pkgdesc = "User daemon to adjust screen backlight based on ambient brightness"
+maintainer = "Anthony <w732qq@gmail.com>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/FedeDP/Clight"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "9a7ec2070b0e1d074477cd219d6894dde9eb85cbe83daebc22054fab29dade34"
+
+
+def post_install(self):
+    self.install_service(self.files_path / "clight.user")

--- a/user/clightd/files/clightd
+++ b/user/clightd/files/clightd
@@ -1,0 +1,4 @@
+type = process
+command = /usr/libexec/clightd
+depends-on = dbus
+log-type = buffer

--- a/user/clightd/template.py
+++ b/user/clightd/template.py
@@ -1,0 +1,37 @@
+pkgname = "clightd"
+# TODO: Can't build 5.9 yet as it requires libiio, which is missing
+pkgver = "5.8"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DDBUS_CONFIG_DIR=/usr/share/dbus-1/system.d/",
+    "-DENABLE_DPMS=1",
+    "-DENABLE_GAMMA=1",
+    "-DENABLE_SCREEN=1",
+]
+hostmakedepends = [
+    "cmake",
+    "dbus-devel",
+    "elogind-devel",
+    "libdrm-devel",
+    "libjpeg-turbo-devel",
+    "libmodule-devel",
+    "libxrandr-devel",
+    "linux-headers",
+    "ninja",
+    "pkgconf",
+    "polkit-devel",
+    "udev-devel",
+    "wayland-devel",
+]
+pkgdesc = "Linux bus interface that lets you change screen brightness"
+# , compute captured webcam frames brightness and change screen temperature"
+maintainer = "Anthony <w732qq@gmail.com>"
+license = "GPL-3.0-or-later"
+url = "https://github.com/FedeDP/Clightd"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "89f0906bc2c1dd4f9bd62194499fd156197c211760c4bb1adcb149650f852684"
+
+
+def post_install(self):
+    self.install_service(self.files_path / "clightd")

--- a/user/libmodule-devel
+++ b/user/libmodule-devel
@@ -1,0 +1,1 @@
+libmodule

--- a/user/libmodule/template.py
+++ b/user/libmodule/template.py
@@ -1,0 +1,25 @@
+pkgname = "libmodule"
+pkgver = "5.0.1"
+pkgrel = 1
+build_style = "cmake"
+# TODO: cmocka misses .pc which makes it undiscoverable, so skip tests for now
+# configure_args = ["-DBUILD_TESTS=true"]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    #    "cmocka",
+    "pkgconf",
+]
+pkgdesc = "Simple and elegant implementation of an actor library in C"
+maintainer = "Anthony <w732qq@gmail.com>"
+license = "MIT"
+url = "https://github.com/FedeDP/libmodule"
+source = (
+    f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+)
+sha256 = "35506360272cb13c0a09f17db6f716cf1c3e9fe40ac1bd574e4dc67916f7ca0a"
+
+
+@subpackage("libmodule-devel")
+def _(self):
+    return self.default_devel()


### PR DESCRIPTION
## Description

Add [`clight`](https://github.com/FedeDP/Clight) user-session daemon package & dependencies. It controls screen brightness, gamma & keyboard backlight in consistent way, across any DE, WM, or even in framebuffer terminal.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date (until I'll stop using Chimera)

See also:

- https://github.com/FedeDP/Clight/issues/312
