### PR TITLE
main/neovim: fix markdown_inline parser detection

### DIFF
--- a/main/neovim/template.py
+++ b/main/neovim/template.py
@@ -1,7 +1,7 @@
 # nb: neovim requires either lua5.1 or luaJIT (a mess)
 pkgname = "neovim"
 pkgver = "0.10.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo",

--- a/main/tree-sitter-markdown/template.py
+++ b/main/tree-sitter-markdown/template.py
@@ -1,6 +1,6 @@
 pkgname = "tree-sitter-markdown"
 pkgver = "0.2.3"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_check_target = "test"
 hostmakedepends = [
@@ -35,7 +35,7 @@ def post_install(self):
         "../libtree-sitter-markdown.so.0",
     )
     self.install_link(
-        "usr/lib/tree-sitter/inline_markdown.so",
+        "usr/lib/tree-sitter/markdown_inline.so",
         "../libtree-sitter-markdown-inline.so.0",
     )
 


### PR DESCRIPTION
## Description

Naming it as inline_markdown causes neovim to dlsym tree_sitter_inline_markdown instead of tree_sitter_markdown_inline, causing the dlsym to fail, and the parser not being loaded.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine