### PR TITLE
main/mandoc: don't reset gzip in mparse_reset

### DIFF
--- a/main/mandoc/patches/no-reset-gzip.patch
+++ b/main/mandoc/patches/no-reset-gzip.patch
@@ -1,0 +1,9 @@
+--- a/read.c
++++ b/read.c
+@@ -692,6 +692,5 @@ mparse_reset(struct mparse *curp)
+ 	roff_man_reset(curp->man);
+ 	free_buf_list(curp->secondary);
+ 	curp->secondary = NULL;
+-	curp->gzip = 0;
+ 	tag_alloc();
+ }

--- a/main/mandoc/template.py
+++ b/main/mandoc/template.py
@@ -1,6 +1,6 @@
 pkgname = "mandoc"
 pkgver = "1.14.6"
-pkgrel = 5
+pkgrel = 6
 build_style = "configure"
 make_check_target = "regress"
 makedepends = ["zlib-ng-compat-devel"]


### PR DESCRIPTION
## Description

setting curp->gzip to 0 disregarding the current value causes gzipped man pages to be shown without gunzipping them first, essentially printing garbage to stdout


## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
