### PR TITLE
user/mg: new package

### DIFF
--- a/user/mg/template.py
+++ b/user/mg/template.py
@@ -1,0 +1,15 @@
+pkgname = "mg"
+pkgver = "3.7"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_gen = []
+make_dir = "."
+make_build_args = ["V=1"]
+makedepends = ["ncurses-devel"]
+pkgdesc = "Micro (GNU) Emacs-like text editor"
+maintainer = "Christiano Haesbaert <haesbaert@haesbaert.org>"
+license = "custom:none"
+url = "https://github.com/troglobit/mg"
+source = f"{url}/releases/download/v{pkgver}/mg-{pkgver}.tar.gz"
+sha256 = "05101360d2194392da0950e8b6f18d067d8af0fd2f572461ba4d4e7b4ccbb4c1"
+hardening = ["vis", "cfi", "!int"]


### PR DESCRIPTION
## Description

mg is the micro emacs clone.

There's an integer overflow that triggers on carriage return, I've disabled the overflow checks for now.
Been using this software for decades.
When I find some time I'll try to fix it upstream.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
