### PR TITLE
cbuild: respect wrksrc for go.mod

### DIFF
--- a/src/cbuild/util/golang.py
+++ b/src/cbuild/util/golang.py
@@ -40,8 +40,14 @@ class Golang:
         if not command:
             self.template.error("golang: missing go command argument")
 
+        moddir = self.template.cwd
+        if wrksrc is not None:
+            moddir = moddir / wrksrc
+        elif self.wrksrc is not None:
+            moddir = moddir / self.wrksrc
+
         # support only go.mod "mode" for now
-        gomod = self.template.cwd / "go.mod"
+        gomod = moddir / "go.mod"
 
         if not gomod.is_file():
             self.template.error(f"golang: missing file {gomod}")


### PR DESCRIPTION
Certain projects such as /gopls have a local go.mod present in their wrksrc, and may or may not have a go.mod in the root directory, this commit respects optional given wrksrc as the directory for the go.mod.

Code copied from Cargo's build instructions.