### PR TITLE
fix example cbuild formatting

### DIFF
--- a/Packaging.md
+++ b/Packaging.md
@@ -73,7 +73,7 @@ pkgdesc = "Simple package"
 maintainer = "q66 <q66@chimera-linux.org>"
 license = "BSD-3-Clause"
 url = "https://foo.software"
-source = f"https://foo.software/foo-{pkgver}.tar.gz"
+source = f"{url}/foo-{pkgver}.tar.gz"
 sha256 = "ad031c86b23ed776697f77f1a3348cd7129835965d4ee9966bc50e65c97703e8"
 ```
 


### PR DESCRIPTION
## Description
Update `source` f-string formatting in the example cbuild to what is currently preferred.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [ ] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
