### PR TITLE
main/wlsunset: fix cross compilation

### DIFF
--- a/main/wlsunset/template.py
+++ b/main/wlsunset/template.py
@@ -1,8 +1,8 @@
 pkgname = "wlsunset"
 pkgver = "0.4.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
-hostmakedepends = ["meson", "pkgconf", "scdoc"]
+hostmakedepends = ["meson", "pkgconf", "scdoc", "wayland-progs"]
 makedepends = ["wayland-devel", "wayland-protocols"]
 pkgdesc = "Day/night gamma adjustments for Wayland"
 license = "MIT"


### PR DESCRIPTION
## Description

I somehow stumbled across the fact that wlsunset package's cross compilation is broken. Fix that with a trivial dependency fix.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
