### PR TITLE
documentation: fix an ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ you have.
 If you want access to local `-dbg` packages, you will also want to add the `debug`
 sub-repositories, e.g. `/home/user/cports/packages/main/debug`.
 
-You will also want to drop your signing public key in `/etc/apk/keys`. The key
+You will also want to drop your signing public key into `/etc/apk/keys`. The key
 can be located in `etc/keys` in the `cports` directory, with the `.pub` extension
 (do not put in the private key).
 

--- a/main/i2pd/template.py
+++ b/main/i2pd/template.py
@@ -1,0 +1,28 @@
+pkgname = "i2pd"
+pkgver = "2.56.0"
+pkgrel = 0
+build_style = "makefile"
+make_build_args = ["DEBUG=no", "USE_STATIC=yes", "USE_UPNP=yes"]
+makedepends = ["boost-devel", "zlib-ng-devel", "openssl3-devel", "miniupnpc"]
+pkgdesc = "I2P Router written in C++"
+license = "BSD-3-Clause"
+url = "https://github.com/PurpleI2P/i2pd"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "eb83f7e98afeb3704d9ee0da2499205f73bab0b1becaf4494ccdcbe4295f8550"
+# no check
+options = ["!check"]
+
+
+def pre_build(self):
+    with open(f"{self.cwd}/Makefile", "r") as file:
+        filedata = file.read()
+
+    filedata = filedata.replace("$(shell $(CXX) -dumpmachine)", "freebsd")
+
+    with open(f"{self.cwd}/Makefile", "w") as file:
+        file.write(filedata)
+
+
+def install(self):
+    self.install_license("LICENSE")
+    self.install_bin(f"{self.cwd}/i2pd")


### PR DESCRIPTION
When playing around with cports today, I initially thought "to drop" meant "to ditch" or "to remove" and got stuck for some time. I think this is a good improvement to make sure nobody else gets confused.