### PR TITLE
main/prosody: update to 0.13.0

### DIFF
--- a/main/prosody/template.py
+++ b/main/prosody/template.py
@@ -1,6 +1,7 @@
 pkgname = "prosody"
-pkgver = "0.12.5"
-pkgrel = 1
+pkgver = "0.13.0"
+_ver = "13.0.0"
+pkgrel = 0
 build_style = "makefile"
 make_check_target = "test"
 make_use_env = True
@@ -23,8 +24,8 @@ checkdepends = ["lua5.4-busted", *depends]
 pkgdesc = "Modern xmpp communication server"
 license = "MIT"
 url = "https://prosody.im"
-source = f"https://prosody.im/downloads/source/prosody-{pkgver}.tar.gz"
-sha256 = "778fb7707a0f10399595ba7ab9c66dd2a2288c0ae3a7fe4ab78f97d462bd399f"
+source = f"https://prosody.im/downloads/source/prosody-{_ver}.tar.gz"
+sha256 = "4309c5cfeb1a74d3f97185f6243a0c1068eb39fa7e91abc42cf2194bf067fc54"
 
 
 def configure(self):

--- a/main/prosody/update.py
+++ b/main/prosody/update.py
@@ -1,0 +1,1 @@
+ignore = True


### PR DESCRIPTION
## Description

also shadows the pkgver due to seemingly incorrect version tagging by upstream.

simply upgrading to version 13.0.0 will cause a regression in the next release cycle
forcing people to use --available/--prune to ignore the downgrade


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
