### PR TITLE
user/caddy: new package

### DIFF
--- a/user/caddy/files/caddy
+++ b/user/caddy/files/caddy
@@ -1,0 +1,9 @@
+type = process
+command = /usr/bin/caddy run --config /etc/caddy/Caddyfile
+working-dir = /var/lib/caddy
+logfile = /var/log/caddy.log
+run-as = _caddy
+depends-on = local.target
+smooth-recovery = true
+load-options: export-passwd-vars
+capabilities = ^cap_net_bind_service

--- a/user/caddy/files/sysusers.conf
+++ b/user/caddy/files/sysusers.conf
@@ -1,0 +1,3 @@
+# create caddy user
+
+u _caddy - "caddy daemon" /var/lib/caddy

--- a/user/caddy/files/tmpfiles.conf
+++ b/user/caddy/files/tmpfiles.conf
@@ -1,0 +1,4 @@
+# create caddy state & configuration directories
+
+d /var/lib/caddy 0750 _caddy _caddy
+d /etc/caddy 0755 root root

--- a/user/caddy/template.py
+++ b/user/caddy/template.py
@@ -1,0 +1,21 @@
+pkgname = "caddy"
+pkgver = "2.9.1"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    f"-ldflags=-X github.com/caddyserver/caddy/v2.CustomVersion=v{pkgver}",
+    "./cmd/caddy",
+]
+make_check_args = ["-p", "1", "./..."]
+hostmakedepends = [ "go" ]
+depends = ["shared-mime-info"]
+pkgdesc = "Extensible HTTP server with automatic HTTPS"
+license = "Apache-2.0"
+url = "https://caddyserver.com"
+source = f"https://github.com/caddyserver/caddy/archive/v{pkgver}.tar.gz"
+sha256 = "beb52478dfb34ad29407003520d94ee0baccbf210d1af72cebf430d6d7dd7b63"
+
+def post_install(self):
+    self.install_sysusers(self.files_path / "sysusers.conf")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
+    self.install_service(self.files_path / "caddy")


### PR DESCRIPTION
## Description

Adds a package for caddy, a "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS".  Set up for unprivileged use under user `_caddy` with a dinit service.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
