### PR TITLE
main/llvm-bootstrap: add architecture mappings for 32-bit ARM

### DIFF
--- a/main/llvm-bootstrap/template.py
+++ b/main/llvm-bootstrap/template.py
@@ -93,6 +93,8 @@ match self.profile().arch:
         _arch = "PowerPC"
     case "riscv64":
         _arch = "RISCV64"
+    case "armhf" | "armv7":
+        _arch = "ARM"
     case "loongarch64" | "loongarch32":
         _arch = "LoongArch"
     case _:


### PR DESCRIPTION
## Description

The mappings for armhf and armv7 were missing.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
