### PR TITLE
main/boost: fix build for ARMv7

### DIFF
--- a/main/boost/patches/fix-armv7-inline-assembly.patch
+++ b/main/boost/patches/fix-armv7-inline-assembly.patch
@@ -1,0 +1,66 @@
+--- a/boost/interprocess/interprocess_printers.hpp
++++ b/boost/interprocess/interprocess_printers.hpp
+@@ -13,7 +13,7 @@
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Woverlength-strings"
+ #endif
+-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
++__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
+         ".ascii \"\\4gdb.inlined-script.BOOST_INTERPROCESS_INTERPROCESS_PRINTERS_HPP\\n\"\n"
+         ".ascii \"import gdb.printing\\n\"\n"
+ 
+--- a/boost/json/detail/gdb_printers.hpp
++++ b/boost/json/detail/gdb_printers.hpp
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ __asm__(
+-  ".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
++  ".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
+   ".ascii \"\\4gdb.inlined-script.BOOST_JSON_DETAIL_GDB_PRINTERS_HPP\\n\"\n"
+   ".ascii \"import gdb\\n\"\n"
+   ".ascii \"import gdb.printing\\n\"\n"
+--- a/boost/outcome/experimental/status-code/status_code.hpp
++++ b/boost/outcome/experimental/status-code/status_code.hpp
+@@ -722,7 +722,7 @@ BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_END
+ #pragma clang diagnostic ignored "-Woverlength-strings"
+ #endif
+ __asm__(
+-".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
++".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
+ ".ascii \"\\4gdb.inlined-script.BOOST_OUTCOME_SYSTEM_ERROR2_INLINE_GDB_PRETTY_PRINTERS_H\\n\"\n"
+ ".ascii \"import gdb.printing\\n\"\n"
+ ".ascii \"import gdb\\n\"\n"
+--- a/boost/outcome/outcome_gdb.h
++++ b/boost/outcome/outcome_gdb.h
+@@ -32,7 +32,7 @@
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Woverlength-strings"
+ #endif
+-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
++__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
+         ".ascii \"\\4gdb.inlined-script.BOOST_OUTCOME_INLINE_GDB_PRETTY_PRINTER_H\\n\"\n"
+         ".ascii \"import gdb.printing\\n\"\n"
+         ".ascii \"import os\\n\"\n"
+--- a/boost/unordered/unordered_printers.hpp
++++ b/boost/unordered/unordered_printers.hpp
+@@ -13,7 +13,7 @@
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Woverlength-strings"
+ #endif
+-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
++__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
+         ".ascii \"\\4gdb.inlined-script.BOOST_UNORDERED_UNORDERED_PRINTERS_HPP\\n\"\n"
+         ".ascii \"import gdb.printing\\n\"\n"
+         ".ascii \"import gdb.xmethod\\n\"\n"
+--- a/libs/json/pretty_printers/generate-gdb-header.py
++++ b/libs/json/pretty_printers/generate-gdb-header.py
+@@ -27,7 +27,7 @@ _top = '''\
+ #endif
+ 
+ __asm__(
+-  ".pushsection \\\".debug_gdb_scripts\\\", \\\"MS\\\",@progbits,1\\n"
++  ".pushsection \\\".debug_gdb_scripts\\\", \\\"MS\\\",%progbits,1\\n"
+   ".ascii \\\"\\\\4gdb.inlined-script.{script_id}\\\\n\\\"\\n"
+ '''
+


### PR DESCRIPTION
## Description

Boost uses inline assembly syntax that is rejected by LLVM for ARMv7. `%progbits` works on all targets and should be used here instead.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
