### PR TITLE
main/fortify-headers: fix tests on 32-bit targets with _REDIR_TIME64

### DIFF
--- a/main/fortify-headers/patches/ppoll-test-guards.patch
+++ b/main/fortify-headers/patches/ppoll-test-guards.patch
@@ -1,0 +1,50 @@
+From be49666ba508283b8ba35a2ef05576b86ba455f5 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Thu, 3 Apr 2025 17:23:31 +0200
+Subject: [PATCH] Add missing ifdef guards for ppoll tests
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ tests/test_ppoll_dynamic.c | 3 +++
+ tests/test_ppoll_static.c  | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/tests/test_ppoll_dynamic.c b/tests/test_ppoll_dynamic.c
+index 7b049d1..9afefa7 100644
+--- a/tests/test_ppoll_dynamic.c
++++ b/tests/test_ppoll_dynamic.c
+@@ -6,10 +6,13 @@
+ int main(int argc, char** argv) {
+   struct pollfd buffer[8] = {0};
+ 
++#if !_REDIR_TIME64
+   CHK_FAIL_START
+   ppoll(buffer, argc, NULL, NULL);
+   CHK_FAIL_END
+ 
+   puts((const char*)buffer);
+   return ret;
++#endif
++  return 0;
+ }
+diff --git a/tests/test_ppoll_static.c b/tests/test_ppoll_static.c
+index 186bafe..f247515 100644
+--- a/tests/test_ppoll_static.c
++++ b/tests/test_ppoll_static.c
+@@ -6,10 +6,13 @@
+ int main(int argc, char** argv) {
+   struct pollfd buffer[12] = {0};
+ 
++#if !_REDIR_TIME64
+   CHK_FAIL_START
+   ppoll(buffer, 14, NULL, NULL);
+   CHK_FAIL_END
+ 
+   puts((const char*)buffer);
+   return ret;
++#endif
++  return 0;
+ }
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

`ppoll` is not re-defined when `_REDIR_TIME64` is set, so the `ppoll` tests should be skipped in that case.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
