### PR TITLE
main/doxygen: work around checks with libxml2-progs 2.14

### DIFF
--- a/main/doxygen/patches/xmllint-expected-xml.patch
+++ b/main/doxygen/patches/xmllint-expected-xml.patch
@@ -1,0 +1,42 @@
+From 02b51e2bb5cd7d8c0f45d50f2904628ec05b08c3 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Fri, 4 Apr 2025 18:56:50 +0200
+Subject: [PATCH] Run expected XML through xmllint as well
+
+This fixes test inconsistencies when xmllint changes its output.
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ testing/runtests.py | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/testing/runtests.py b/testing/runtests.py
+index f4f0cb6d6..3a39a16fa 100755
+--- a/testing/runtests.py
++++ b/testing/runtests.py
+@@ -331,7 +331,21 @@ class Tester:
+                     with xopen(out_file,'w') as f:
+                         print(data,file=f)
+                     ref_file='%s/%s/%s' % (self.args.inputdir,self.test_id,check)
+-                    (failed_xml,xml_msg) = self.compare_ok(out_file,ref_file,self.test_name)
++                    # convert reference file to canonical form
++                    ref_file = ref_file.replace('\\','/')
++                    data = xpopen('%s --format --noblanks --nowarning %s' % (self.args.xmllint,ref_file))
++                    if data:
++                        # strip version
++                        data = re.sub(r'xsd" version="[0-9.-]+"','xsd" version=""',data).rstrip('\n')
++                    else:
++                        msg += ('Failed to run %s on the reference output file %s' % (self.args.xmllint,ref_file),)
++                        break
++                    if self.args.subdirs:
++                        data = re.sub('d[0-9a-f]/d[0-9a-f][0-9a-f]/','',data)
++                    ref_file_fmt = ref_file + '.new'
++                    with xopen(ref_file_fmt,'w') as f:
++                        print(data,file=f)
++                    (failed_xml,xml_msg) = self.compare_ok(out_file,ref_file_fmt,self.test_name)
+                     if failed_xml:
+                         msg+= (xml_msg,)
+                         break
+-- 
+2.49.0
+

--- a/main/doxygen/template.py
+++ b/main/doxygen/template.py
@@ -16,6 +16,8 @@ hardening = ["vis", "cfi"]
 def post_extract(self):
     # needs texlive stuff
     self.rm("testing/012_cite.dox")
+    # xmllint produces different outputs on semantically identical input
+    self.rm("testing/009_bug.cpp")
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

doxygen's testsuite uses `xmllint`, which changed its behaviour in libxml2 2.14. To avoid breakage of the tests like this, let's run `xmllint` over the expected output files as well. This fixes all erroring tests except 1, which is because `xmllint` refuses to properly indent a closing tag. I disabled that test because I couldn't come up with an appropriate fix.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
