### PR TITLE
main/libucontext: fix on ARMv7

### DIFF
--- a/main/libucontext/patches/arm-hardfloat.patch
+++ b/main/libucontext/patches/arm-hardfloat.patch
@@ -1,0 +1,61 @@
+From 2a806cd9919f0f39bf3daadef4f10abc843cd37a Mon Sep 17 00:00:00 2001
+From: Richard Campbell <rlcamp@users.noreply.github.com>
+Date: Wed, 20 Nov 2024 13:29:46 -0800
+Subject: [PATCH] fix arm hard float code path broken by 9e5de65076
+
+---
+ Makefile               |  3 +--
+ arch/arm/swapcontext.S | 11 ++++++-----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0c68f13..1fb1580 100644
+--- a/Makefile
++++ b/Makefile
+@@ -42,8 +42,7 @@ else
+ 	CPPFLAGS += -Iarch/common/include
+ endif
+ 
+-# ARM hard float support is presently broken.
+-FORCE_SOFT_FLOAT := yes
++FORCE_SOFT_FLOAT := no
+ 
+ ifeq ($(FORCE_SOFT_FLOAT),yes)
+         CPPFLAGS += -DFORCE_SOFT_FLOAT
+diff --git a/arch/arm/swapcontext.S b/arch/arm/swapcontext.S
+index f0627bf..e072002 100644
+--- a/arch/arm/swapcontext.S
++++ b/arch/arm/swapcontext.S
+@@ -16,13 +16,17 @@ ALIAS(swapcontext, libucontext_swapcontext)
+ ALIAS(__swapcontext, libucontext_swapcontext)
+ 
+ FUNC(libucontext_swapcontext)
++	/* copy all of the current registers into the ucontext structure */
++	str	r13, [r0,#REG_OFFSET(13)]
++	str	r14, [r0,#REG_OFFSET(15)]
++
+ #ifndef FORCE_SOFT_FLOAT
+ #ifndef FORCE_HARD_FLOAT
+ 	/* test for vfp magic number, copy to other ucontext */
+ 	ldr	r3, [r1, #VFP_MAGIC_OFFSET]
+-	ldr	r4, =#0x56465001
++	ldr	r2, =#0x56465001
+ 	str	r3, [r0, #VFP_MAGIC_OFFSET]
+-	cmp	r3, r4
++	cmp	r3, r2
+ 	bne	1f
+ #endif
+ 	/* if vfp in use, save and restore d8-d15 */
+@@ -36,9 +40,6 @@ FUNC(libucontext_swapcontext)
+ 1:
+ #endif
+ 
+- 	/* copy all of the current registers into the ucontext structure */
+- 	str	r13, [r0,#REG_OFFSET(13)]
+- 	str	r14, [r0,#REG_OFFSET(15)]
+ 	add	r2, r0, #REG_OFFSET(0)
+ 	/* copy r0 with value 0 to indicate success (return value 0) */
+ 	mov r0, #0
+-- 
+2.49.0
+

--- a/main/libucontext/patches/arm-llvm.patch
+++ b/main/libucontext/patches/arm-llvm.patch
@@ -1,0 +1,54 @@
+From ea1bc3f7c923b40c738c631f710266803d5134d8 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Sat, 5 Apr 2025 03:12:09 +0200
+Subject: [PATCH] arm: make assembly compile with LLVM
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ arch/arm/getcontext.S  | 2 +-
+ arch/arm/setcontext.S  | 2 +-
+ arch/arm/swapcontext.S | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/getcontext.S b/arch/arm/getcontext.S
+index 0afa150..c65a03f 100644
+--- a/arch/arm/getcontext.S
++++ b/arch/arm/getcontext.S
+@@ -31,7 +31,7 @@ FUNC(libucontext_getcontext)
+         tst     r0, #64
+         pop     {r0-r1,fp,lr}
+ 	moveq	r2, #0
+-	ldrne	r2, =#0x56465001
++	ldrne	r2, =0x56465001
+ 	str	r2, [r0, #VFP_MAGIC_OFFSET]
+         beq     1f
+ #endif
+diff --git a/arch/arm/setcontext.S b/arch/arm/setcontext.S
+index 792d8f2..b475153 100644
+--- a/arch/arm/setcontext.S
++++ b/arch/arm/setcontext.S
+@@ -20,7 +20,7 @@ FUNC(libucontext_setcontext)
+ #ifndef FORCE_HARD_FLOAT
+ 	/* test for vfp magic number set by getcontext */
+ 	ldr	r2, [r0, #VFP_MAGIC_OFFSET]
+-	ldr	r3, =#0x56465001
++	ldr	r3, =0x56465001
+ 	cmp	r2, r3
+         bne     1f
+ #endif
+diff --git a/arch/arm/swapcontext.S b/arch/arm/swapcontext.S
+index e072002..6e853ec 100644
+--- a/arch/arm/swapcontext.S
++++ b/arch/arm/swapcontext.S
+@@ -24,7 +24,7 @@ FUNC(libucontext_swapcontext)
+ #ifndef FORCE_HARD_FLOAT
+ 	/* test for vfp magic number, copy to other ucontext */
+ 	ldr	r3, [r1, #VFP_MAGIC_OFFSET]
+-	ldr	r2, =#0x56465001
++	ldr	r2, =0x56465001
+ 	str	r3, [r0, #VFP_MAGIC_OFFSET]
+ 	cmp	r3, r2
+ 	bne	1f
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

The first patch fixes hardfloat support, the second patch fixes the assembly syntax. Since hardfloat was only disabled when using the Makefile, not when using Meson, we need that patch to pass the testsuite.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
