### PR TITLE
main/wayland-protocols: !check for armv7

### DIFF
--- a/main/wayland-protocols/template.py
+++ b/main/wayland-protocols/template.py
@@ -12,7 +12,7 @@ sha256 = "f25b0d00f3c610158b00b57b1b7b6e59c4bfd4d91aed46f24d9eba7acf220788"
 # check conditional
 options = []
 
-if self.profile().arch in ["loongarch64", "riscv64"]:
+if self.profile().arch in ["armv7", "loongarch64", "riscv64"]:
     # several pedantic tests complain about symbol not found
     options += ["!check"]
 


### PR DESCRIPTION
## Description

Fails with missing symbols in pedantic tests just like riscv64 and loongarch64:

```
Summary of Failures:

 76/156 test-build-pedantic-staging_cursor_shape_cursor_shape_v1_xml                                               FAIL            0.20s   exit status 127
 80/156 test-build-pedantic-staging_ext_image_capture_source_ext_image_capture_source_v1_xml                       FAIL            0.17s   exit status 127
 91/156 test-build-pedantic-staging_ext_image_copy_capture_ext_image_copy_capture_v1_xml                           FAIL            0.25s   exit status 127
105/156 test-build-pedantic-staging_xdg_dialog_xdg_dialog_v1_xml                                                   FAIL            0.21s   exit status 127
106/156 test-build-pedantic-staging_xdg_toplevel_drag_xdg_toplevel_drag_v1_xml                                     FAIL            0.18s   exit status 127
109/156 test-build-pedantic-staging_xdg_toplevel_icon_xdg_toplevel_icon_v1_xml                                     FAIL            0.20s   exit status 127
```

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
