### PR TITLE
main/python-pexpect: disable performance test on ARMv7

### DIFF
--- a/main/python-pexpect/template.py
+++ b/main/python-pexpect/template.py
@@ -29,6 +29,11 @@ def post_extract(self):
     # can't deal with escapes
     self.rm("tests/test_replwrap.py")
 
+    if self.profile().arch == "armv7":
+        # doesn't find a match when searching with regex and windowsize
+        # see https://github.com/pexpect/pexpect/issues/816
+        self.rm("tests/test_performance.py")
+
 
 def post_install(self):
     self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This test currently times out on ARMv7, see the linked issue for details.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
