### PR TITLE
user/micro: generate syntax highlighting files

### DIFF
--- a/user/micro/template.py
+++ b/user/micro/template.py
@@ -1,6 +1,6 @@
 pkgname = "micro"
 pkgver = "2.0.14"
-pkgrel = 7
+pkgrel = 8
 build_style = "go"
 make_build_args = [
     f"-ldflags=-X github.com/zyedidia/micro/v2/internal/util.Version={pkgver}",
@@ -12,6 +12,12 @@ license = "MIT"
 url = "https://micro-editor.github.io"
 source = f"https://github.com/zyedidia/micro/archive/v{pkgver}.tar.gz"
 sha256 = "40177579beb3846461036387b649c629395584a4bbe970f61ba7591bd9c0185a"
+
+
+def pre_build(self):
+    from cbuild.util import golang
+
+    self.do("go", "generate", "./runtime", env=golang.get_go_env(self))
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

the editor was built without syntax highlighting files. to generate them, one needs to additionally run `go generate ./runtime` during build (their Makefile takes care of it but we don't use it)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [n/a] I will take responsibility for my template and keep it up to date

---
<sup><sub>i copied the commit message [from alpine](https://git.alpinelinux.org/aports/commit/?id=20d1a8722b5600f9d3d6d341484ca4c135b284ce). hope nobody will be mad (ó﹏ò｡)</sub></sup>