### PR TITLE
main/http-parser: Patch out non-portable test

### DIFF
--- a/main/http-parser/patches/dont-test-http_parser-size.patch
+++ b/main/http-parser/patches/dont-test-http_parser-size.patch
@@ -1,0 +1,30 @@
+From efec29370bfe51c63dc2c2cd88aaadc0933072e5 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Tue, 8 Apr 2025 22:42:05 +0200
+Subject: [PATCH] Don't test http_parser size
+
+This test is pointless and not portable because alignment differs
+between architectures (notably 32-bit ARM fails this test).
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ test.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/test.c b/test.c
+index 7983424..7dd83c6 100644
+--- a/test.c
++++ b/test.c
+@@ -4220,9 +4220,6 @@ main (void)
+   patch = version & 255;
+   printf("http_parser v%u.%u.%u (0x%06lx)\n", major, minor, patch, version);
+ 
+-  printf("sizeof(http_parser) = %u\n", (unsigned int)sizeof(http_parser));
+-  assert(sizeof(http_parser) == 4 + 4 + 8 + 2 + 2 + 4 + sizeof(void *));
+-
+   //// API
+   test_preserve_data();
+   test_parse_url();
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

Testing for the size of the struct is not portable due to different alignments. This fixes tests on 32-bit ARM.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
