### PR TITLE
main/chez-scheme: disable checks on 32-bit ARM

### DIFF
--- a/main/chez-scheme/template.py
+++ b/main/chez-scheme/template.py
@@ -25,6 +25,8 @@ match self.profile().arch:
         _machine = "tarm64le"
     case "armhf" | "armv7":
         _machine = "tarm32le"
+        # takes a long time and fails
+        options += ["!check"]
     case "ppc":
         _machine = "tppc32le"
     case "riscv64":


### PR DESCRIPTION
## Description

Tests take an eternity and then fail very cryptically on 32-bit ARM. Other distros don't run tests at all or only for aarch64 and x86_64, so this isn't too unreasonable.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
