### PR TITLE
main/openexr: disable failing test on ARMv7

### DIFF
--- a/main/openexr/template.py
+++ b/main/openexr/template.py
@@ -5,13 +5,6 @@ build_style = "cmake"
 configure_args = [
     "-DBUILD_SHARED_LIBS=ON",
 ]
-make_check_args = [
-    "-E",
-    # fails to catch a divzero assert by wrong name
-    "(OpenEXR.Iex"
-    # require downloaded exr files to test against
-    "|OpenEXR.bin)",
-]
 hostmakedepends = [
     "cmake",
     "ninja",
@@ -29,6 +22,19 @@ source = f"https://github.com/openexr/openexr/archive/v{pkgver}.tar.gz"
 sha256 = "0ffbd842a7ee2128d44affdea30f42294b4061293cde3aa75b61a53573413d1e"
 # CIF: has a bunch of test failures
 hardening = ["vis", "!cfi"]
+
+_exclude_tests = [
+    # fails to catch a divzero assert by wrong name
+    "OpenEXR.Iex",
+    # require downloaded exr files to test against
+    "OpenEXR.bin",
+]
+
+if self.profile().arch == "armv7":
+    # bus error
+    _exclude_tests.append("OpenEXR.testLargeDataWindowOffsets")
+
+make_check_args = ["-E", f"({'|'.join(_exclude_tests)})"]
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Test fails with bus error on ARMv7, same on Alpine so this is somewhat (?) expected. Remaining tests pass fine, so let's only disable this one.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
