### PR TITLE
main/libde265: fix build for ARMv7

### DIFF
--- a/main/libde265/patches/fix-arm-include-paths.patch
+++ b/main/libde265/patches/fix-arm-include-paths.patch
@@ -1,0 +1,38 @@
+From 75cb1d496125ff34818bcc7b902e9ee2122daa98 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Wed, 9 Apr 2025 02:42:48 +0200
+Subject: [PATCH] Fix ARM include paths
+
+Akin to 4b63f6b07cfc692058fda254b901ea817ef2bbd5.
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ libde265/arm/Makefile.am | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libde265/arm/Makefile.am b/libde265/arm/Makefile.am
+index 9ef62d98..faea8af9 100644
+--- a/libde265/arm/Makefile.am
++++ b/libde265/arm/Makefile.am
+@@ -1,6 +1,6 @@
+ noinst_LTLIBRARIES = libde265_arm.la
+ 
+-libde265_arm_la_CXXFLAGS = -I.. $(CFLAG_VISIBILITY)
++libde265_arm_la_CXXFLAGS = -I$(top_srcdir)/libde265 $(CFLAG_VISIBILITY)
+ libde265_arm_la_SOURCES = arm.cc arm.h
+ libde265_arm_la_LIBADD =
+ 
+@@ -14,8 +14,8 @@ if ENABLE_NEON_OPT
+ 
+ noinst_LTLIBRARIES += libde265_arm_neon.la
+ libde265_arm_la_LIBADD += libde265_arm_neon.la
+-libde265_arm_neon_la_CXXFLAGS = -mfpu=neon -I.. $(CFLAG_VISIBILITY)
+-libde265_arm_neon_la_CCASFLAGS = -mfpu=neon -I.. \
++libde265_arm_neon_la_CXXFLAGS = -mfpu=neon -I$(top_srcdir)/libde265 $(CFLAG_VISIBILITY)
++libde265_arm_neon_la_CCASFLAGS = -mfpu=neon -I$(top_srcdir)/libde265 \
+ 	-DHAVE_NEON \
+ 	-DEXTERN_ASM= \
+ 	-DHAVE_AS_FUNC \
+-- 
+2.49.0
+

--- a/main/libde265/patches/remove-.func-.endfunc-usage.patch
+++ b/main/libde265/patches/remove-.func-.endfunc-usage.patch
@@ -1,0 +1,40 @@
+From 9dc25da617f3c66cb82b7f46386c19100e6e375d Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Wed, 9 Apr 2025 02:50:39 +0200
+Subject: [PATCH] Remove .func/.endfunc usage
+
+Only necessary when generating STABS debug info, which is practically
+not used anymore (DWARF is used nowadays).
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ libde265/arm/asm.S | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/libde265/arm/asm.S b/libde265/arm/asm.S
+index 1d0e5a97..4fe674f7 100644
+--- a/libde265/arm/asm.S
++++ b/libde265/arm/asm.S
+@@ -72,7 +72,6 @@ ELF     .section .note.GNU-stack,"",%progbits @ Mark stack as non-executable
+         .noaltmacro
+       .endif
+ ELF     .size   \name, . - \name
+-FUNC    .endfunc
+         .purgem endfunc
+     .endm
+         .text
+@@ -80,11 +79,9 @@ FUNC    .endfunc
+     .if \export
+         .global EXTERN_ASM\name
+ ELF     .type   EXTERN_ASM\name, %function
+-FUNC    .func   EXTERN_ASM\name
+ EXTERN_ASM\name:
+     .else
+ ELF     .type   \name, %function
+-FUNC    .func   \name
+ \name:
+     .endif
+ .endm
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

Patches should be self-explanatory. This fixes the include paths and removes unnecessary syntax not understood by the integrated assembler in clang.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
