### PR TITLE
main/libtpms: fix checks on 32-bit targets

### DIFF
--- a/main/libtpms/patches/10-fix-nvram_offsets-32bit-test.patch
+++ b/main/libtpms/patches/10-fix-nvram_offsets-32bit-test.patch
@@ -1,0 +1,27 @@
+From 806141196296150c03e5d826ab7e6c3602f41b98 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Fri, 15 Nov 2024 08:07:23 -0500
+Subject: [PATCH] tpm2: Add padding to OBJECT for 32bit targets
+
+The nvram_offsets test fails on 32bit targets due to an unexpected size
+of an OBJECT. This was due to missing padding.
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm2/Global.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/tpm2/Global.h b/src/tpm2/Global.h
+index 910b940e3..c4d7176f3 100644
+--- a/src/tpm2/Global.h
++++ b/src/tpm2/Global.h
+@@ -265,6 +265,9 @@ typedef struct OBJECT
+     // this field carries additional metadata
+     // needed to derive the proof value for
+     // the object.
++#if __LONG_WIDTH__ == 32
++    UINT8               _pad1[4]; /* 32 bit targets need padding */
++#endif
+ 
+     // libtpms added: SEED_COMPAT_LEVEL to use for deriving child keys
+     SEED_COMPAT_LEVEL   seedCompatLevel;


### PR DESCRIPTION
## Description

This patch fixes tests on 32-bit targets like ARMv7.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
