### PR TITLE
main/snappy: fix build for ARMv7

### DIFF
--- a/main/snappy/patches/neon-only-64-bit.patch
+++ b/main/snappy/patches/neon-only-64-bit.patch
@@ -1,0 +1,30 @@
+From 32ded457c0b1fe78ceb8397632c416568d6714a0 Mon Sep 17 00:00:00 2001
+From: Danila Kutenin <danilak@google.com>
+Date: Sat, 17 Aug 2024 19:03:10 -0700
+Subject: [PATCH] Update CMakeLists NEON flag to reflect only AArch64 NEON
+ optimizations
+
+---
+ CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 644df24..b1d072c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -206,10 +206,13 @@ int main() {
+ 
+ check_cxx_source_compiles("
+ #include <arm_neon.h>
++#include <stdint.h>
+ int main() {
+   uint8_t val = 3, dup[8];
+-  uint8x16_t v = vld1q_dup_u8(&val);
+-  vst1q_u8(dup, v);
++  uint8x16_t v1 = vld1q_dup_u8(&val);
++  uint8x16_t v2 = vqtbl1q_u8(v1, v1);
++  vst1q_u8(dup, v1);
++  vst1q_u8(dup, v2);
+   return 0;
+ }" SNAPPY_HAVE_NEON)
+ 


### PR DESCRIPTION
## Description

Cherry-pick a fix that only enables NEON for 64-bit ARM since incompatible intrinsics are used.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
