### PR TITLE
main/qemu-user: fix installing binfmt configs for ARMv7

### DIFF
--- a/main/qemu-user/template.py
+++ b/main/qemu-user/template.py
@@ -82,6 +82,7 @@ def post_install(self):
 
 _skip_32bit = {
     "i386": "x86_64",
+    "aarch64": "arm",
     "arm": "aarch64",
     "ppc": "ppc64",
     "ppc64": "ppc",
@@ -99,7 +100,13 @@ def _upkg(uname):
         return [f"usr/bin/qemu-{uname}"]
 
     do_pkg = True
-    curarch = self.profile().arch
+
+    match self.profile().arch:
+        case "armv7":
+            curarch = "arm"
+        case arch:
+            curarch = arch
+
     if uname == curarch:
         do_pkg = False
     elif uname in _skip_32bit and _skip_32bit[uname] == curarch:


### PR DESCRIPTION
## Description

Trivial fix, `armv7` is `arm` in QEMU naming.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
