### PR TITLE
main/gdk-pixbuf: disable checks on 32-bit targets

### DIFF
--- a/main/gdk-pixbuf/template.py
+++ b/main/gdk-pixbuf/template.py
@@ -29,7 +29,12 @@ source = f"$(GNOME_SITE)/gdk-pixbuf/{pkgver[:-3]}/gdk-pixbuf-{pkgver}.tar.xz"
 sha256 = "b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7"
 # FIXME int
 hardening = ["!int"]
+# check may be disabled
 options = ["!cross"]
+
+if self.profile().wordsize == 32:
+    # https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/issues/215
+    options += ["!check"]
 
 
 @subpackage("gdk-pixbuf-devel")


### PR DESCRIPTION
## Description

They apparently fail on a bunch of 32-bit targets so it's fair to assume they fail on all.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
