### PR TITLE
main/capnproto: skip failing test on ARMv7

### DIFF
--- a/main/capnproto/template.py
+++ b/main/capnproto/template.py
@@ -21,6 +21,10 @@ if self.profile().cross:
     hostmakedepends += ["capnproto-devel"]
     configure_args += ["-DEXTERNAL_CAPNP=ON", "-DBUILD_TESTING=OFF"]
 
+if self.profile().arch == "armv7":
+    # mutex-test.c++ has timing issues
+    make_check_args = ["-E", "kj-tests-run"]
+
 
 def post_install(self):
     self.install_license("LICENSE.txt")


### PR DESCRIPTION
## Description

We can still run the other tests, better than disabling them all.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
