### PR TITLE
cbuild: fix mispelled invocation

### DIFF
--- a/src/cbuild/hooks/pkg/001_runtime_deps.py
+++ b/src/cbuild/hooks/pkg/001_runtime_deps.py
@@ -318,7 +318,7 @@ def _scan_svc(pkg):
 
     def subpkg_provides_svc(pn, pfx):
         for sp in pkg.rparent.subpkg_list:
-            if pkg_provies_svc(sp, pn, pfx):
+            if pkg_provides_svc(sp, pn, pfx):
                 return sp.pkgname
         return None
 


### PR DESCRIPTION
## Description

Fix mispelled `pkg_provies_svc`

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
