### PR TITLE
user/calcurse: fix checks for 32-bit targets

### DIFF
--- a/user/calcurse/patches/0001-Change-arg_print_date-argument-to-time_t.patch
+++ b/user/calcurse/patches/0001-Change-arg_print_date-argument-to-time_t.patch
@@ -1,0 +1,28 @@
+From 874381b28466ab0c240b46292089be0e63117a1c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?MrSm=C3=B6r?= <66489839+MrSmoer@users.noreply.github.com>
+Date: Wed, 16 Apr 2025 01:11:31 +0200
+Subject: [PATCH] Change arg_print_date argument to time_t
+
+arg_print_date was casting a long* to time_t*.
+This is undefined behaviour (eg. with 64-bit time_t and 32-bit long,
+64 bits will be read from a 32-bit wide location).
+---
+ src/args.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/args.c b/src/args.c
+index c2cc3de..93dc910 100644
+--- a/src/args.c
++++ b/src/args.c
+@@ -251,7 +251,7 @@ static void next_arg(void)
+ /*
+  * Print the date on stdout.
+  */
+-static void arg_print_date(long date)
++static void arg_print_date(time_t date)
+ {
+ 	char date_str[BUFSIZ];
+ 	struct tm lt;
+-- 
+2.48.1
+

--- a/user/calcurse/patches/0002-gcc14-32-bit.patch
+++ b/user/calcurse/patches/0002-gcc14-32-bit.patch
@@ -1,0 +1,35 @@
+Use time_t in overflow_add() time value.
+
+--- calcurse-4.8.1-orig/src/calcurse.h
++++ calcurse-4.8.1/src/calcurse.h
+@@ -1272,7 +1272,7 @@
+ int starts_with(const char *, const char *);
+ int starts_with_ci(const char *, const char *);
+ int hash_matches(const char *, const char *);
+-long overflow_add(long, long, long *);
++long overflow_add(long, long, time_t *);
+ long overflow_mul(long, long, long *);
+ time_t next_wday(time_t, int);
+ int wday_per_year(int, int);
+--- calcurse-4.8.1-orig/src/utils.c
++++ calcurse-4.8.1/src/utils.c
+@@ -1260,8 +1260,8 @@
+ 	dur += in;
+ 	if (start) {
+ 		/* wanted: end = start + dur * MININSEC */
+-		time_t end;
+-		long p, s;
++		time_t end, s;
++		long p;
+ 		if (overflow_mul(dur, MININSEC, &p))
+ 			return 0;
+ 		if (overflow_add(start, p, &s))
+@@ -2043,7 +2043,7 @@
+ /*
+  * Overflow check for addition with positive second term.
+  */
+-long overflow_add(long x, long y, long *z)
++long overflow_add(long x, long y, time_t *z)
+ {
+ 	if (!YEAR1902_2037)
+ 		goto exit;


### PR DESCRIPTION
## Description

There was a bunch of misuse of `long` instead of `time_t` here, resulting in pointers to 64-bit integers crafted from 32-bit ones and therefore UB.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
