### PR TITLE
main/lagrange: fix build on ARMv7

### DIFF
--- a/main/lagrange/neon-only-64-bit.patch
+++ b/main/lagrange/neon-only-64-bit.patch
@@ -1,0 +1,27 @@
+From 2ea03504b274296c4d3ea15a49895c83fb057015 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Wed, 16 Apr 2025 02:42:36 +0200
+Subject: [PATCH] STBIR_NEON uses 64-bit intrinsics, don't enable on 32-bit
+ targets
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ src/stb_image_resize2.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/stb_image_resize2.h b/src/stb_image_resize2.h
+index 7aaeab0..37eecff 100644
+--- a/src/stb_image_resize2.h
++++ b/src/stb_image_resize2.h
+@@ -400,7 +400,7 @@ typedef uint64_t stbir_uint64;
+   #endif
+ #endif
+ 
+-#if defined( _M_ARM64 ) || defined( __aarch64__ ) || defined( __arm64__ ) || defined(_M_ARM) || (__ARM_NEON_FP & 4) != 0 &&  __ARM_FP16_FORMAT_IEEE != 0
++#if defined( _M_ARM64 ) || defined( __aarch64__ ) || defined( __arm64__ )
+ #ifndef STBIR_NEON
+ #define STBIR_NEON
+ #endif
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

The code guarded by `#ifdef STBIR_NEON` uses 64-bit NEON intrinsics, so the conditions for enabling it are wrong. Just disable NEON outright on 32-bit targets.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
