### PR TITLE
user/supertuxkart: work around LLVM bug on ARMv7

### DIFF
--- a/user/supertuxkart/patches/0001-Force-disable-NEON-on-ARMv7.patch
+++ b/user/supertuxkart/patches/0001-Force-disable-NEON-on-ARMv7.patch
@@ -1,0 +1,30 @@
+From 59893c8475b85f8bda7d2ff2ca45a48b913bac51 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Wed, 16 Apr 2025 15:02:36 +0200
+Subject: [PATCH] Force disable NEON on ARMv7
+
+Works around an internal compiler bug in LLVM and makes the game run on
+a wider variety of ARMv7 devices. This should be re-evaluated with LLVM
+20.
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ lib/simd_wrapper/simde/simde-arch.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/simd_wrapper/simde/simde-arch.h b/lib/simd_wrapper/simde/simde-arch.h
+index 2d09ff7..aaf9efa 100644
+--- a/lib/simd_wrapper/simde/simde-arch.h
++++ b/lib/simd_wrapper/simde/simde-arch.h
+@@ -112,7 +112,7 @@
+ #endif
+ 
+ /* ARM SIMD ISA extensions */
+-#if defined(__ARM_NEON) || defined(SIMDE_ARCH_AARCH64)
++#if (defined(__ARM_NEON) && false) || defined(SIMDE_ARCH_AARCH64)
+ #  if defined(SIMDE_ARCH_AARCH64)
+ #    define SIMDE_ARCH_ARM_NEON SIMDE_ARCH_AARCH64
+ #  elif defined(SIMDE_ARCH_ARM)
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

This disables NEON on ARMv7 in supertuxkart. If enabled, LLVM will crash. If this still occurs with LLVM 20 we should probably report it upstream, for now disabling NEON is a good enough hack to get it building.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
