### PR TITLE
main/gpgme: don't assume 32-bit time in tests

### DIFF
--- a/main/gpgme/patches/time_t-is-64-bit.patch
+++ b/main/gpgme/patches/time_t-is-64-bit.patch
@@ -1,0 +1,66 @@
+From bb26903a1c1c8b93819ce264eef8cd0b214b4397 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Thu, 17 Apr 2025 03:40:24 +0200
+Subject: [PATCH] We have 64-bit time
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ lang/qt/tests/t-addexistingsubkey.cpp | 42 ++++++++++++---------------
+ 1 file changed, 18 insertions(+), 24 deletions(-)
+
+diff --git a/lang/qt/tests/t-addexistingsubkey.cpp b/lang/qt/tests/t-addexistingsubkey.cpp
+index df620dd..a579f1b 100644
+--- a/lang/qt/tests/t-addexistingsubkey.cpp
++++ b/lang/qt/tests/t-addexistingsubkey.cpp
+@@ -213,30 +213,24 @@ private Q_SLOTS:
+ 
+         const auto result = job->exec(key, sourceSubkey);
+ 
+-        if (sourceSubkey.expirationTime() > 0) {
+-            QCOMPARE(result.code(), static_cast<int>(GPG_ERR_NO_ERROR));
+-            key.update();
+-            QCOMPARE(key.numSubkeys(), 3u);
+-
+-            // allow 1 second different expiration because gpg calculates with
+-            // expiration as difference to current time and takes current time
+-            // several times
+-            const auto allowedDeltaTSeconds = 1;
+-            const auto expectedExpirationRange = std::make_pair(
+-                uint_least32_t(sourceSubkey.expirationTime()) - allowedDeltaTSeconds,
+-                uint_least32_t(sourceSubkey.expirationTime()) + allowedDeltaTSeconds);
+-            const auto actualExpiration = uint_least32_t(key.subkey(2).expirationTime());
+-            QVERIFY2(actualExpiration >= expectedExpirationRange.first,
+-                    ("actual: " + std::to_string(actualExpiration) +
+-                    "; expected: " + std::to_string(expectedExpirationRange.first)).c_str());
+-            QVERIFY2(actualExpiration <= expectedExpirationRange.second,
+-                    ("actual: " + std::to_string(actualExpiration) +
+-                    "; expected: " + std::to_string(expectedExpirationRange.second)).c_str());
+-        } else {
+-            // on 32-bit systems the expiration date of the test key overflows;
+-            // in this case we expect an appropriate error code
+-            QCOMPARE(result.code(), static_cast<int>(GPG_ERR_INV_TIME));
+-        }
++        QCOMPARE(result.code(), static_cast<int>(GPG_ERR_NO_ERROR));
++        key.update();
++        QCOMPARE(key.numSubkeys(), 3u);
++
++        // allow 1 second different expiration because gpg calculates with
++        // expiration as difference to current time and takes current time
++        // several times
++        const auto allowedDeltaTSeconds = 1;
++        const auto expectedExpirationRange = std::make_pair(
++            uint_least32_t(sourceSubkey.expirationTime()) - allowedDeltaTSeconds,
++            uint_least32_t(sourceSubkey.expirationTime()) + allowedDeltaTSeconds);
++        const auto actualExpiration = uint_least32_t(key.subkey(2).expirationTime());
++        QVERIFY2(actualExpiration >= expectedExpirationRange.first,
++                ("actual: " + std::to_string(actualExpiration) +
++                "; expected: " + std::to_string(expectedExpirationRange.first)).c_str());
++        QVERIFY2(actualExpiration <= expectedExpirationRange.second,
++                ("actual: " + std::to_string(actualExpiration) +
++                "; expected: " + std::to_string(expectedExpirationRange.second)).c_str());
+     }
+ 
+ private:
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

This test assume 32-bit time_t behaviour.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
