### PR TITLE
user/forgejo: pass a reasonable work path in service file

### DIFF
--- a/user/forgejo/files/forgejo
+++ b/user/forgejo/files/forgejo
@@ -1,10 +1,9 @@
-# forgejo service
-
 type = process
-command = /usr/bin/forgejo web
+command = /usr/bin/env FORGEJO_WORK_DIR=/var/lib/forgejo /usr/bin/forgejo web
 logfile = /var/log/forgejo.log
-depends-on = network.target
-depends-on = local.target
+depends-on: network.target
+depends-on: local.target
 smooth-recovery = true
 run-as = _forgejo
-load-options = export-passwd-vars
+load-options: export-passwd-vars
+working-dir = /var/lib/forgejo

--- a/user/forgejo/template.py
+++ b/user/forgejo/template.py
@@ -1,6 +1,6 @@
 pkgname = "forgejo"
 pkgver = "11.0.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "makefile"
 make_build_target = "all"
 make_check_target = "test-backend"


### PR DESCRIPTION
otherwise this "defaults to the directory of the Forgejo binary", which means it e.g. tries to save the initial configuration to /usr/bin/custom/conf/app.ini

also match the working-dir to the upstream systemd service file