### PR TITLE
main/mc: fix mouse-key garbage output on ncurses and modern terminals

### DIFF
--- a/main/mc/patches/ncurses-mouse.patch
+++ b/main/mc/patches/ncurses-mouse.patch
@@ -1,0 +1,16 @@
+Fix mouse-key input with ncurses6 in terminals without basic X10 mouse
+support, at the cost of breaking it with ncurses5. See discussion in
+https://github.com/MidnightCommander/mc/issues/4144 .
+
+--- a/lib/tty/key.c
++++ b/lib/tty/key.c
+@@ -2124,8 +2124,7 @@
+         gboolean extended = c == MCKEY_EXTENDED_MOUSE;
+ 
+ #ifdef KEY_MOUSE
+-        extended = extended || (c == KEY_MOUSE && xmouse_seq == NULL
+-                                && xmouse_extended_seq != NULL);
++        extended = extended || (c == KEY_MOUSE && xmouse_extended_seq != NULL);
+ #endif /* KEY_MOUSE */
+ 
+         xmouse_get_event (event, extended);

--- a/main/mc/template.py
+++ b/main/mc/template.py
@@ -1,6 +1,6 @@
 pkgname = "mc"
 pkgver = "4.8.33"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = ["--with-screen=ncurses", "--without-x"]
 configure_gen = []  # broken m4


### PR DESCRIPTION
Fix mouse-key garbage output on ncurses and modern terminals

## Description

Fix mouse-key input with ncurses6 in terminals without basic X10 mouse support, at the cost of breaking it with ncurses5. See discussion in:
https://github.com/MidnightCommander/mc/issues/4144
https://bugs.gentoo.org/753578

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
