### PR TITLE
main/qemu: adjust shutdown parameters

### DIFF
--- a/main/qemu/patches/fix-shutdown.patch
+++ b/main/qemu/patches/fix-shutdown.patch
@@ -1,0 +1,24 @@
+commit 086bccdaa
+Author: Renato Botelho do Couto <renato@netgate.com>
+Date:   Thu Apr 24 08:50:54 2025
+
+    qga: Adjust shutdown call to dinit
+    
+    Do not pass time and wall parameters since they are unsupported
+
+diff --git a/qga/commands-posix.c b/qga/commands-posix.c
+index 12bc086d7..c4786a13d 100644
+--- a/qga/commands-posix.c
++++ b/qga/commands-posix.c
+@@ -251,9 +251,9 @@ void qmp_guest_shutdown(const char *mode, Error **errp)
+ #elif defined(CONFIG_BSD)
+                           shutdown_flag, "+0",
+ #else
+-                          "-h", shutdown_flag, "+0",
++                          "-h", shutdown_flag,
+ #endif
+-                          "hypervisor initiated shutdown", (char *) NULL};
++                          (char *) NULL};
+ 
+     ga_run_command(argv, NULL, "shutdown", &local_err);
+     if (local_err) {

--- a/main/qemu/template.py
+++ b/main/qemu/template.py
@@ -1,6 +1,6 @@
 pkgname = "qemu"
 pkgver = "10.0.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 # TODO vde
 configure_args = [


### PR DESCRIPTION
dinit's shutdown binary doesn't take time and wall message parameters.
Adjust qemu-guest-agent call to make it to work fine on Chimera.
