### PR TITLE
main/wasi-libc: update for llvm 20

### DIFF
--- a/main/wasi-libc/patches/no-double-build.patch
+++ b/main/wasi-libc/patches/no-double-build.patch
@@ -1,10 +1,8 @@
-diff --git a/Makefile b/Makefile
-index 542b43e..327169c 100644
---- a/Makefile
-+++ b/Makefile
-@@ -959,7 +959,7 @@ check-symbols: startup_files libc
- 	# This ignores whitespace because on Windows the output has CRLF line endings.
- 	diff -wur "$(EXPECTED_TARGET_DIR)" "$(SYSROOT_SHARE)"
+--- Makefile.old	2025-04-26 18:38:09.994484652 +1000
++++ Makefile	2025-04-26 18:38:21.610694502 +1000
+@@ -814,7 +814,7 @@
+ endif
+ endif
  
 -install: finish
 +install:

--- a/main/wasi-libc/template.py
+++ b/main/wasi-libc/template.py
@@ -1,12 +1,13 @@
 pkgname = "wasi-libc"
-pkgver = "0.20240724"
+pkgver = "0.20250204"
 pkgrel = 0
-_gitrev = "b9ef79d7dbd47c6c5bafdae760823467c2f60b70"
+_gitrev = "e9524a0980b9bb6bb92e87a41ed1055bdda5bb86"
+hostmakedepends = ["bash"]
 pkgdesc = "WebAssembly libc implementation"
 license = "Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND MIT AND CC0-1.0 AND BSD-2-Clause"
 url = "https://github.com/WebAssembly/wasi-libc"
 source = f"{url}/archive/{_gitrev}.tar.gz"
-sha256 = "9f557e81f7622cbf51b59eaf2d2ebceaa74eb745c4e557dbb5a01e9a36142040"
+sha256 = "9bae87650be66d10662055ec138c6550b127f1ceedaf079266f89b7c7dfb7f34"
 # no tests
 options = ["!check", "!lto"]
 


### PR DESCRIPTION
After the LLVM 20 update this failed to build.

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine