### PR TITLE
user/docker-engine: new package

### DIFF
--- a/user/docker-engine-rootless
+++ b/user/docker-engine-rootless
@@ -1,0 +1,1 @@
+docker-engine

--- a/user/docker-engine/files/docker
+++ b/user/docker-engine/files/docker
@@ -1,0 +1,5 @@
+type = process
+command = /usr/bin/dockerd
+logfile = /var/log/docker.log
+depends-on: containerd
+options: signal-process-only

--- a/user/docker-engine/files/docker.user
+++ b/user/docker-engine/files/docker.user
@@ -1,0 +1,3 @@
+type = process
+command = /usr/bin/dockerd-rootless
+depends-on: dbus

--- a/user/docker-engine/files/sysusers.conf
+++ b/user/docker-engine/files/sysusers.conf
@@ -1,0 +1,1 @@
+g	docker	-

--- a/user/docker-engine/patches/fix-missing-basename.patch
+++ b/user/docker-engine/patches/fix-missing-basename.patch
@@ -1,0 +1,14 @@
+Patch-Source: https://gitlab.alpinelinux.org/alpine/aports/-/blob/a84e604860396f8194e0b0154efd2f94f47517ed/community/tini/fix-missing-basename.patch
+diff --git a/tini/src/tini.c b/tini/src/tini.c
+index eb62015..0e7d5da 100644
+--- a/tini/src/tini.c
++++ b/tini/src/tini.c
+@@ -18,6 +18,8 @@
+ #include "tiniConfig.h"
+ #include "tiniLicense.h"
+ 
++#define basename(name) (strrchr((name),'/') ? strrchr((name),'/')+1 : (name))
++
+ #if TINI_MINIMAL
+ #define PRINT_FATAL(...)                         fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n");
+ #define PRINT_WARNING(...)  if (verbosity > 0) { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }

--- a/user/docker-engine/patches/function-declaration.patch
+++ b/user/docker-engine/patches/function-declaration.patch
@@ -1,0 +1,41 @@
+Patch-Source: https://github.com/krallin/tini/commit/66d0b5fd94fafe1e15bf21a1b73618ca23de078f
+diff --git a/tini/src/tini.c b/tini/src/tini.c
+index 2c873f9..7914d3a 100644
+--- a/tini/src/tini.c
++++ b/tini/src/tini.c
+@@ -147,7 +147,7 @@ int restore_signals(const signal_configuration_t* const sigconf_ptr) {
+ 	return 0;
+ }
+ 
+-int isolate_child() {
++int isolate_child(void) {
+ 	// Put the child into a new process group.
+ 	if (setpgid(0, 0) < 0) {
+ 		PRINT_FATAL("setpgid failed: %s", strerror(errno));
+@@ -392,7 +392,7 @@ int parse_args(const int argc, char* const argv[], char* (**child_args_ptr_ptr)[
+ 	return 0;
+ }
+ 
+-int parse_env() {
++int parse_env(void) {
+ #if HAS_SUBREAPER
+ 	if (getenv(SUBREAPER_ENV_VAR) != NULL) {
+ 		subreaper++;
+@@ -413,7 +413,7 @@ int parse_env() {
+ 
+ 
+ #if HAS_SUBREAPER
+-int register_subreaper () {
++int register_subreaper (void) {
+ 	if (subreaper > 0) {
+ 		if (prctl(PR_SET_CHILD_SUBREAPER, 1)) {
+ 			if (errno == EINVAL) {
+@@ -431,7 +431,7 @@ int register_subreaper () {
+ #endif
+ 
+ 
+-void reaper_check () {
++void reaper_check (void) {
+ 	/* Check that we can properly reap zombies */
+ #if HAS_SUBREAPER
+ 	int bit = 0;

--- a/user/docker-engine/template.py
+++ b/user/docker-engine/template.py
@@ -1,0 +1,97 @@
+pkgname = "docker-engine"
+pkgver = "29.5.0"
+pkgrel = 0
+_commit = "ff8d90ae98c160c3c8751412edbf95ec557217c5"
+_tiniver = "0.19.0"
+hostmakedepends = ["bash", "cmake", "go", "ninja", "pkgconf"]
+makedepends = [
+    "containerd-dinit",
+    "dinit-dbus",
+    "libatomic-chimera-devel-static",
+    "libunwind-devel-static",
+    "linux-headers",
+    "musl-devel-static",
+    "nftables-devel",
+]
+depends = [
+    "containerd",
+    "e2fsprogs",
+    "iptables",
+    "pigz",
+    "procps",
+    "xfsprogs",
+    "xz",
+]
+pkgdesc = "Container management daemon"
+license = "Apache-2.0"
+url = "https://docker.io"
+source = [
+    f"https://github.com/moby/moby/archive/refs/tags/docker-v{pkgver}.tar.gz",
+    f"https://github.com/krallin/tini/archive/refs/tags/v{_tiniver}.tar.gz",
+]
+source_paths = [".", "tini"]
+sha256 = [
+    "406f6ba2f369e384e39bebe837859a888413dd71608ace7a9b0dc7d550dbd570",
+    "0fd35a7030052acd9f58948d1d900fe1e432ee37103c5561554408bdac6bbf0d",
+]
+env = {
+    "DOCKER_GITCOMMIT": _commit,
+    "VERSION": pkgver,
+}
+# the build system was originally designed to be ran in a container so tests are a mess
+# also likely wouldnt work in a cbuild environment anyways
+options = ["!check"]
+
+
+def prepare(self):
+    self.do("make", wrksrc="man")
+
+
+def configure(self):
+    from cbuild.util import cmake
+
+    cmake.configure(
+        self, "tini", "tini", ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
+    )
+
+
+def build(self):
+    from cbuild.util import golang
+
+    self.do("hack/make.sh", "dynbinary", env=golang.get_go_env(self))
+
+
+def post_build(self):
+    from cbuild.util import cmake
+
+    cmake.build(self, "tini", ["--target", "tini-static"])
+
+
+def install(self):
+    self.install_service(self.files_path / "docker")
+    self.install_sysusers(self.files_path / "sysusers.conf")
+    self.install_bin("bundles/dynbinary-daemon/dockerd")
+    self.install_bin("bundles/dynbinary-daemon/docker-proxy")
+    self.install_bin("tini/tini-static", name="docker-init")
+    # rootless
+    self.install_service(self.files_path / "docker.user")
+    self.install_bin("contrib/dockerd-rootless.sh", name="dockerd-rootless")
+
+
+def post_install(self):
+    self.do(
+        "make",
+        "install",
+        f"prefix={self.chroot_destdir}/usr/share",
+        wrksrc="man",
+    )
+
+
+@subpackage("docker-engine-rootless")
+def _(self):
+    self.subdesc = "rootless support"
+    self.depends = [self.parent, "dbus", "rootlesskit", "slirp4netns"]
+    return [
+        "usr/bin/dockerd-rootless",
+        "usr/lib/dinit.d/user",
+    ]

--- a/user/docker-engine/update.py
+++ b/user/docker-engine/update.py
@@ -1,0 +1,2 @@
+pattern = r"docker-v(.+)\<"
+ignore = [r"*rc*"]


### PR DESCRIPTION
## Description

this pr adds the "classic" docker daemon, for times where podman or plain containerd doesn't suffice
both rootful and rootless (given that /etc/subuid and /etc/subguid are set up) setups work

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
