### PR TITLE
user/maim: fix SIGILL and CMake error

### DIFF
--- a/user/maim/template.py
+++ b/user/maim/template.py
@@ -1,7 +1,8 @@
 pkgname = "maim"
 pkgver = "5.8.0"
-pkgrel = 2
+pkgrel = 3
 build_style = "cmake"
+configure_args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
 hostmakedepends = [
     "cmake",
     "ninja",
@@ -24,4 +25,5 @@ license = "GPL-3.0-or-later"
 url = "https://github.com/naelstrof/maim"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "ecafe01dcbe4246071c58ff36acdcd93d290ed501f67933334b646436650450e"
-hardening = ["vis", "cfi"]
+# cfi: SIGILL when trying to take a screenshot
+hardening = ["vis", "!cfi"]


### PR DESCRIPTION
## Description

CFI hardening caused SIGILL when trying to take a screenshot, so I removed it. CMake 4.0+ removed compatibility with CMake <3.5, so minimum version was also bumped to fix the build

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
