### PR TITLE
main/zxing-cpp: Build reader and write programs

### DIFF
--- a/main/zxing-cpp-progs
+++ b/main/zxing-cpp-progs
@@ -1,0 +1,1 @@
+zxing-cpp

--- a/main/zxing-cpp/template.py
+++ b/main/zxing-cpp/template.py
@@ -1,14 +1,14 @@
 pkgname = "zxing-cpp"
 pkgver = "2.3.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DBUILD_UNIT_TESTS=ON",
-    "-DBUILD_EXAMPLES=OFF",
+    "-DBUILD_EXAMPLES=ON",
     "-DBUILD_BLACKBOX_TESTS=OFF",
     "-DBUILD_DEPENDENCIES=LOCAL",
 ]
-hostmakedepends = ["cmake", "ninja", "pkgconf"]
+hostmakedepends = ["cmake", "ninja", "pkgconf", "stb"]
 checkdepends = ["gtest-devel"]
 pkgdesc = "Multi-format 1D/2D barcode library"
 license = "Apache-2.0"
@@ -20,3 +20,8 @@ sha256 = "64e4139103fdbc57752698ee15b5f0b0f7af9a0331ecbdc492047e0772c417ba"
 @subpackage("zxing-cpp-devel")
 def _(self):
     return self.default_devel()
+
+
+@subpackage("zxing-cpp-progs")
+def _(self):
+    return self.default_progs()


### PR DESCRIPTION
It was disabled in 100dcb6fe4e3e9e253c53f18b4273939ca20a8d8 commit.

Debian and Alpine both provide those programs.
* https://packages.debian.org/sid/amd64/zxing-cpp-tools/filelist
* https://pkgs.alpinelinux.org/contents?name=zxing&repo=community&branch=edge&arch=x86_64