### PR TITLE
user/widle: new package

### DIFF
--- a/user/widle/template.py
+++ b/user/widle/template.py
@@ -1,0 +1,23 @@
+pkgname = "widle"
+pkgver = "1.0"
+pkgrel = 0
+build_style = "makefile"
+hostmakedepends = [
+    "pkgconf",
+    "wayland-progs",
+]
+makedepends = [
+    "wayland-devel",
+    "wayland-protocols",
+]
+pkgdesc = "Run a command upon becoming idle"
+license = "MIT"
+url = "https://codeberg.org/sewn/widle"
+source = f"{url}/archive/{pkgver}.tar.gz"
+sha256 = "729f37e232d0863d33486641ac874c72d005a9e27d226110cc65ddbbe1ef00fa"
+# no test suite
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

`widle(1)` is a program that runs a command when a user has idled. This functionality is useful for screenlocking with a program like `wlock(1)` .

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
