### PR TITLE
user/oniux: new package

### DIFF
--- a/user/oniux/template.py
+++ b/user/oniux/template.py
@@ -1,0 +1,18 @@
+pkgname = "oniux"
+pkgver = "0.7.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable", "cmake", "pkgconf", "rust-bindgen"]
+makedepends = ["openssl3-devel", "rust-std", "sqlite-devel", "zstd-devel"]
+pkgdesc = "Kernel-level Tor isolation for Linux applications"
+license = "MIT OR Apache-2.0"
+url = "https://gitlab.torproject.org/tpo/core/oniux"
+source = f"{url}/-/archive/v{pkgver}/oniux-v{pkgver}.tar.gz"
+sha256 = "e84e9237e16b6f119ef2c02c05f94161fdd903727f9bf6038ccd2418228e8473"
+# no tests
+options = ["!check"]
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/oniux")
+    self.install_license("LICENSE-MIT")

--- a/user/oniux/update.py
+++ b/user/oniux/update.py
@@ -1,0 +1,1 @@
+url = "https://gitlab.torproject.org/tpo/core/oniux/-/tags"


### PR DESCRIPTION
## Description

Oniux is a tool which provides easy to use Tor isolation for any Linux program with namespaces

example:
```
chiruno% curl ipv6.icanhazip.com
curl: (7) Failed to connect to ipv6.icanhazip.com port 80 after 7 ms: Could not connect to server
chiruno% oniux curl ipv6.icanhazip.com
2a0b:f4c0:16c:4::1
```

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
