### PR TITLE
user/libyang: add pkgconf dependency

### DIFF
--- a/user/libyang/template.py
+++ b/user/libyang/template.py
@@ -1,9 +1,9 @@
 pkgname = "libyang"
 pkgver = "2.1.148"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
-hostmakedepends = ["cmake", "ninja"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
 makedepends = ["pcre2-devel"]
 pkgdesc = "YANG data modelling language parser and toolkit"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Without it, libyang.pc is not installed and FRR will not find it

## Description

Basically what commit message says.  I'm working on FRR cport and it needs libyang.pc to find and use it.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
