### PR TITLE
main/cryptsetup-scripts: Directly depend on lvm2-dm-initramfs-tools

### DIFF
--- a/main/cryptsetup-scripts/template.py
+++ b/main/cryptsetup-scripts/template.py
@@ -8,7 +8,7 @@ make_build_args = [
     f"VERSION={pkgver}",
 ]
 hostmakedepends = ["perl", "docbook-xsl-nons", "libxslt-progs"]
-depends = ["cryptsetup", "lvm2-dm", "util-linux-mount", "util-linux-mkfs"]
+depends = ["cryptsetup", "lvm2-dm-initramfs-tools", "util-linux-mount", "util-linux-mkfs"]
 pkgdesc = "Supporting infrastructure for cryptsetup from Debian"
 license = "GPL-2.0-or-later"
 url = "https://salsa.debian.org/cryptsetup-team/cryptsetup"


### PR DESCRIPTION
## Description

This commit adds a requirement on lvm2-dm-initramfs-tools for cryptsetup-scripts.  Normally lvm2-dm-initramfs-tools gets pulled in by an install rule when booth lvm2-dm and initramfs-tools are installed. This causes a problem when installing a new system inside of an chroot, because one needs to run apk upgrade after installing cryptsetup-scripts otherwise the lvm2-dm-initramfs-tools wont get pulled in by apk and the user has a non-booting system.  With this change lvm2-dm-initramfs-tools pulls in lvm2-dm via dependency and the user ends up with the correct set of packages without needing to upgrade the system

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
