### PR TITLE
main/ffmpeg: don't use unversioned libvapoursynth-script.so

### DIFF
--- a/main/ffmpeg/patches/vapoursynth-script.patch
+++ b/main/ffmpeg/patches/vapoursynth-script.patch
@@ -1,0 +1,12 @@
+libvapoursynth-script.so goes in vapoursynth-devel and not the main package
+--- a/libavformat/vapoursynth.c	2025-05-25 02:55:12.995404830 +0100
++++ b/libavformat/vapoursynth.c	2025-05-25 02:55:25.273460968 +0100
+@@ -49,7 +49,7 @@
+ #else
+   #include <dlfcn.h>
+   #define VSSCRIPT_NAME "libvapoursynth-script"
+-  #define VSSCRIPT_LIB VSSCRIPT_NAME SLIBSUF
++  #define VSSCRIPT_LIB VSSCRIPT_NAME SLIBSUF ".0"
+ #endif
+ 
+ struct VSState {

--- a/main/ffmpeg/template.py
+++ b/main/ffmpeg/template.py
@@ -1,6 +1,6 @@
 pkgname = "ffmpeg"
 pkgver = "7.1.1"
-pkgrel = 8
+pkgrel = 9
 build_style = "configure"
 configure_args = [
     "--prefix=/usr",


### PR DESCRIPTION
otherwise using vapoursynth scripts with ffmpeg requires vapoursynth-devel installed

i was initially going to move the unversioned .so from `vapoursynth-devel` to `vapoursynth` but then i thought that fixing this in ffmpeg is maybe a better idea