### PR TITLE
main/mpv: fix high cpu usage when receiving unsupported wayland clipboard offer

### DIFF
--- a/main/mpv/patches/001-fix-wayland-clipboard-high-cpu-usage.patch
+++ b/main/mpv/patches/001-fix-wayland-clipboard-high-cpu-usage.patch
@@ -1,0 +1,29 @@
+From d20ded876d27497d3fe6a9494add8106b507a45c Mon Sep 17 00:00:00 2001
+From: llyyr <llyyr.public@gmail.com>
+Date: Fri, 28 Mar 2025 15:34:33 +0530
+Subject: [PATCH] clipboard-wayland: prevent reading from hung up fd
+
+This causes mpv to use up 100% of a core if there's an offer for a
+mime_type that mpv doesn't accept with ext_data_control clipboard
+backend.
+---
+ player/clipboard/clipboard-wayland.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/player/clipboard/clipboard-wayland.c b/player/clipboard/clipboard-wayland.c
+index c4a5e504724f0..bd8ac35af2da5 100644
+--- a/player/clipboard/clipboard-wayland.c
++++ b/player/clipboard/clipboard-wayland.c
+@@ -348,6 +348,12 @@ static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl,
+     if (fds[1].revents & POLLIN)
+         return false;
+ 
++    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->selection_offer);
++
++    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->primary_selection_offer);
++
+     if (fds[2].revents & POLLIN)
+         get_selection_data(wl, wl->selection_offer, false);
+ 

--- a/main/mpv/patches/002-fix-wayland-clipboard-high-cpu-usage.patch
+++ b/main/mpv/patches/002-fix-wayland-clipboard-high-cpu-usage.patch
@@ -1,0 +1,49 @@
+From 896b3400f3cad286533dbb9cc3658ce18ed9966c Mon Sep 17 00:00:00 2001
+From: nanahi <130121847+na-na-hi@users.noreply.github.com>
+Date: Sun, 13 Apr 2025 08:33:12 -0400
+Subject: [PATCH] clipboard-wayland: read already sent data when the fd is hung
+ up
+
+A "hung up" fd only indicates that the other end of the pipe is closed.
+This can happen when the other client has already sent some data into
+the pipe and closed its end. This should not be treated as an error,
+and reading data should proceed until read() returns 0 or -1.
+
+Premuturely destroying offer in this case breaks getting selection
+data. Change it so that the cleanup on error happens after the selection
+data is read.
+
+Fixes: d20ded876d27497d3fe6a9494add8106b507a45c
+---
+ player/clipboard/clipboard-wayland.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/player/clipboard/clipboard-wayland.c b/player/clipboard/clipboard-wayland.c
+index bd8ac35af2da5..b3da3ff134574 100644
+--- a/player/clipboard/clipboard-wayland.c
++++ b/player/clipboard/clipboard-wayland.c
+@@ -348,18 +348,18 @@ static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl,
+     if (fds[1].revents & POLLIN)
+         return false;
+ 
+-    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
+-        destroy_offer(wl->selection_offer);
+-
+-    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
+-        destroy_offer(wl->primary_selection_offer);
+-
+     if (fds[2].revents & POLLIN)
+         get_selection_data(wl, wl->selection_offer, false);
+ 
+     if (fds[3].revents & POLLIN)
+         get_selection_data(wl, wl->primary_selection_offer, true);
+ 
++    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->selection_offer);
++
++    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
++        destroy_offer(wl->primary_selection_offer);
++
+     wl_display_dispatch_pending(wl->display);
+     return true;
+ }

--- a/main/mpv/template.py
+++ b/main/mpv/template.py
@@ -1,6 +1,6 @@
 pkgname = "mpv"
 pkgver = "0.40.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 configure_args = [
     "-Dlibmpv=true",


### PR DESCRIPTION
## Description

This commit backports a fix for an issue in mpv where a single CPU core could be driven to 100% usage when handling the wayland clipboard — for example, when taking a screenshot in niri.

Related upstream issue: https://github.com/mpv-player/mpv/issues/16139

![image_2025-05-27_13-10-19](https://github.com/user-attachments/assets/ca9492e2-0795-41aa-9aa1-f2eb5d215e80)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
