### PR TITLE
user/diffutils: new package

### DIFF
--- a/user/diffutils/template.py
+++ b/user/diffutils/template.py
@@ -1,0 +1,17 @@
+pkgname = "diffutils"
+pkgver = "3.12"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--program-prefix=g"]
+# broken autoreconf
+configure_gen = []
+hostmakedepends = [
+    "gettext-devel",
+    "texinfo",
+]
+pkgdesc = "Tools for showing differences between files"
+license = "GPL-3.0-or-later"
+url = "https://www.gnu.org/software/diffutils"
+source = f"$(GNU_SITE)/diffutils/diffutils-{pkgver}.tar.xz"
+sha256 = "7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd"
+hardening = ["vis", "cfi"]


### PR DESCRIPTION
## Description

Adds GNU diffutils. I need GNU diff for the test suite of the product I work on for my job. Unfortunately BSD diff and GNU diff have incompatible forms for grouping in regexs `\(`, `\)` for GNU, `(` and `)` for BSD, which we use. So I can't easily avoid the need for GNU diff without breaking things for other colleagues.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
