### PR TITLE
user/nushell: update to 0.105.0

### DIFF
--- a/user/nushell/template.py
+++ b/user/nushell/template.py
@@ -1,5 +1,5 @@
 pkgname = "nushell"
-pkgver = "0.104.1"
+pkgver = "0.105.0"
 pkgrel = 0
 build_style = "cargo"
 make_check_args = [
@@ -20,7 +20,7 @@ pkgdesc = "Shell with a focus on structured data"
 license = "MIT"
 url = "https://www.nushell.sh"
 source = f"https://github.com/nushell/nushell/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "3dafca8bf892f5a2afaac1122a88a7eb7f22a0b62ef901f550173a11d5cbdf6e"
+sha256 = "2c2f4062820602a773682c5b9189d52ddc03793bc2a5d367d88f73c604f290d3"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Release 0.105.0 adds a lot of nice changes. While 0.105.1 is the most update-to-date version, it reverts a version of the coreutils crate to make `cargo install nu` possible, which we don't care about here, obiviously.

https://www.nushell.sh/blog/2025-06-10-nushell_0_105_0.html

https://www.nushell.sh/blog/2025-06-10-nushell_0_105_1.html

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
