### PR TITLE
main/mingw-w64-*: update to 13.0.0

### DIFF
--- a/main/mingw-w64-crt/template.py
+++ b/main/mingw-w64-crt/template.py
@@ -1,6 +1,6 @@
 pkgname = "mingw-w64-crt"
-pkgver = "12.0.0"
-pkgrel = 1
+pkgver = "13.0.0"
+pkgrel = 0
 build_wrksrc = "mingw-w64-crt"
 build_style = "gnu_configure"
 configure_args = ["--disable-dependency-tracking"]
@@ -10,7 +10,7 @@ pkgdesc = "C runtime for Windows development"
 license = "ZPL-2.1"
 url = "https://www.mingw-w64.org"
 source = f"$(SOURCEFORGE_SITE)/mingw-w64/mingw-w64-v{pkgver}.tar.bz2"
-sha256 = "cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
+sha256 = "5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"
 # checks fail
 options = ["empty", "!check", "!lto"]
 
@@ -44,6 +44,7 @@ def configure(self):
                 wrksrc=f"build-{an}",
                 env={
                     "CC": f"clang -target {at}",
+                    "CPP": "",
                     "CFLAGS": "",
                     "LDFLAGS": "",
                 },

--- a/main/mingw-w64-headers/template.py
+++ b/main/mingw-w64-headers/template.py
@@ -1,5 +1,5 @@
 pkgname = "mingw-w64-headers"
-pkgver = "12.0.0"
+pkgver = "13.0.0"
 pkgrel = 0
 build_wrksrc = "mingw-w64-headers"
 build_style = "gnu_configure"
@@ -9,7 +9,7 @@ pkgdesc = "Header files for Windows development"
 license = "ZPL-2.1"
 url = "https://www.mingw-w64.org"
 source = f"$(SOURCEFORGE_SITE)/mingw-w64/mingw-w64-v{pkgver}.tar.bz2"
-sha256 = "cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
+sha256 = "5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"
 options = ["empty"]
 
 _targets = ["x86_64", "i686", "aarch64", "armv7"]

--- a/main/mingw-w64-winpthreads/template.py
+++ b/main/mingw-w64-winpthreads/template.py
@@ -1,6 +1,6 @@
 pkgname = "mingw-w64-winpthreads"
-pkgver = "12.0.0"
-pkgrel = 1
+pkgver = "13.0.0"
+pkgrel = 0
 build_wrksrc = "mingw-w64-libraries/winpthreads"
 build_style = "gnu_configure"
 configure_args = ["--disable-dependency-tracking"]
@@ -11,7 +11,7 @@ pkgdesc = "POSIX threading APIs for Windows development"
 license = "ZPL-2.1"
 url = "https://www.mingw-w64.org"
 source = f"$(SOURCEFORGE_SITE)/mingw-w64/mingw-w64-v{pkgver}.tar.bz2"
-sha256 = "cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
+sha256 = "5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"
 # check requires libunwind
 options = ["empty", "!check", "!lto"]
 


### PR DESCRIPTION
Unset CPP environment variable for mingw-w64-crt to fix the following error.
clang-cpp: error: unsupported option '-mfpu=' for target 'x86_64-chimera-linux-musl'
