### PR TITLE
main/qbittorrent: make service depend on local.target

### DIFF
--- a/main/qbittorrent/files/qbittorrent-nox
+++ b/main/qbittorrent/files/qbittorrent-nox
@@ -1,10 +1,9 @@
-# qbittorrent-nox service
-
 type = process
 command = /usr/bin/qbittorrent-nox
-load-options = export-passwd-vars
 log-type = buffer
 # qbittorrent usually can open a few thousand files depending on seeding
 rlimit-nofile = 10000
 run-as = _qbittorrent
 working-dir = /var/lib/qbittorrent
+depends-on: local.target
+load-options: export-passwd-vars

--- a/main/qbittorrent/template.py
+++ b/main/qbittorrent/template.py
@@ -1,6 +1,6 @@
 pkgname = "qbittorrent"
 pkgver = "5.1.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "cmake"
 configure_args = ["-DSTACKTRACE=OFF"]
 hostmakedepends = [


### PR DESCRIPTION
was giving me problems on boot
```
******** Information ********
Unable to bind to IP: ::1, port: 8090. Reason: The address is not available
To fix the error, you may need to edit the config file manually.
```