### PR TITLE
main/abseil-cpp: fix OOM in tests on 32-bit targets

### DIFF
--- a/main/abseil-cpp/patches/oom-test-fix-1.patch
+++ b/main/abseil-cpp/patches/oom-test-fix-1.patch
@@ -1,0 +1,37 @@
+From be5661825b1172d55c190a087ceb8907187d523a Mon Sep 17 00:00:00 2001
+From: Ben Beasley <code@musicinmybrain.net>
+Date: Thu, 15 May 2025 08:14:53 -0700
+Subject: [PATCH] PR #1888: Adjust Table.GrowExtremelyLargeTable to avoid OOM
+ on i386
+
+Imported from GitHub PR https://github.com/abseil/abseil-cpp/pull/1888
+
+While this only covers `i386`/`i686`, which is the motivation for this PR, this test can be expected to OOM on any 32-bit platform. For now, this is the minimal change that avoids the problem [in the Fedora package](https://src.fedoraproject.org/rpms/abseil-cpp/).
+
+This fixes one of the two test failures reported in https://github.com/abseil/abseil-cpp/issues/1887.
+Merge 395acb74da05fa35d924059a170ebd8267356b65 into f28774a28227c4e30041616bff4aa0120ed724c0
+
+Merging this change closes #1888
+
+COPYBARA_INTEGRATE_REVIEW=https://github.com/abseil/abseil-cpp/pull/1888 from musicinmybrain:extremely-large-table-32-bit 395acb74da05fa35d924059a170ebd8267356b65
+PiperOrigin-RevId: 759154889
+Change-Id: I0a105fc42c51898c277b4a056ccd6599b43e1a50
+---
+ absl/container/internal/raw_hash_set_test.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/absl/container/internal/raw_hash_set_test.cc b/absl/container/internal/raw_hash_set_test.cc
+index a5cbd44d3b2..2c55d0fc079 100644
+--- a/absl/container/internal/raw_hash_set_test.cc
++++ b/absl/container/internal/raw_hash_set_test.cc
+@@ -4267,8 +4267,8 @@ struct ConstUint8Hash {
+ // 5. Finally we will catch up and go to overflow codepath.
+ TEST(Table, GrowExtremelyLargeTable) {
+   constexpr size_t kTargetCapacity =
+-#if defined(__wasm__) || defined(__asmjs__)
+-      NextCapacity(ProbedItem4Bytes::kMaxNewCapacity);  // OOMs on WASM.
++#if defined(__wasm__) || defined(__asmjs__) || defined(__i386__)
++      NextCapacity(ProbedItem4Bytes::kMaxNewCapacity);  // OOMs on WASM, 32-bit.
+ #else
+       NextCapacity(ProbedItem8Bytes::kMaxNewCapacity);
+ #endif

--- a/main/abseil-cpp/patches/oom-test-fix-2.patch
+++ b/main/abseil-cpp/patches/oom-test-fix-2.patch
@@ -1,0 +1,26 @@
+From df5a2c7e0b00cf0cc01b4ffd44fa65bb5e657a27 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Sat, 21 Jun 2025 02:35:06 +0200
+Subject: [PATCH] Adjust Table.GrowExtremelyLargeTable to avoid OOM on ARMv7
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ absl/container/internal/raw_hash_set_test.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/absl/container/internal/raw_hash_set_test.cc b/absl/container/internal/raw_hash_set_test.cc
+index e1dafff3..3946c5e1 100644
+--- a/absl/container/internal/raw_hash_set_test.cc
++++ b/absl/container/internal/raw_hash_set_test.cc
+@@ -4043,7 +4043,7 @@ struct ConstUint8Hash {
+ // 5. Finally we will catch up and go to overflow codepath.
+ TEST(Table, GrowExtremelyLargeTable) {
+   constexpr size_t kTargetCapacity =
+-#if defined(__wasm__) || defined(__asmjs__) || defined(__i386__)
++#if defined(__wasm__) || defined(__asmjs__) || defined(__i386__) || defined(__arm__)
+       NextCapacity(ProbedItem4Bytes::kMaxNewCapacity);  // OOMs on WASM, 32-bit.
+ #else
+       NextCapacity(ProbedItem8Bytes::kMaxNewCapacity);
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

First patch is a backport so that the second patch applies cleanly when abseil is upgraded in the future.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
