### PR TITLE
user/gdu: disable checks on 32-bit targets

### DIFF
--- a/user/gdu/template.py
+++ b/user/gdu/template.py
@@ -11,6 +11,12 @@ license = "MIT"
 url = "https://github.com/dundee/gdu"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "ad363967b6a34e02812e4cba36bb340f377cf64a435e23f6e8e9e6b3f775220e"
+# check may be disabled
+options = []
+
+# err: while opening file: /tmp/badger/000003.vlog err: cannot allocate memory
+if self.profile().wordsize == 32:
+    options += ["!check"]
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

gdu's testsuite fails with "cannot allocate memory" on all 32-bit targets due to an issue in a dependency that cannot trivially be upgraded.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
