### PR TITLE
main/rust: fix bootstrapping with 1.87

### DIFF
--- a/main/rust/template.py
+++ b/main/rust/template.py
@@ -155,13 +155,13 @@ def configure(self):
             f.write(
                 """
 #[link(name = "ffi")]
-extern {}
+unsafe extern "C" {}
 #[link(name = "z")]
-extern {}
+unsafe extern "C" {}
 #[link(name = "zstd")]
-extern {}
+unsafe extern "C" {}
 #[link(name = "ncursesw")]
-extern {}
+unsafe extern "C" {}
 """
             )
 


### PR DESCRIPTION
## Description

Edition 2024 prohibits extern blocks without unsafe.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
