### PR TITLE
user/selene: fix crash on 32-bit targets

### DIFF
--- a/user/selene/template.py
+++ b/user/selene/template.py
@@ -1,6 +1,6 @@
 pkgname = "selene"
 pkgver = "0.28.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 prepare_after_patch = True
 hostmakedepends = ["cargo-auditable"]
@@ -10,6 +10,20 @@ license = "MPL-2.0"
 url = "https://github.com/Kampfkarren/selene"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
 sha256 = "c51acf52e7c3136cd0b67b9a39a4a447c8f0257371b2b2acc7e77587260a377b"
+
+
+def pre_prepare(self):
+    # unsafe-libyaml 0.2.5 does not have the fix for
+    # https://github.com/dtolnay/unsafe-libyaml/issues/21 yet
+    self.do(
+        "cargo",
+        "update",
+        "--package",
+        "unsafe-libyaml",
+        "--precise",
+        "0.2.10",
+        allow_network=True,
+    )
 
 
 def install(self):


### PR DESCRIPTION
## Description

Otherwise we would see

```
thread 'validate_config::tests::validate_config_tests' panicked at /usr/lib/rustlib/src/rust/library/core/src/panicking.rs:218:5:
unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap

This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
```

in tests and probably any invocation.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
