### PR TITLE
main/firefox: make it compile on ARMv7

### DIFF
--- a/main/firefox/template.py
+++ b/main/firefox/template.py
@@ -169,6 +169,12 @@ def configure(self):
             pass
         case "loongarch64":
             conf_opts += ["--disable-crashreporter"]
+        case "armv7":
+            conf_opts += [
+                "--disable-crashreporter",
+                "--disable-debug",
+                "--disable-debug-symbols",
+            ]
 
     if self.has_lto():
         conf_opts += ["--enable-lto=cross"]


### PR DESCRIPTION
## Description

Crashreporter fails to compile just like loongarch64, debug info needs to be disabled entirely to not OOM during linking.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
