### PR TITLE
main/gnome-keyring: disable checks on 32-bit targets

### DIFF
--- a/main/gnome-keyring/template.py
+++ b/main/gnome-keyring/template.py
@@ -42,3 +42,9 @@ source = (
     f"$(GNOME_SITE)/gnome-keyring/{pkgver[:-2]}/gnome-keyring-{pkgver}.tar.xz"
 )
 sha256 = "f20518c920e9ea3f9c9b8b44be8c50d8d7feecd0dd5624960f77bd2ca4fbeb9d"
+# check may be disabled
+options = []
+
+if self.profile().wordsize == 32:
+    # 32-bit targets fail 2 tests: https://gitlab.gnome.org/GNOME/gnome-keyring/-/issues/124
+    options += ["!check"]


### PR DESCRIPTION
## Description

See the linked issue for more information.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
