### PR TITLE
user/agate: update to 3.3.17

### DIFF
--- a/user/agate/files/sysusers.conf
+++ b/user/agate/files/sysusers.conf
@@ -1,0 +1,3 @@
+# create agate user
+
+u _agate - "agate gemini user" /var/lib/agate

--- a/user/agate/files/tmpfiles.conf
+++ b/user/agate/files/tmpfiles.conf
@@ -1,0 +1,3 @@
+# create agate state directories
+
+d /var/lib/agate 0750 _agate _agate

--- a/user/agate/template.py
+++ b/user/agate/template.py
@@ -1,5 +1,5 @@
 pkgname = "agate"
-pkgver = "3.3.16"
+pkgver = "3.3.17"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "pkgconf"]
@@ -9,9 +9,11 @@ pkgdesc = "Server for the Gemini Protocol"
 license = "Apache-2.0 OR MIT"
 url = "https://github.com/mbrubeck/agate"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "943a77d2416871b663264e079925806afd3b1109df43523b6da8f60e89afa27b"
+sha256 = "51d9eb747adfa125d1b19db4e94e235455524547961cdbfbac19f32943e454ff"
 
 
 def install(self):
     self.install_bin(f"target/{self.profile().triplet}/release/agate")
+    self.install_tmpfiles("^/tmpfiles.conf")
+    self.install_sysusers("^/sysusers.conf")
     self.install_license("LICENSE-MIT")


### PR DESCRIPTION
## Description

updated agate to 3.3.17

added sysusers.conf and tmpfiles.conf for the agate service

a dinit service file was not added because agate needs some user defined state (hostname, a content directory) to get started

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine