### PR TITLE
main/sddm: fix build with CMake 4.0

### DIFF
--- a/main/sddm/patches/cmake-version.patch
+++ b/main/sddm/patches/cmake-version.patch
@@ -1,0 +1,22 @@
+From 228778c2b4b7e26db1e1d69fe484ed75c5791c3a Mon Sep 17 00:00:00 2001
+From: Heiko Becker <heiko.becker@kde.org>
+Date: Sun, 23 Feb 2025 22:21:25 +0100
+Subject: [PATCH] CMake: Raise required version to 3.5
+
+CMake >= 4.0.0-rc1 removed compatibility with versions < 3.5 and errors
+out with such versions passed to cmake_minimum_required(). 3.5.0 has
+been released 9 years ago, so I'd assume it's available almost everywhere.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 690ee7095..1b5f54af5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(SDDM)
+ 


### PR DESCRIPTION
## Description

Currently fails to build due to CMake 4.0 dropping compatibility with versions older than 3.5.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
