### PR TITLE
main/fluidsynth: enable alsa support

### DIFF
--- a/main/fluidsynth/template.py
+++ b/main/fluidsynth/template.py
@@ -1,6 +1,6 @@
 pkgname = "fluidsynth"
 pkgver = "2.4.6"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DLIB_SUFFIX=",
@@ -9,6 +9,7 @@ configure_args = [
 make_check_target = "check"
 hostmakedepends = ["cmake", "ninja", "pkgconf"]
 makedepends = [
+    "alsa-lib-devel",
     "dbus-devel",
     "glib-devel",
     "pipewire-devel",


### PR DESCRIPTION
## Description

Add ALSA makedepend to enable alsa_seq midi driver support. 

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
