### PR TITLE
user/vis: new package

### DIFF
--- a/user/lua5.5-lpeg/patches
+++ b/user/lua5.5-lpeg/patches
@@ -1,0 +1,1 @@
+../../main/lua5.1-lpeg/patches

--- a/user/lua5.5-lpeg/template.py
+++ b/user/lua5.5-lpeg/template.py
@@ -1,0 +1,29 @@
+pkgname = "lua5.5-lpeg"
+pkgver = "1.1.0"
+pkgrel = 0
+build_style = "makefile"
+make_build_target = "lpeg.so"
+make_check_target = "test"
+makedepends = ["lua5.5-devel"]
+pkgdesc = "Pattern-matching library based on Parsing Expression Grammars"
+license = "MIT"
+url = "https://www.inf.puc-rio.br/~roberto/lpeg"
+source = f"{url}/lpeg-{pkgver}.tar.gz"
+sha256 = "4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a"
+# for check
+exec_wrappers = [("/usr/bin/lua5.5", "lua")]
+
+
+def init_configure(self):
+    self.tool_flags["CFLAGS"] += [
+        f"-I{self.profile().sysroot / 'usr/include/lua5.5'}",
+        "-fPIC",
+    ]
+
+
+def install(self):
+    self.install_license("lpeg.html")
+    self.install_dir("usr/lib/lua/5.5")
+    self.install_file("lpeg.so", "usr/lib/lua/5.5", mode=0o755)
+    self.install_dir("usr/share/lua/5.5")
+    self.install_file("re.lua", "usr/share/lua/5.5")

--- a/user/lua5.5-lpeg/update.py
+++ b/user/lua5.5-lpeg/update.py
@@ -1,0 +1,1 @@
+../../main/lua5.1-lpeg/update.py

--- a/user/vis/template.py
+++ b/user/vis/template.py
@@ -1,0 +1,31 @@
+pkgname = "vis"
+pkgver = "0.9_git20260726"
+_gitrev = "aa99d1775c1faf2446bc294bc4072ccb661d7cd6"
+pkgrel = 0
+build_style = "configure"
+configure_args = ["--prefix=/usr"]
+make_check_target = "test"
+hostmakedepends = ["pkgconf"]
+makedepends = [
+    "acl-devel",
+    "lua5.5-devel",
+    "lua5.5-lpeg",
+    "ncurses-devel",
+]
+checkdepends = ["vim"]
+depends = ["lua5.5-lpeg"]
+pkgdesc = "Modern, legacy-free, simple yet efficient vim-like text editor"
+license = "ISC"
+url = "https://github.com/martanne/vis"
+source = f"https://github.com/martanne/vis/archive/{_gitrev}.tar.gz"
+sha256 = "d70bd1058e97b4f1ff61fcace50376d44dadc9c04a1b0f5d622384e6e38e6d88"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+    self.mv(self.destdir / "usr/bin/vis", self.destdir / "usr/bin/vis-editor")
+    self.mv(
+        self.destdir / "usr/share/man/man1/vis.1",
+        self.destdir / "usr/share/man/man1/vis-editor.1",
+    )


### PR DESCRIPTION
I ended up packaging this without realizing #3328 already existed. Oops. But there are a few notable differences to this attempt:

- Release 0.9 is packaged, instead of a (newer) git snapshot.
- The editor binary is named `vis-editor` instead of `vise`, following the [upstream recommendation](https://github.com/martanne/vis/issues/338#issuecomment-1666053166).
- `libtermkey` is vendored. @sewnie started a [discussion](https://github.com/martanne/vis/pull/1241) to try and vendor it upstream, so this should not be necessary once that is merged. The patch I wrote is kinda ugly, so it would be nice to get rid of it.

I hesitated before creating this redundant pull request, but since releases set up the testing very differently from the git snapshots (the `test/` subdirectory is a separate repo, which is not included in the release tarball) I thought it might be worth sharing this version, since it was mostly done anyway.

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
- [X] I am willing to take responsibility for my template and keep it up to date
