### PR TITLE
cbuild: Make it easier to troubleshoot patch failures

### DIFF
--- a/src/cbuild/util/patch.py
+++ b/src/cbuild/util/patch.py
@@ -1,4 +1,4 @@
-from cbuild.core import chroot
+from cbuild.core import chroot, paths
 
 import shutil
 import pathlib
@@ -111,10 +111,14 @@ def patch_git(pkg, patch_list, wrksrc=None, apply_args=[], stamp=False):
 
     def _apply(p):
         if subprocess.run([*srcmd, p], cwd=pkg.srcdir).returncode != 0:
+            pkg.log(f"failed to apply '{p.name}', repeating in verbose mode")
+            subprocess.run([*srcmd, "--verbose", p], cwd=pkg.srcdir)
             pkg.error(f"failed to apply '{p.name}'")
 
+    relative_srcdir_path = pkg.srcdir.resolve().relative_to(paths.distdir())
+
     for p in patch_list:
-        pkg.log(f"patching: {p.name}")
+        pkg.log(f"patching {relative_srcdir_path}: {p.name}")
         if stamp:
             with pkg.stamp(f"patch_{p.name}") as s:
                 s.check()


### PR DESCRIPTION
## Description

In order to make troubleshooting patch failures easier, this PR adds the following:

* The path of each package's extracted source relative to the `cports` repo is now printed
  * This makes it easier to go and look at the exact source that's being patched (maybe another patch that's already been applied is causing the problem)
* If a patch fails, the patch is reapplied with the `--verbose` flag so that you can actually see why it's failing

Side note, is it worth considering removing support for `patch_style=patch` now that it's been like 9 months since https://github.com/chimera-linux/cports/commit/579ff9d26f750a3b6293090db8aacc5bacae4702?

Before:
```
0:00:14.226 => starship-1.23.0-r0: patching: atomic64.patch
error: patch failed: vendor/zvariant/src/type/libstd.rs:8
error: vendor/zvariant/src/type/libstd.rs: patch does not apply
0:00:14.238 => starship-1.23.0-r0: ERROR: failed to apply 'atomic64.patch'
```

After:
```
0:00:13.570 => starship-1.23.0-r0: patching bldroot/builddir/starship-1.23.0: atomic64.patch
error: patch failed: vendor/zvariant/src/type/libstd.rs:8
error: vendor/zvariant/src/type/libstd.rs: patch does not apply
0:00:13.573 => starship-1.23.0-r0: failed to apply 'atomic64.patch', repeating in verbose mode
Checking patch vendor/zvariant/src/type/libstd.rs...
error: while searching for:
    rc::{Rc, Weak as RcWeak},
    sync::{
        atomic::{
            AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16,
            AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
        },
        Arc, Mutex, RwLock, Weak as ArcWeak,
    },
    time::Duration,
};

impl<T> Type for PhantomData<T>
where
    T: Type + ?Sized,xxxxxxxxxxxxxxxxxxxxxxxxxxxx

error: patch failed: vendor/zvariant/src/type/libstd.rs:8
error: vendor/zvariant/src/type/libstd.rs: patch does not apply
0:00:13.577 => starship-1.23.0-r0: ERROR: failed to apply 'atomic64.patch'
```

## Checklist

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

