### PR TITLE
user/nushell: Update to 0.106.1, add core plugins as subpackages

### DIFF
--- a/user/nushell-plugin-formats
+++ b/user/nushell-plugin-formats
@@ -1,0 +1,1 @@
+nushell

--- a/user/nushell-plugin-gstat
+++ b/user/nushell-plugin-gstat
@@ -1,0 +1,1 @@
+nushell

--- a/user/nushell-plugin-inc
+++ b/user/nushell-plugin-inc
@@ -1,0 +1,1 @@
+nushell

--- a/user/nushell-plugin-polars
+++ b/user/nushell-plugin-polars
@@ -1,0 +1,1 @@
+nushell

--- a/user/nushell-plugin-query
+++ b/user/nushell-plugin-query
@@ -1,0 +1,1 @@
+nushell

--- a/user/nushell/template.py
+++ b/user/nushell/template.py
@@ -1,5 +1,5 @@
 pkgname = "nushell"
-pkgver = "0.105.1"
+pkgver = "0.106.1"
 pkgrel = 0
 build_style = "cargo"
 make_build_args = [
@@ -9,8 +9,6 @@ make_build_args = [
 make_install_args = [*make_build_args]
 make_check_args = [
     "--",
-    "--skip=shell::environment::env::env_shlvl_in_exec_repl",
-    "--skip=shell::environment::env::env_shlvl_in_repl",
     "--skip=shell::environment::env::path_is_a_list_in_repl",
 ]
 hostmakedepends = ["cargo-auditable", "pkgconf"]
@@ -25,8 +23,7 @@ pkgdesc = "Shell with a focus on structured data"
 license = "MIT"
 url = "https://www.nushell.sh"
 source = f"https://github.com/nushell/nushell/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "2c52ef5aef2ba1a3ae873e84bf72b52220f47c8fe47b99950b791e678a43d597"
-
+sha256 = "3e24044c354d050a850b69dc77c99cc503542c3d9d75fed0aef1c12fefdf380b"
 
 def post_install(self):
     self.install_shell("/usr/bin/nu")

--- a/user/nushell/template.py
+++ b/user/nushell/template.py
@@ -1,12 +1,15 @@
 pkgname = "nushell"
 pkgver = "0.106.1"
-pkgrel = 0
+pkgrel = 2
 build_style = "cargo"
-make_build_args = [
+_features_args = [
     "--no-default-features",
     "--features=plugin,trash-support,sqlite,native-tls",
 ]
-make_install_args = [*make_build_args]
+make_build_args = [
+    *_features_args,
+    "--workspace",
+]
 make_check_args = [
     "--",
     "--skip=shell::environment::env::path_is_a_list_in_repl",
@@ -24,7 +27,42 @@ license = "MIT"
 url = "https://www.nushell.sh"
 source = f"https://github.com/nushell/nushell/archive/refs/tags/{pkgver}.tar.gz"
 sha256 = "3e24044c354d050a850b69dc77c99cc503542c3d9d75fed0aef1c12fefdf380b"
+_plugins = [
+    "polars",
+    "formats",
+    "gstat",
+    "query",
+    "inc",
+]
+
+
+def install(self):
+    self.cargo.install(args=[*_features_args])
+    nu_autoload_path = "usr/share/nushell/vendor/autoload"
+    self.install_dir(nu_autoload_path)
+    for _plugin in _plugins:
+        self.cargo.install(wrksrc=f"crates/nu_plugin_{_plugin}")
+        with open(
+            self.destdir / nu_autoload_path / f"enable_plugin_{_plugin}.nu", "w"
+        ) as ofile:
+            ofile.write(f"plugin add /usr/bin/nu_plugin_{_plugin}\n")
+
 
 def post_install(self):
     self.install_shell("/usr/bin/nu")
     self.install_license("LICENSE")
+
+
+def _genmod(pname):
+    @subpackage(f"nushell-plugin-{pname}")
+    def _(self):
+        self.subdesc = f"{pname} plugin"
+        self.install_if = [self.parent]
+        return [
+            f"usr/bin/nu_plugin_{pname}",
+            f"usr/share/nushell/vendor/autoload/enable_plugin_{pname}.nu",
+        ]
+
+
+for _plugin in _plugins:
+    _genmod(_plugin)


### PR DESCRIPTION
## Description

Updates nushell to 0.106.1, and builds the [core plugins](https://www.nushell.sh/book/plugins.html#core-plugins) as subpackages. All of the subpackages are installed with the main `nushell` package by default, and include nushell scripts that will automatically [register the appropriate plugin](https://www.nushell.sh/book/plugins.html#registering-plugins).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
