### PR TITLE
main/libinput: Fix tests on 32-bit targets

### DIFF
--- a/main/libinput/patches/atou64-fix.patch
+++ b/main/libinput/patches/atou64-fix.patch
@@ -1,0 +1,30 @@
+From 931dad76a90c46036374196c617ca6aca0d27fe9 Mon Sep 17 00:00:00 2001
+From: Adam Sampson <ats@offog.org>
+Date: Fri, 1 Aug 2025 13:11:50 +0100
+Subject: [PATCH] test: correct value type in atou64_test
+
+This needs to be an unsigned 64-bit value, given the constants that are
+stored in this field below; unsigned long is 32 bits on some platforms
+(e.g. ia32).
+
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1288>
+---
+ test/test-utils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test-utils.c b/test/test-utils.c
+index 55a2e156..7c938b0a 100644
+--- a/test/test-utils.c
++++ b/test/test-utils.c
+@@ -1445,7 +1445,7 @@ END_TEST
+ struct atou64_test {
+ 	char *str;
+ 	bool success;
+-	unsigned long val;
++	uint64_t val;
+ };
+ 
+ START_TEST(safe_atou64_test)
+-- 
+GitLab
+

--- a/main/libinput/patches/duplicate-sizeof.patch
+++ b/main/libinput/patches/duplicate-sizeof.patch
@@ -1,0 +1,32 @@
+From 47d4c563f4eacc9557904c3bf9bccfce519581b0 Mon Sep 17 00:00:00 2001
+From: Adam Sampson <ats@offog.org>
+Date: Fri, 1 Aug 2025 14:50:36 +0100
+Subject: [PATCH] evdev: remove duplicate sizeof
+
+This looks like a copy-and-paste error. In practice it was harmless on
+64-bit systems because evdev_event happens to be 64 bits long, but on
+32-bit systems it would allocate too little memory.
+
+Found by GCC 15 with _FORTIFY_SOURCE=3 on ia32.
+
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1288>
+---
+ src/evdev-frame.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/evdev-frame.h b/src/evdev-frame.h
+index 965dbc24..ccf6f385 100644
+--- a/src/evdev-frame.h
++++ b/src/evdev-frame.h
+@@ -509,7 +509,7 @@ static inline struct evdev_frame *
+ evdev_frame_new(size_t max_size)
+ {
+ 	struct evdev_frame *frame =
+-		zalloc(max_size * sizeof(sizeof(*frame->events)) + sizeof(*frame));
++		zalloc(max_size * sizeof(*frame->events) + sizeof(*frame));
+ 
+ 	frame->refcount = 1;
+ 	frame->max_size = max_size;
+-- 
+GitLab
+

--- a/main/libinput/patches/litest-constants-32bit.patch
+++ b/main/libinput/patches/litest-constants-32bit.patch
@@ -1,0 +1,49 @@
+From 4a9027ede5df8ea68d4af9494e40a3a7608076b8 Mon Sep 17 00:00:00 2001
+From: Jens Reidel <adrian@travitia.xyz>
+Date: Tue, 5 Aug 2025 04:31:48 +0200
+Subject: [PATCH] Fix LITEST_* constants on 32-bit targets
+
+Prior to this change, the constants were defined to be 32-bit on 32-bit
+targets, but the test suite treated them as 64-bit, resulting in a
+couple of asserts being triggered because e.g. the value of
+LITEST_DEVICELESS was not in fact -2 as an int64_t.
+
+Signed-off-by: Jens Reidel <adrian@travitia.xyz>
+---
+ src/util-bits.h | 2 +-
+ test/litest.h   | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/util-bits.h b/src/util-bits.h
+index c0c39ce8..f8d1c447 100644
+--- a/src/util-bits.h
++++ b/src/util-bits.h
+@@ -33,7 +33,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+-#define bit(x_) (1UL << (x_))
++#define bit(x_) (1ULL << (x_))
+ #define NBITS(b) (b * 8)
+ #define LONG_BITS (sizeof(long) * 8)
+ #define NLONGS(x) (((x) + LONG_BITS - 1) / LONG_BITS)
+diff --git a/test/litest.h b/test/litest.h
+index 4b310146..6aabe6bf 100644
+--- a/test/litest.h
++++ b/test/litest.h
+@@ -532,9 +532,9 @@ enum litest_device_type {
+ 	LITEST_WALTOP,
+ };
+ 
+-#define LITEST_DEVICELESS	-2
+-#define LITEST_DISABLE_DEVICE	-1
+-#define LITEST_ANY		0
++#define LITEST_DEVICELESS	(-2LL)
++#define LITEST_DISABLE_DEVICE	(-1LL)
++#define LITEST_ANY		(0LL)
+ #define LITEST_TOUCHPAD		bit(0)
+ #define LITEST_CLICKPAD		bit(1)
+ #define LITEST_BUTTON		bit(2)
+-- 
+2.50.1
+

--- a/main/libinput/template.py
+++ b/main/libinput/template.py
@@ -1,6 +1,6 @@
 pkgname = "libinput"
 pkgver = "1.29.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "--libexecdir=/usr/lib",  # XXX drop libexec


### PR DESCRIPTION
## Description

Fixes all test failures on ARMv7. Two patches are cherry-picked from upstream, one is mine that I cannot submit upstream because freedesktop.org is I guess too restrictive about my account age (?).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
