### PR TITLE
user/keychain: new package

### DIFF
--- a/user/keychain/template.py
+++ b/user/keychain/template.py
@@ -1,0 +1,18 @@
+pkgname = "keychain"
+pkgver = "2.9.8"
+pkgrel = 0
+build_style = "makefile"
+hostmakedepends = ["perl"]
+pkgdesc = "Manager for ssh-agent and gpg-agent"
+license = "GPL-2.0-or-later"
+url = "https://github.com/funtoo/keychain"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "589cf55ae5c4b65af1d977d705beb319006efca5bcdda8352b8558d0dcff5a84"
+# no tests
+options = ["!check"]
+
+
+def install(self):
+    self.make.build()
+    self.install_bin("keychain")
+    self.install_man("keychain.1")


### PR DESCRIPTION
## Description

> Keychain is a frontend to ssh-agent and ssh-add, allowing long running sessions and letting the user enter passphases just once. It can also be used to allow scripts access to SSH connections. 

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
