### PR TITLE
main/initramfs-tools: update to 0.150

### DIFF
--- a/main/initramfs-tools/patches/0002-remove-remaining-dpkg-references.patch
+++ b/main/initramfs-tools/patches/0002-remove-remaining-dpkg-references.patch
@@ -1,12 +1,12 @@
-From 38b954a7a059c81ca74b16f0c700f0952a1e7a02 Mon Sep 17 00:00:00 2001
+From 2559c857971fa6e2097042305ab65da90c82e63d Mon Sep 17 00:00:00 2001
 From: q66 <q66@chimera-linux.org>
 Date: Tue, 22 Apr 2025 15:56:28 +0200
 Subject: [PATCH 2/8] remove remaining dpkg references
 
 ---
  mkinitramfs      |  2 +-
- update-initramfs | 15 ++-------------
- 2 files changed, 3 insertions(+), 14 deletions(-)
+ update-initramfs | 11 ++---------
+ 2 files changed, 3 insertions(+), 10 deletions(-)
 
 diff --git a/mkinitramfs b/mkinitramfs
 index 774ef68..5c850a1 100755
@@ -22,14 +22,14 @@ index 774ef68..5c850a1 100755
  			echo "W: $1 is a directory instead of file" >&2
  		else
 diff --git a/update-initramfs b/update-initramfs
-index ff8286d..30131e0 100755
+index 25a3051..0fb08ea 100755
 --- a/update-initramfs
 +++ b/update-initramfs
-@@ -11,13 +11,6 @@ set -e
+@@ -17,13 +17,6 @@ backup_initramfs=no
  
  [ -r ${CONF} ] && . ${CONF}
  
--if [ -n "$DPKG_MAINTSCRIPT_PACKAGE" ] && [ $# = 1 ] && [ "$1" = -u ]; then
+-if [ -n "${DPKG_MAINTSCRIPT_PACKAGE-}" ] && [ $# = 1 ] && [ "$1" = -u ]; then
 -	if dpkg-trigger --no-await update-initramfs; then
 -		echo "update-initramfs: deferring update (trigger activated)"
 -		exit 0
@@ -39,7 +39,7 @@ index ff8286d..30131e0 100755
  usage()
  {
  	cat << EOF
-@@ -83,7 +72,7 @@ set_initramfs()
+@@ -85,7 +78,7 @@ set_initramfs()
  backup_initramfs()
  {
  	[ ! -r "${initramfs}" ] && return 0
@@ -48,7 +48,7 @@ index ff8286d..30131e0 100755
  	[ -r "${initramfs_bak}" ] && rm -f "${initramfs_bak}"
  	ln -f "${initramfs}" "${initramfs_bak}" 2>/dev/null \
  		|| cp -a "${initramfs}" "${initramfs_bak}"
-@@ -93,7 +82,7 @@ backup_initramfs()
+@@ -95,7 +88,7 @@ backup_initramfs()
  # keep booted initramfs
  backup_booted_initramfs()
  {
@@ -58,5 +58,5 @@ index ff8286d..30131e0 100755
  	# first time run thus no backup
  	[ ! -r "${initramfs_bak}" ] && return 0
 -- 
-2.49.0
+2.50.1
 

--- a/main/initramfs-tools/patches/0004-enforce-strictly-usrmerged-layout.patch
+++ b/main/initramfs-tools/patches/0004-enforce-strictly-usrmerged-layout.patch
@@ -1,22 +1,23 @@
-From 2a474e6994a9ce056c4214d60be69ec18862f4e2 Mon Sep 17 00:00:00 2001
+From 06042b9ced9bebe201b0e51825b5e7f376200210 Mon Sep 17 00:00:00 2001
 From: q66 <q66@chimera-linux.org>
 Date: Tue, 22 Apr 2025 16:03:27 +0200
 Subject: [PATCH 4/8] enforce strictly usrmerged layout
 
 ---
- docs/framebuffer                 |  6 +++---
- hooks/fsck                       |  8 ++++----
- hooks/keymap                     |  2 +-
- init                             | 15 ++++-----------
- initramfs-tools.7                | 12 ++++++------
- mkinitramfs                      | 24 +++++++++++++++---------
- scripts/functions                |  6 +++---
- scripts/init-top/all_generic_ide |  4 ++--
- scripts/init-top/keymap          |  4 ++--
- scripts/local                    |  2 +-
- scripts/local-premount/resume    |  4 ++--
- scripts/nfs                      |  4 ++--
- 12 files changed, 45 insertions(+), 46 deletions(-)
+ docs/framebuffer                    |  6 +++---
+ hooks/fsck                          |  8 ++++----
+ hooks/keymap                        |  2 +-
+ init                                | 15 ++++-----------
+ initramfs-tools.7                   | 12 ++++++------
+ mkinitramfs                         | 24 +++++++++++++++---------
+ scripts/functions                   |  8 ++++----
+ scripts/init-top/all_generic_ide    |  4 ++--
+ scripts/init-top/keymap             |  4 ++--
+ scripts/init-top/simple-framebuffer |  2 +-
+ scripts/local                       |  2 +-
+ scripts/local-premount/resume       |  4 ++--
+ scripts/nfs                         |  4 ++--
+ 13 files changed, 47 insertions(+), 48 deletions(-)
 
 diff --git a/docs/framebuffer b/docs/framebuffer
 index 453ac8f..5c75e23 100644
@@ -237,10 +238,10 @@ index ba181ba..2102d1d 100755
  for file in /etc/modprobe.d/*.conf /lib/modprobe.d/*.conf ; do
  	if test -e "$file" || test -L "$file" ; then
 diff --git a/scripts/functions b/scripts/functions
-index ef009e2..799f15a 100644
+index 1e8b26f..fee0cb4 100644
 --- a/scripts/functions
 +++ b/scripts/functions
-@@ -100,13 +100,13 @@ maybe_break()
+@@ -100,14 +100,14 @@ maybe_break()
  			else
  				opts="-v"
  			fi
@@ -248,6 +249,8 @@ index ef009e2..799f15a 100644
 +			/usr/bin/modprobe ${opts} -a i8042 atkbd ehci-pci ehci-orion \
  				 ehci-hcd ohci-hcd ohci-pci uhci-hcd usbhid xhci \
  				 xhci-pci xhci-hcd
+-			/sbin/modprobe ${opts} -a simpledrm simplefb framebuffer_coreboot
++			/usr/bin/modprobe ${opts} -a simpledrm simplefb framebuffer_coreboot
  			sleep 2
  			for modalias in /sys/bus/hid/devices/*/modalias; do
  				if [ -f "${modalias}" ]; then
@@ -256,7 +259,7 @@ index ef009e2..799f15a 100644
  				fi
  			done
  		fi
-@@ -140,7 +140,7 @@ load_modules()
+@@ -141,7 +141,7 @@ load_modules()
  				continue
  			fi
  			# shellcheck disable=SC2086
@@ -296,6 +299,16 @@ index 1c6b2dc..160cb61 100755
 +if [ -x /usr/bin/setupcon ]; then
 +	/usr/bin/setupcon
  fi
+diff --git a/scripts/init-top/simple-framebuffer b/scripts/init-top/simple-framebuffer
+index 2ffbe97..06c6c11 100755
+--- a/scripts/init-top/simple-framebuffer
++++ b/scripts/init-top/simple-framebuffer
+@@ -17,4 +17,4 @@ esac
+ 
+ # These sometimes don't get probed automatically, but we need them
+ # for efifb etc. when SYSFB_SIMPLEFB=y, or with framebuffer-coreboot
+-/sbin/modprobe simpledrm || /sbin/modprobe simplefb || true
++/usr/bin/modprobe simpledrm || /usr/bin/modprobe simplefb || true
 diff --git a/scripts/local b/scripts/local
 index 78653af..c31a2b2 100644
 --- a/scripts/local
@@ -346,5 +359,5 @@ index f7dc89f..ea08f82 100644
  	wait_for_udev 10
  
 -- 
-2.49.0
+2.50.1
 

--- a/main/initramfs-tools/patches/0005-general-portability-fixes-for-bsdutils-and-musl.patch
+++ b/main/initramfs-tools/patches/0005-general-portability-fixes-for-bsdutils-and-musl.patch
@@ -1,5 +1,4 @@
-
-From cedc4b27f5d0746769ba8b6dd9db29d93f0b7260 Mon Sep 17 00:00:00 2001
+From edff9fc94ccdda3df69e0f59327a375bf1ef7eda Mon Sep 17 00:00:00 2001
 From: q66 <q66@chimera-linux.org>
 Date: Tue, 22 Apr 2025 16:21:48 +0200
 Subject: [PATCH 5/8] general portability fixes for bsdutils and musl
@@ -7,14 +6,15 @@ Subject: [PATCH 5/8] general portability fixes for bsdutils and musl
 ---
  hook-functions   | 35 ++++++++---------------------------
  mkinitramfs      | 33 ++++++++++++---------------------
+ unmkinitramfs.c  | 14 +++++++++-----
  update-initramfs |  2 +-
- 4 files changed, 31 insertions(+), 60 deletions(-)
+ 4 files changed, 30 insertions(+), 54 deletions(-)
 
 diff --git a/hook-functions b/hook-functions
-index fa4a48e..058b95d 100644
+index 729b7c9..d1fe545 100644
 --- a/hook-functions
 +++ b/hook-functions
-@@ -260,30 +260,10 @@ copy_exec() {
+@@ -263,30 +263,10 @@ copy_exec() {
  	copy_file binary "${src}" "${target}" || return $(($? - 1))
  
  	# Copy the dependant libraries
@@ -49,7 +49,7 @@ index fa4a48e..058b95d 100644
  		copy_file binary "${x}" || {
  			ret=$?
  			[ ${ret} = 1 ] || return $((ret - 1))
-@@ -339,7 +319,8 @@ copy_modules_dir()
+@@ -342,7 +322,8 @@ copy_modules_dir()
  	done
  
  	# shellcheck disable=SC2044
@@ -59,7 +59,7 @@ index fa4a48e..058b95d 100644
  		modules="$modules ${kmod%%.*}"
  	done
  	# shellcheck disable=SC2086
-@@ -435,8 +416,8 @@ block_dev_mod_add()
+@@ -438,8 +419,8 @@ block_dev_mod_add()
  	dev_node="$1"
  
  	# Look up device number and convert to decimal as it appears in sysfs
@@ -148,28 +148,10 @@ index 2102d1d..6b5e2c6 100755
  		} | $compress -c ||
  			{ echo "E: mkinitramfs failure $compress $?" >&2; echo 1 >&3; exit; }
 diff --git a/unmkinitramfs.c b/unmkinitramfs.c
-index d69fd7a..30ea754 100644
+index ab42d72..63ce554 100644
 --- a/unmkinitramfs.c
 +++ b/unmkinitramfs.c
-@@ -155,7 +155,7 @@ static void warn_after_fread_failure(FILE *file, const char *name)
-  */
- static bool cpio_parse_hex(const char *field, uint32_t *value_p)
- {
--	const char digits[] = "0123456789ABCDEF", *p;
-+	const char digits[] = "0123456789abcdef", *p;
- 	uint32_t value = 0;
- 	unsigned int i;
- 	bool found_digit = false;
-@@ -166,7 +166,7 @@ static bool cpio_parse_hex(const char *field, uint32_t *value_p)
- 
- 	/* Parse digits up to end of field or null */
- 	for (; i < 8 && field[i] != 0; ++i) {
--		p = strchr(digits, field[i]);
-+		p = strchr(digits, field[i] | 32);
- 		if (!p)
- 			return false;
- 		value = (value << 4) | (p - digits);
-@@ -420,7 +420,7 @@ static bool write_trailer(int out_pipe)
+@@ -400,7 +400,7 @@ static bool write_trailer(int out_pipe)
  	return true;
  }
  
@@ -178,7 +160,7 @@ index d69fd7a..30ea754 100644
  {
  	const char *argv[10];
  	int pipe_fds[2], pid;
-@@ -430,8 +430,9 @@ static bool spawn_cpio(int optc, const char **optv, struct cpio_proc *proc)
+@@ -410,8 +410,9 @@ static bool spawn_cpio(int optc, const char **optv, struct cpio_proc *proc)
  	argc = 0;
  	argv[argc++] = "cpio";
  	argv[argc++] = "-i";
@@ -189,7 +171,7 @@ index d69fd7a..30ea754 100644
  	argv[argc++] = "--quiet";
  	assert(argc + optc < sizeof(argv) / sizeof(argv[0]));
  	while (optc--)
-@@ -458,6 +459,9 @@ static bool spawn_cpio(int optc, const char **optv, struct cpio_proc *proc)
+@@ -438,6 +439,9 @@ static bool spawn_cpio(int optc, const char **optv, struct cpio_proc *proc)
  		dup2(pipe_fds[0], 0);
  		close(pipe_fds[0]);
  
@@ -199,47 +181,34 @@ index d69fd7a..30ea754 100644
  		execvp("cpio", (char **)argv);
  		_exit(127);
  	}
-@@ -522,6 +526,7 @@ int main(int argc, char **argv)
- 	const char *out_dirname = NULL;
- 	char *out_subdirname = NULL;
+@@ -501,6 +505,7 @@ int main(int argc, char **argv)
+ 	FILE *in_file;
+ 	const char *out_dirname;
  	const char *cpio_optv[3];
 +	const char *cpio_dir = NULL;
  	int cpio_optc;
  	struct cpio_proc cpio_proc = { 0 };
- 	unsigned int early_count = 0;
-@@ -571,8 +576,7 @@ int main(int argc, char **argv)
+ 	bool ok;
+@@ -546,12 +551,11 @@ int main(int argc, char **argv)
  	if (do_list) {
  		cpio_optv[cpio_optc++] = "--list";
  	} else {
 -		cpio_optv[cpio_optc++] = "-D";
--		cpio_optv[cpio_optc++] = out_subdirname;
-+		cpio_dir = out_subdirname;
+-		cpio_optv[cpio_optc++] = out_dirname;
++		cpio_dir = out_dirname;
  	}
  	if (verbose)
  		cpio_optv[cpio_optc++] = "-v";
-@@ -636,7 +640,7 @@ int main(int argc, char **argv)
- 				ok = false;
- 				break;
- 			}
--			if (!spawn_cpio(cpio_optc, cpio_optv,
-+			if (!spawn_cpio(cpio_optc, cpio_dir, cpio_optv,
- 					&early_cpio_proc)) {
- 				ok = false;
- 				break;
-@@ -670,7 +674,7 @@ int main(int argc, char **argv)
- 				} else {
- 					strcpy(out_subdirname, out_dirname);
- 				}
--				if (!spawn_cpio(cpio_optc, cpio_optv,
-+				if (!spawn_cpio(cpio_optc, cpio_dir, cpio_optv,
- 						&cpio_proc)) {
- 					ok = false;
- 					break;
+-	if (!spawn_cpio(cpio_optc, cpio_optv, &cpio_proc))
++	if (!spawn_cpio(cpio_optc, cpio_dir, cpio_optv, &cpio_proc))
+ 		return 1;
+ 
+ 	/* Iterate over archives within the initramfs */
 diff --git a/update-initramfs b/update-initramfs
-index 30131e0..6db6aa1 100755
+index 0fb08ea..a8a50e4 100755
 --- a/update-initramfs
 +++ b/update-initramfs
-@@ -224,7 +224,7 @@ set_highest_version()
+@@ -230,7 +230,7 @@ set_highest_version()
  
  has_been_updated_since_timestamp() {
  	local initramfs_timestamp timestamp="$1"
@@ -249,5 +218,5 @@ index 30131e0..6db6aa1 100755
  }
  
 -- 
-2.49.0
+2.50.1
 

--- a/main/initramfs-tools/patches/0008-force-ugetopt.patch
+++ b/main/initramfs-tools/patches/0008-force-ugetopt.patch
@@ -7,7 +7,7 @@ Subject: [PATCH 8/8] force ugetopt
  lsinitramfs      | 2 +-
  mkinitramfs      | 2 +-
  update-initramfs | 2 +-
- 4 files changed, 4 insertions(+), 4 deletions(-)
+ 3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/lsinitramfs b/lsinitramfs
 index 8d2a967..0e75019 100755

--- a/main/initramfs-tools/template.py
+++ b/main/initramfs-tools/template.py
@@ -1,6 +1,6 @@
 pkgname = "initramfs-tools"
-pkgver = "0.148.3"
-pkgrel = 1
+pkgver = "0.150"
+pkgrel = 0
 build_style = "makefile"
 make_install_args = [f"VERSION={pkgver}"]
 depends = [
@@ -21,7 +21,7 @@ pkgdesc = "Generic modular initramfs generator"
 license = "GPL-2.0-or-later"
 url = "https://salsa.debian.org/kernel-team/initramfs-tools"
 source = f"{url}/-/archive/v{pkgver}/initramfs-tools-v{pkgver}.tar.gz"
-sha256 = "8285e6a5557aba74cf745737319f0af2d4df4d48aba65e1a6fb67d1117bf1662"
+sha256 = "d2578bed875b65962dfb51fae3bea8af11765ae76d1d66708fffef1fd3512a0c"
 # no tests
 options = ["!check"]
 


### PR DESCRIPTION
at least for most Snapdragon X Elite laptops https://salsa.debian.org/kernel-team/initramfs-tools/-/commit/d82a1e91 was of interest. works for me after the conflict resolves but possible I missed something.

adapts `0005-general-portability-fixes-for-bsdutils-and-musl.patch` for https://salsa.debian.org/kernel-team/initramfs-tools/-/commit/9fa9ae01 etc.