### PR TITLE
user/dnscrypt-proxy: don't install default config

### DIFF
--- a/user/dnscrypt-proxy/files/tmpfiles.conf
+++ b/user/dnscrypt-proxy/files/tmpfiles.conf
@@ -1,7 +1,6 @@
 # Create dnscrypt-proxy state directory
 
 d /etc/dnscrypt-proxy 0755 root root -
-C /etc/dnscrypt-proxy/dnscrypt-proxy.toml - - - - /usr/share/dnscrypt-proxy/dnscrypt-proxy.toml
 
 # cache dir for resolver source lists
 d /var/cache/dnscrypt-proxy 0755 _dnscrypt _dnscrypt -

--- a/user/dnscrypt-proxy/template.py
+++ b/user/dnscrypt-proxy/template.py
@@ -1,6 +1,6 @@
 pkgname = "dnscrypt-proxy"
 pkgver = "2.1.12"
-pkgrel = 0
+pkgrel = 1
 build_style = "go"
 make_build_args = ["./dnscrypt-proxy"]
 hostmakedepends = ["go"]


### PR DESCRIPTION
## Description

as discussed on IRC, installing a default config file in /etc using tmpfiles in the manner that I did would prevent installation of an updated config file later

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine