### PR TITLE
user/quickshell: new package

### DIFF
--- a/user/cli11/template.py
+++ b/user/cli11/template.py
@@ -1,0 +1,27 @@
+pkgname = "cli11"
+pkgver = "2.6.1"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DCLI11_SINGLE_FILE=OFF",  # Build the CLI11.hpp file from the sources. Requires Python (version 3 or 2.7).
+    "-DCLI11_PRECOMPILED=OFF",  # generate a precompiled static library instead of header-only
+    "-DCLI11_SINGLE_FILE_TESTS=OFF",  # Run the tests on the generated single file version as well
+    "-DCLI11_BUILD_DOCS=ON",  # build CLI11 documentation and book
+    "-DCLI11_BUILD_EXAMPLES=OFF",  # Build the example programs.
+    "-DCLI11_BUILD_EXAMPLES_JSON=OFF",  # Build some additional example using json libraries
+    "-DCLI11_INSTALL=ON",  # install CLI11 to the install folder during the install process
+    "-DCLI11_FORCE_LIBCXX=OFF",  # use libc++ instead of libstdc++ if building with clang on linux
+    "-DCLI11_CUDA_TESTS=OFF",  # build the tests with NVCC
+    "-DCLI11_BUILD_TESTS=ON",  # Build the tests.
+]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+checkdepends = ["catch2-devel"]
+pkgdesc = "Command line parser for C++11 and beyond"
+license = "BSD-3-Clause"
+url = "https://github.com/CLIUtils/CLI11"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "377691f3fac2b340f12a2f79f523c780564578ba3d6eaf5238e9f35895d5ba95"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/quickshell/template.py
+++ b/user/quickshell/template.py
@@ -1,0 +1,67 @@
+pkgname = "quickshell"
+pkgver = "0.2.1"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [  # https://git.outfoxxed.me/quickshell/quickshell/src/branch/master/BUILD.md
+    '-DDISTRIBUTOR="Chimera Linux"',
+    "-DDISTRIBUTOR_DEBUGINFO_AVAILABLE=YES",
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+    "-DCRASH_REPORTER=OFF",  # depends on google-breakpad
+    "-DUSE_JEMALLOC=ON",  # depends on jemalloc
+    "-DSOCKETS=ON",
+    "-DWAYLAND=ON",  # depends on qt6wayland, wayland, wayland-scanner, wayland-protocols
+    "-DWAYLAND_WLR_LAYERSHELL=ON",  # zwlr-layer-shell-v1 protocol
+    "-DWAYLAND_SESSION_LOCK=ON",  # ext-session-lock-v1 protocol
+    "-DWAYLAND_TOPLEVEL_MANAGEMENT=ON",  # zwlr-foreign-toplevel-management-v1 protocol
+    "-DSCREENCOPY=ON",  # depends on libdrm-devel and qt6-qtbase
+    "-DSCREENCOPY_ICC=ON",  # ext-image-copy-capture-v1 protocol
+    "-DSCREENCOPY_WLR=ON",  # zwlr-screencopy-v1 protocol
+    "-DSCREENCOPY_HYPRLAND_TOPLEVEL=ON",  # hyprland-toplevel-export-v1 protocol
+    "-DX11=ON",  # depends on libxcb
+    "-DSERVICE_PIPEWIRE=ON",  # depends on libpipewire
+    "-DSERVICE_STATUS_NOTIFIER=ON",  # depends on qt6dbus
+    "-DSERVICE_MPRIS=ON",  # depends on qt6dbus
+    "-DSERVICE_PAM=ON",  # depends on pam
+    "-DHYPRLAND=ON",  # requires WAYLAND=ON
+    "-DHYPRLAND_GLOBAL_SHORTCUTS=ON",  # hyprland-global-shortcuts-v1 protocol
+    "-DHYPRLAND_FOCUS_GRAB=ON",  # hyprland-focus-grab-v1 protocol.
+    "-DI3=ON",
+    "-DI3_IPC=ON",
+]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+    "spirv-tools",
+    "wayland-progs",
+]
+makedepends = [
+    "cli11",
+    "jemalloc-devel",  # memory masking support
+    "libdrm-devel",  # screencopy support
+    "libxcb-devel",  # X11 support
+    "linux-pam-devel",  # PAM support
+    "pipewire-devel",  # pipewire support
+    "qt6-qtbase-devel",
+    "qt6-qtbase-private-devel",
+    "qt6-qtdeclarative-devel",
+    "qt6-qtscxml-devel",  # for QML
+    "qt6-qtshadertools-devel",
+    "qt6-qtwayland-devel",
+    "wayland-devel",
+    "wayland-protocols",
+]
+depends = [
+    "qt6-qtsvg",  # icon and image support
+]
+pkgdesc = "Flexible QtQuick-based desktop shell toolkit"
+license = "LGPL-3.0-only"
+url = "https://quickshell.org"
+source = (
+    f"https://git.outfoxxed.me/quickshell/quickshell/archive/v{pkgver}.tar.gz"
+)
+sha256 = "d815c5f99f4a0a28545ffaa90464420c773b7c0ab62f713d9d8735a8e7282ca7"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/quickshell/update.py
+++ b/user/quickshell/update.py
@@ -1,0 +1,2 @@
+url = "https://git.outfoxxed.me/quickshell/quickshell/tags.atom"
+pattern = r"/releases/tag/v?([\d.]+)(?=\")"


### PR DESCRIPTION
## Description

> Quickshell is a toolkit for building status bars, widgets, lockscreens, and other desktop components using QtQuick. It can be used alongside your wayland compositor or window manager to build a complete desktop environment. 

from https://quickshell.org

following packaging recommendations from https://git.outfoxxed.me/quickshell/quickshell/src/branch/master/BUILD.md

requires `cli11`: blocked by https://github.com/chimera-linux/cports/pull/4726

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
