### PR TITLE
cbuild: Fix kernel install with _ in version

### DIFF
--- a/src/cbuild/util/linux.py
+++ b/src/cbuild/util/linux.py
@@ -96,7 +96,9 @@ def install(pkg, env=None):
         env=_build_env(pkg, pkg.make_env, pkg.make_install_env, env),
     )
     kdest = list(
-        (pkg.destdir / "usr/lib/modules").glob(f"{pkg.pkgver}-{pkg.pkgrel}-*")
+        (pkg.destdir / "usr/lib/modules").glob(
+            f"{pkg.pkgver.replace('_', '-')}-{pkg.pkgrel}-*"
+        )
     )[0]
     # most things get relocated to a distribution directory
     pkg.install_dir(f"{kdest.relative_to(pkg.destdir)}/apk-dist/boot")


### PR DESCRIPTION
## Description

Versions like `6.17.0-rc1` are `6.17.0_rc1` in `pkgver`, so the glob wouldn't match without this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
