### PR TITLE
main/fuzzel: update to 1.13.1

### DIFF
--- a/main/fuzzel/template.py
+++ b/main/fuzzel/template.py
@@ -1,5 +1,5 @@
 pkgname = "fuzzel"
-pkgver = "1.12.0"
+pkgver = "1.13.1"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dsvg-backend=librsvg"]
@@ -25,7 +25,7 @@ pkgdesc = "Application launcher for wlroots-based Wayland compositors"
 license = "MIT"
 url = "https://codeberg.org/dnkl/fuzzel"
 source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "7f23b86d8fc635c368c69be7227aa7f8068a6ec7d07305a33c12db259400d3e8"
+sha256 = "17e8f01753469573965a2a37b5745d03e6f6e7bda9d675cd2bc4644abb42d818"
 hardening = ["vis", "cfi"]
 
 


### PR DESCRIPTION
## Description

upgraded fuzzel to 1.13.1

The 1.13.0 release added gamma correct blending but it can't be added in librsvg+cairo enabled builds of fuzzel. However, using nanosvg would disable some features that are possible only with librsvg+cairo.

There's an [open PR](https://codeberg.org/dnkl/fuzzel/pulls/650) for a new SVG backend, maybe that'll improve fuzzel.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
