### PR TITLE
user/cicada: new package

### DIFF
--- a/user/cicada/patches/unbash-and-release.patch
+++ b/user/cicada/patches/unbash-and-release.patch
@@ -1,0 +1,166 @@
+From https://github.com/mitnk/cicada/pull/55
+
+From 8718bb77fcbeb5570d49d63970bd129f94f95554 Mon Sep 17 00:00:00 2001
+From: Aster Boese <asterboese@mailbox.org>
+Date: Sat, 23 Aug 2025 14:36:11 -0400
+Subject: [PATCH 1/3] use sh in tests/test_scripting.sh instead of bash
+
+---
+ tests/test_scripts.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_scripts.sh b/tests/test_scripts.sh
+index 82f0ef9..76af1c2 100755
+--- a/tests/test_scripts.sh
++++ b/tests/test_scripts.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ set -e
+ CICADA="./target/debug/cicada"
+ 
+
+From 86ef292f7c728d2289b6754ceecd9e8580e77944 Mon Sep 17 00:00:00 2001
+From: Aster Boese <asterboese@mailbox.org>
+Date: Sat, 23 Aug 2025 14:44:24 -0400
+Subject: [PATCH 2/3] tests: fix shellcheck and allow using release version for
+ tests
+
+Signed-off-by: Aster Boese <asterboese@mailbox.org>
+---
+ tests/scripts/regression-001.sh |  4 ++--
+ tests/test_scripts.sh           | 16 +++++++++-------
+ 2 files changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/tests/scripts/regression-001.sh b/tests/scripts/regression-001.sh
+index 49c3491..8ee4164 100644
+--- a/tests/scripts/regression-001.sh
++++ b/tests/scripts/regression-001.sh
+@@ -45,9 +45,9 @@ ulimit -c
+ ulimit | wc
+ 
+ echo '--- for exit code ---'
+-./target/debug/cicada -c cinfo1
++./"${CICADA}" -c cinfo1
+ echo $?
+ echo 'exit 3' > exit3.sh
+-./target/debug/cicada exit3.sh
++./"${CICADA}" exit3.sh
+ echo $?
+ rm -f exit3.sh
+diff --git a/tests/test_scripts.sh b/tests/test_scripts.sh
+index 76af1c2..b823951 100755
+--- a/tests/test_scripts.sh
++++ b/tests/test_scripts.sh
+@@ -1,8 +1,10 @@
+ #!/bin/sh
++
+ set -e
+-CICADA="./target/debug/cicada"
+ 
+-if [ ! -f $CICADA ]; then
++CICADA="./target/${MODE}/cicada"
++
++if [ ! -f "$CICADA" ]; then
+     echo "cicada binary not found: $CICADA"
+     echo "please build it out with cargo build first"
+     exit 1
+@@ -11,10 +13,10 @@ fi
+ DIR_TEST="$( cd "$(dirname "$0")" ; pwd -P )"
+ TMP_FILE="${DIR_TEST}/tmpfile-test-cicada-scripts.out"
+ 
+-for src in ${DIR_TEST}/scripts/*.sh; do
+-    echo Runing $CICADA $src
+-    $CICADA $src > "$TMP_FILE"
+-    if diff -u "${src}.out" $TMP_FILE; then
++for src in "${DIR_TEST}"/scripts/*.sh; do
++    echo "Running $CICADA $src"
++    CICADA="$CICADA" "$CICADA" "$src" > "$TMP_FILE"
++    if diff -u "${src}.out" "$TMP_FILE"; then
+         echo OK.
+     else
+         echo Failed.
+@@ -22,4 +24,4 @@ for src in ${DIR_TEST}/scripts/*.sh; do
+     fi
+ done
+ 
+-rm -f $TMP_FILE
++rm -f "$TMP_FILE"
+
+From b886e34cbca9c075ee98da9181525e4e9dfd39c8 Mon Sep 17 00:00:00 2001
+From: Aster Boese <asterboese@mailbox.org>
+Date: Sat, 23 Aug 2025 15:41:08 -0400
+Subject: [PATCH 3/3] Makefile: clean up and support both debug and release
+ mode
+
+---
+ Makefile | 53 +++++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 33 insertions(+), 20 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 5e06c1b..77329a9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,28 +1,41 @@
+-run:
+-	@rustc -V
+-	# cargo update
+-	cargo build
+-	./target/debug/cicada -l
++# Install to current root by default
++DESTDIR := ""
++# Install to homedir by default to avoid using root
++PREFIX := ${HOME}/.local
++# Debug is the default
++MODE := debug
+ 
+-install:
+-	# cargo update
+-	cargo build --release
+-	cp target/release/cicada /usr/local/bin/
++ifeq ($(MODE),debug)
++	MODEFLAG="--"
++else
++	MODEFLAG="--$(MODE)"
++endif
++
++build:
++	cargo build "${MODEFLAG}"
++
++clean:
++	cargo clean
++	find . -name '*.rs.bk' | xargs -0 rm -f
++
++clippy:
++	cargo clippy -- -A clippy::needless_return -A clippy::ptr_arg
+ 
+ doc:
+ 	cargo doc --open
+ 
+-test:
+-	@rustc -V
+-	cargo test --bins
++fmt:
++	cargo fmt
+ 
+-scripting-test:
+-	cargo build
+-	./tests/test_scripts.sh 2>/dev/null
++install: build
++	install -Dm755 target/"${MODE}"/cicada "${DESTDIR}"/"${PREFIX}"/bin/cicada
+ 
+-clippy:
+-	cargo clippy -- -A clippy::needless_return -A clippy::ptr_arg
++run: build
++	cargo run "${MODEFLAG}" -- -l
+ 
+-clean:
+-	cargo clean
+-	find . -name '*.rs.bk' | xargs rm -f
++test: build
++	cargo test --bins "${MODEFLAG}"
++	MODE="${MODE}" ./tests/test_scripts.sh 2>/dev/null
++
++
++.PHONY: build clean clippy doc fmt install run test
+

--- a/user/cicada/patches/unbundle-sqlite.patch
+++ b/user/cicada/patches/unbundle-sqlite.patch
@@ -1,0 +1,24 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index a62de1c..c2c1372 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -422,7 +422,6 @@ version = "0.30.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+ dependencies = [
+- "cc",
+  "pkg-config",
+  "vcpkg",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index 44f8484..6c3ab8b 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -48,7 +48,6 @@ features = ["std", "derive", "help"]
+ 
+ [dependencies.rusqlite]
+ version = "0.32"
+-features = ["bundled"]
+ 
+ [dependencies.time]
+ version = "0.3"

--- a/user/cicada/template.py
+++ b/user/cicada/template.py
@@ -1,0 +1,24 @@
+pkgname = "cicada"
+pkgver = "1.1.2"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = [
+    "rust-std",
+    "sqlite-devel",
+]
+checkdepends = [
+    "less",
+]
+pkgdesc = "Bash-like Unix shell"
+license = "MIT"
+url = "https://github.com/mitnk/cicada"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "fa98e4b15d62ce0343d69a9f51d737fe02b8200f5903c14f5131dec6c7a54656"
+# Needs exact matching coreutils command output
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+    self.install_shell("/usr/bin/cicada")


### PR DESCRIPTION
## Description

Adds the `cicada` package. Cicada is a bash-like shell that is meant for interactive use. Due to this, it does not include most POSIX shell scripting logic and is not supposed to be a replacement for `/bin/sh`.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
