### PR TITLE
main/wlroots0.19: backport fix for single-pixel buffer textures

### DIFF
--- a/main/wlroots0.19/patches/0001-scene-Block-damage-on-single-pixel-buffer-textures.patch
+++ b/main/wlroots0.19/patches/0001-scene-Block-damage-on-single-pixel-buffer-textures.patch
@@ -1,0 +1,62 @@
+From 58c3680d96bffa1b8f59c274050a6ecfa27e7c23 Mon Sep 17 00:00:00 2001
+From: David Turner <david.turner@raspberrypi.com>
+Date: Mon, 30 Jun 2025 15:45:03 +0100
+Subject: [PATCH] scene: Block damage on single-pixel buffer textures
+
+We cache whether buffers are single-pixel buffers (and if so what color
+they are) to allow rendering optimizations.  But this breaks if the
+client changes out the single-pixel buffer for one with a different
+color, because this updates the texture in-place instead of actually
+changing the buffer.
+
+We can fix this by blocking in-place texture updates for single pixel
+buffers.
+
+Original bug: https://codeberg.org/ifreund/waylock/issues/121
+See also: !5092
+---
+ types/scene/surface.c | 24 +++++++++++++++++++++---
+ 1 file changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/types/scene/surface.c b/types/scene/surface.c
+index 07ef7ebe..1ee0e313 100644
+--- a/types/scene/surface.c
++++ b/types/scene/surface.c
+@@ -127,8 +127,11 @@ static void scene_buffer_unmark_client_buffer(struct wlr_scene_buffer *scene_buf
+ 		return;
+ 	}
+ 
+-	assert(buffer->n_ignore_locks > 0);
+-	buffer->n_ignore_locks--;
++	// If the buffer was a single-pixel buffer where we cached its color
++	// then it won't have been marked as damage-allowed.
++	if (buffer->n_ignore_locks > 0) {
++		buffer->n_ignore_locks--;
++	}
+ }
+ 
+ static int min(int a, int b) {
+@@ -229,7 +232,22 @@ static void surface_reconfigure(struct wlr_scene_surface *scene_surface) {
+ 	scene_buffer_unmark_client_buffer(scene_buffer);
+ 
+ 	if (surface->buffer) {
+-		client_buffer_mark_next_can_damage(surface->buffer);
++		// If we've cached the buffer's single-pixel buffer color
++		// then any in-place updates to the texture wouldn't be
++		// reflected in rendering. So only allow in-place texture
++		// updates if it's not a single pixel buffer.  Note that we
++		// can't use the cached scene_buffer->is_single_pixel_buffer
++		// because that's only set later on.
++		bool is_single_pixel_buffer = false;
++		struct wlr_client_buffer *client_buffer = wlr_client_buffer_get(&surface->buffer->base);
++		if (client_buffer != NULL && client_buffer->source != NULL) {
++			struct wlr_single_pixel_buffer_v1 *spb =
++				wlr_single_pixel_buffer_v1_try_from_buffer(client_buffer->source);
++			is_single_pixel_buffer = spb != NULL;
++		}
++		if (!is_single_pixel_buffer) {
++			client_buffer_mark_next_can_damage(surface->buffer);
++		}
+ 
+ 		struct wlr_linux_drm_syncobj_surface_v1_state *syncobj_surface_state =
+ 			wlr_linux_drm_syncobj_v1_get_surface_state(surface);

--- a/main/wlroots0.19/template.py
+++ b/main/wlroots0.19/template.py
@@ -1,6 +1,6 @@
 pkgname = "wlroots0.19"
 pkgver = "0.19.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "meson"
 configure_args = [
     # all auto features are needed,


### PR DESCRIPTION
## Description

patch from Alpine:

> Without this patch, waylock is incapable of setting the input
and fail color. This is due to a regression in wlroots which is fixed by this patch. The patch has been merged in wlroots upstream.

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine