### PR TITLE
user/chars: new package

### DIFF
--- a/user/chars/template.py
+++ b/user/chars/template.py
@@ -1,0 +1,16 @@
+pkgname = "chars"
+pkgver = "0.7.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["rust-std"]
+pkgdesc = "CLI tool to display information about unicode characters"
+license = "MIT"
+url = "https://github.com/boinkor-net/chars"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "2f79843a3b1173870b41ebce491a54812b13a44090d0ae30a6f572caa91f0736"
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/chars")
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

A handy little CLI utility for when you're uncertain what unicode characters a string is made up of. I use this semi-frequently when string comparisons fail and I wonder whether there's some hidden unicode character that I didn't expect.


## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
