### PR TITLE
main/kea: update to 3.0.1

### DIFF
--- a/main/kea/template.py
+++ b/main/kea/template.py
@@ -1,14 +1,11 @@
 pkgname = "kea"
-pkgver = "2.6.3"
+pkgver = "3.0.1"
 pkgrel = 0
-build_style = "gnu_configure"
-configure_args = [
-    "--disable-static",
-    "--enable-shell",
-]
+build_style = "meson"
+configure_args = ["-Drunstatedir=run"]
 hostmakedepends = [
-    "automake",
-    "slibtool",
+    "meson",
+    "pkgconf",
 ]
 makedepends = [
     "boost-devel",
@@ -21,8 +18,8 @@ checkdepends = ["procps"]
 pkgdesc = "Alternative DHCP implementation by ISC"
 license = "MPL-2.0"
 url = "https://kea.isc.org"
-source = f"https://downloads.isc.org/isc/kea/cur/{pkgver[: pkgver.rfind('.')]}/kea-{pkgver}.tar.gz"
-sha256 = "00241a5955ffd3d215a2c098c4527f9d7f4b203188b276f9a36250dd3d9dd612"
+source = f"https://downloads.isc.org/isc/kea/cur/{pkgver[: pkgver.rfind('.')]}/kea-{pkgver}.tar.xz"
+sha256 = "ec84fec4bb7f6b9d15a82e755a571e9348eb4d6fbc62bb3f6f1296cd7a24c566"
 
 
 def post_install(self):


### PR DESCRIPTION
Starting on Kea 2.6.3, it enforces the directory defined at compile time to be the only option to be used for sockets.  From changelog:

```
    3. To address potential denial-of-service and spoofing attacks, Kea no
    longer creates sockets in `/tmp`, which is a world-writable directory on
    most systems. Instead, it uses the
    ``[kea-installation-dir]/var/run/kea`` directory for sockets. The new
    default configurations have this change applied so new installations are
    secured, but please alter your configuration if upgrading.
```

The default runstatedir is /var/run but we are using /run.  It usually is not a big deal since /var/run is a symlink to /run but in this case we need to use what is defined at compile-time.  Change it to /run as the simplest solution.