### PR TITLE
user/ocaml-findlib: new package

### DIFF
--- a/user/ocaml-findlib-devel
+++ b/user/ocaml-findlib-devel
@@ -1,0 +1,1 @@
+ocaml-findlib

--- a/user/ocaml-findlib/template.py
+++ b/user/ocaml-findlib/template.py
@@ -1,0 +1,41 @@
+pkgname = "ocaml-findlib"
+pkgver = "1.9.8"
+pkgrel = 0
+build_style = "configure"
+configure_args = [
+    "-bindir", "/usr/bin",
+    "-mandir", "/usr/share/man",
+    "-sitelib", "/usr/lib/ocaml",
+    "-config", "/etc/ocaml-findlib.conf",
+]
+makedepends = [
+    "ocaml",
+    "ocaml-compiler-libs",
+]
+pkgdesc = "OCaml library manager"
+license = "MIT"
+url = "https://projects.camlcity.org/projects/findlib.html"
+source = f"https://download.camlcity.org/download/findlib-{pkgver}.tar.gz"
+sha256 = "662c910f774e9fee3a19c4e057f380581ab2fc4ee52da4761304ac9c31b8869d"
+options = ["!lintstatic"]
+
+
+def check(self):
+    # These are the libraries itest has tests for which also have META files in
+    # the ocaml package.
+    for i in ["str", "unix"]:
+        self.do("./itest", i, env={"OCAMLFIND_CONF": "./findlib.conf"})
+
+
+def build(self):
+    self.do("make", "all")
+    self.do("make", "opt")
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+@subpackage("ocaml-findlib-devel")
+def _(self):
+    return ["usr/lib/ocaml/findlib/*.cmxs"]


### PR DESCRIPTION
The tests here are not very useful, in particular when ocamlfind is compiled as a "custom" executable (a concatenation of the ocamlrun bytecode interpreter and the bytecode program itself), it doesn't work, but the tests still pass.

This isn't that important here since we're compiling a native executable, but is worth keeping in mind.

## Description

ocamlfind is a tool kind of like pkg-config for OCaml, which interprets META files distributed with OCaml modules.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
