### PR TITLE
user/haproxy-dataplaneapi: new package

### DIFF
--- a/user/haproxy-dataplaneapi/template.py
+++ b/user/haproxy-dataplaneapi/template.py
@@ -1,0 +1,17 @@
+pkgname = "haproxy-dataplaneapi"
+pkgver = "3.3.5"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    "-ldflags="
+    + f" -X main.GitTag={pkgver}"
+    + " -X main.GitCommit="
+    + " -X main.GitDirty= ",
+    "./cmd/dataplaneapi",
+]
+hostmakedepends = ["go"]
+pkgdesc = "HAProxy Data Plane API"
+license = "Apache-2.0"
+url = "https://github.com/haproxytech/dataplaneapi"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "7e9d0a97571fba51969cd28efd1fcde28e3757457a62d3f2c6861659060a2877"


### PR DESCRIPTION
## Description

The HAProxy DataPlane API. This is useful starting from version 3.2.x because it supports writing certificates to disk when using the native ACME feature of HAProxy. Without this package, HAProxy will keep certificates in memory and one has to manually dump those certs on disk.

I haven't added a dinit service file for this package because the program expects `/etc/haproxy/dataplaneapi.yaml` and we can't ship files in `/etc`. Should I use a wrapper script as mentioned in the soju PR or do something else? Let me know.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
