### PR TITLE
main/rabbitmq-c: fix build by disabling cfi

### DIFF
--- a/main/rabbitmq-c/template.py
+++ b/main/rabbitmq-c/template.py
@@ -16,7 +16,7 @@ license = "MIT"
 url = "https://github.com/alanxz/rabbitmq-c"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "7b652df52c0de4d19ca36c798ed81378cba7a03a0f0c5d498881ae2d79b241c2"
-hardening = ["vis", "cfi"]
+hardening = ["vis"]
 
 
 def post_install(self):


### PR DESCRIPTION
cfi conflicts with static libraries, and they are needed for tests
