### PR TITLE
user/atop: new package

### DIFF
--- a/user/atop/template.py
+++ b/user/atop/template.py
@@ -1,0 +1,39 @@
+pkgname = "atop"
+pkgver = "2.13.0"
+pkgrel = 0
+build_style = "makefile"
+make_build_args = [
+    "SBINPATH=/usr/bin",
+]
+make_install_target = "genericinstall"
+make_install_args = make_build_args
+hostmakedepends = [
+    "clang",
+    "gmake",
+    "pkgconf",
+]
+makedepends = [
+    "glib-devel",
+    "linux-headers",
+    "ncurses-devel",
+    "zlib-ng-compat-devel",
+]
+pkgdesc = "ASCII full-screen performance monitor"
+license = "GPL-2.0-only"
+url = "https://github.com/Atoptool/atop"
+source = f"https://github.com/Atoptool/atop/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "5ee38c93afd64767a09a06698a0e90bfc390189a5058d245878a559d476d8572"
+tool_flags = {
+    # From pkgconf --cflags ncursesw
+    "CFLAGS": ["-DNCURSES_WIDECHAR"]
+}
+# Dies with 0x0c on startup. Later investigation is needed.
+hardening = ["!int"]
+# `atop` does not implement `make check` or similar
+options = ["!check"]
+
+
+def post_install(self):
+    # The upstream creates an empty file in /etc/default/atop via touch.
+    # It's read by the varios services, which aren't included, since they don't support dinit
+    self.rm(self.destdir / "etc", True)


### PR DESCRIPTION
## Description

This PR adds a `atop` to the `user` repo.  
Atop is (my personal favorite) top variant.

### Packaging notes:
* Upstream supports "sysv", "systemd" and "generic" install modes. "Generic" is used here.
* With the default hardening (specifically `int`), the application dies on startup. I've not yet run down exactly where in the application this is occurring (the notes in PACKAGING were really useful to understand what was happening)
* Upstream does not support `make check` or equivalent.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
