### PR TITLE
main/cups-filters: install_if brlaser

### DIFF
--- a/main/cups-filters/template.py
+++ b/main/cups-filters/template.py
@@ -22,13 +22,13 @@ makedepends = [
     "linux-headers",
 ]
 depends = ["cups"]
+install_if = [self.with_pkgver("brlaser")]
 pkgdesc = "Filters, backends, utilities for CUPS"
 license = "Apache-2.0 AND custom:gpl-exception"
 url = "https://github.com/OpenPrinting/cups-filters"
 source = f"https://github.com/OpenPrinting/cups-filters/releases/download/{pkgver}/cups-filters-{pkgver}.tar.xz"
 sha256 = "39e71de3ce06762b342749f1dc7cba6817738f7bf4d322c1bb9ab10b8569ab80"
 hardening = ["vis", "cfi"]
-
 
 def post_install(self):
     self.install_license("COPYING")


### PR DESCRIPTION
## Description

brlaser requires cups-filters to be useful.
The driver will technically do it's job but cups will fail to execute basically anything, since the document format isn't supported without the filters.
If someone has installed brlaser and cups, they most likely want to print things, requiring the filters.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
