### PR TITLE
[CI SKIP] user/wasmtime: update to 37.0.2

### DIFF
--- a/user/wasmtime/patches/cargo-auditable.patch
+++ b/user/wasmtime/patches/cargo-auditable.patch
@@ -1,0 +1,38 @@
+--- a/cranelift/Cargo.toml
++++ b/cranelift/Cargo.toml
+@@ -65,4 +65,4 @@
+ souper-harvest = ["cranelift-codegen/souper-harvest", "rayon"]
+ all-arch = ["cranelift-codegen/all-arch"]
+ all-native-arch = ["cranelift-codegen/all-native-arch"]
+-pulley = ['cranelift-codegen/pulley', 'dep:pulley-interpreter']
++pulley = ['cranelift-codegen/pulley', 'pulley-interpreter']
+--- a/cranelift/codegen/Cargo.toml
++++ b/cranelift/codegen/Cargo.toml
+@@ -90,7 +90,7 @@
+ s390x = []
+ riscv64 = []
+ pulley = [
+-    "dep:pulley-interpreter",
++    "pulley-interpreter",
+     "pulley-interpreter/encode",
+     "pulley-interpreter/disas",
+     "cranelift-codegen-meta/pulley",
+--- a/cranelift/codegen/meta/Cargo.toml
++++ b/cranelift/codegen/meta/Cargo.toml
+@@ -23,4 +23,4 @@
+ heck = "0.5.0"
+ 
+ [features]
+-pulley = ['dep:pulley-interpreter']
++pulley = ['pulley-interpreter']
+--- a/crates/cranelift/Cargo.toml
++++ b/crates/cranelift/Cargo.toml
+@@ -39,7 +39,7 @@
+ [features]
+ all-arch = ["cranelift-codegen/all-arch"]
+ host-arch = ["cranelift-codegen/host-arch"]
+-pulley = ["cranelift-codegen/pulley", "dep:pulley-interpreter"]
++pulley = ["cranelift-codegen/pulley", "pulley-interpreter"]
+ trace-log = ["cranelift-codegen/trace-log"]
+ component-model = ["wasmtime-environ/component-model"]
+ incremental-cache = ["cranelift-codegen/incremental-cache"]

--- a/user/wasmtime/template.py
+++ b/user/wasmtime/template.py
@@ -1,8 +1,6 @@
 pkgname = "wasmtime"
-pkgver = "31.0.0"
+pkgver = "37.0.2"
 pkgrel = 0
-# no implementation for other architectures
-archs = ["aarch64", "riscv64", "x86_64"]
 build_style = "cargo"
 make_check_args = [
     "--",
@@ -24,9 +22,7 @@ pkgdesc = "Runtime for webassembly"
 license = "Apache-2.0"
 url = "https://wasmtime.dev"
 source = f"https://github.com/bytecodealliance/wasmtime/releases/download/v{pkgver}/wasmtime-v{pkgver}-src.tar.gz"
-sha256 = "7f58f9a5b398ed6d8ef3682e60729320e2cc671da387e8f97de8dc021e154a64"
-# wast tests take like an hour
-options = ["!check"]
+sha256 = "df4b9b77cc607728b20fac730531c8dbe2039989f8e2654dce901228c51d65b1"
 
 
 def post_extract(self):


### PR DESCRIPTION
Now that there's the pulley backend, wasmtime _should_ technically work on architectures which cranelift doesn't support yet. **Further testing needed.**

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

---

Known to work
- x86_64

Should work (hasn't been tested yet)
- aarch64
- riscv64

Needs testing
- loongarch64
- ppc64le
- ppc64
- ppc
