### PR TITLE
cbuild: handle git log being configured to show signatures

### DIFF
--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -1317,7 +1317,13 @@ class Template(Package):
         )
 
         def _gitlog(fmt, tgt, pkg):
-            bargs = ["git", "log", "-n1", f"--format={fmt}"]
+            bargs = [
+                "git",
+                "log",
+                "-n1",
+                f"--format={fmt}",
+                "--no-show-signature",
+            ]
             if pkg:
                 bargs += ["--", tgt]
             else:


### PR DESCRIPTION
## Description

I have git configured globally with `log.showSignature` set to `true`, which caused cbuild to fail with an `invalid commit format` error. This PR explictly tells `git log` not to print signatures.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
