### PR TITLE
user/nushell: re-enable network support

### DIFF
--- a/user/nushell/template.py
+++ b/user/nushell/template.py
@@ -1,10 +1,10 @@
 pkgname = "nushell"
 pkgver = "0.108.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 make_build_args = [
     "--no-default-features",
-    "--features=plugin,trash-support,sqlite,native-tls",
+    "--features=plugin,trash-support,sqlite,native-tls,network",
     "--workspace",
 ]
 make_check_args = [


### PR DESCRIPTION
## Description

Version 0.108.0 made network support (things like the `http` command) a separate build feature

See https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#add-network-feature-to-top-level-crate-16686-toc

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
