### PR TITLE
user/hyx: new package

### DIFF
--- a/user/hyx/template.py
+++ b/user/hyx/template.py
@@ -1,0 +1,16 @@
+pkgname = "hyx"
+pkgver = "2024.02.29"
+pkgrel = 0
+build_style = "makefile"
+pkgdesc = "Terminal hex editor inspired by vim"
+license = "MIT"
+url = "https://yx7.cc/code"
+source = f"https://yx7.cc/code/hyx/hyx-{pkgver}.tar.xz"
+sha256 = "76e7f1df3b1a6de7aded1a7477ad0c22e36a8ac21077a52013b5836583479771"
+
+# hyx has no check step
+options = ["!check"]
+
+def install(self):
+    self.install_bin("hyx")
+    self.install_license("license.txt")


### PR DESCRIPTION
## Description

The pull request adds a new package, `user/hyx`.
`hyx` is a vim-inspired terminal hex editor, or, [to quote the author's website](https://yx7.cc/code/):

> ...a minimalistic (< 2300 lines of C) but powerful (hex/ASCII, insert/replace/delete, copy/paste, undo/redo, search, colors, vim-inspired controls) terminal hex editor (current version 2024.02.29).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
