### PR TITLE
main/kio: update to 6.19.1

### DIFF
--- a/main/kio/template.py
+++ b/main/kio/template.py
@@ -1,5 +1,5 @@
 pkgname = "kio"
-pkgver = "6.19.0"
+pkgver = "6.19.1"
 pkgrel = 0
 build_style = "cmake"
 # XXX drop libexec
@@ -47,7 +47,7 @@ url = "https://api.kde.org/frameworks/kio/html"
 source = (
     f"$(KDE_SITE)/frameworks/{pkgver[: pkgver.rfind('.')]}/kio-{pkgver}.tar.xz"
 )
-sha256 = "06de4ce5c91aac91a127c50bd9caad6fbdef26c6c86164ed28a546a8e4cf0567"
+sha256 = "2f0ea7af4ca227031f0f0341a232d186d40db001d5bb6287ef9fa4bca127ee3f"
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
 hardening = ["vis"]
 # >60% (40/62) tests fail, pain to get working in a limited enviroment due to expecting e.g. real disks


### PR DESCRIPTION
## Description

Upgrades kio to version 6.19.1. [To quote the release notes](https://blogs.kde.org/2025/10/18/this-week-in-plasma-plasma-6.5-is-nigh-and-kde-is-29-years-old-help-us-celebrate/#frameworks-6191):

> ## Frameworks 6.19.1
>
> Fixed a serious regression accidentally introduced into Frameworks 6.19 that made it impossible to write files into Samba shares. The relevant code will be covered with an autotest soon so it doesn’t regress again. (Akseli Lahtinen, [link](https://bugs.kde.org/show_bug.cgi?id=510567))

I installed the change locally and can confirm that it fixes the problem with copying and pasting files onto samba shares.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine