### PR TITLE
Legibility improvements for concurrent / repeated builds

### DIFF
--- a/src/cbuild/core/build.py
+++ b/src/cbuild/core/build.py
@@ -599,6 +599,7 @@ def _build(
     # in there) but not any other stage
     if not dirty and pkg.stage > 0:
         # clean up old state
+        pkg.log(f"cleaning build state ({dirty=}, stage={pkg.stage})")
         pkgm.remove_pkg_wrksrc(pkg)
         pkgm.remove_pkg(pkg)
         pkgm.remove_pkg_statedir(pkg)

--- a/src/cbuild/core/pkg.py
+++ b/src/cbuild/core/pkg.py
@@ -38,12 +38,12 @@ def _remove_ro(f, path, _):
 def remove_pkg_wrksrc(pkg):
     if pkg.srcdir.is_dir():
         pkg.log("cleaning build directory...")
-        shutil.rmtree(pkg.srcdir, onerror=_remove_ro)
+        shutil.rmtree(pkg.srcdir, onexc=_remove_ro)
 
 
 def remove_pkg_statedir(pkg):
     if pkg.statedir.is_dir():
-        shutil.rmtree(pkg.statedir, onerror=_remove_ro)
+        shutil.rmtree(pkg.statedir, onexc=_remove_ro)
 
 
 def remove_pkg(pkg):
@@ -67,7 +67,7 @@ def remove_pkg(pkg):
     for sp in pkg.subpkg_list:
         remove_state(sp, pkg.destdir_base)
 
-    shutil.rmtree(pkg.destdir_base, onerror=_remove_ro)
+    shutil.rmtree(pkg.destdir_base, onexc=_remove_ro)
 
     (pkg.statedir / f"{pkg.pkgname}_{crossb}_install_done").unlink(
         missing_ok=True

--- a/src/cbuild/core/pkg.py
+++ b/src/cbuild/core/pkg.py
@@ -29,7 +29,9 @@ def set_failed(pkg):
 
 
 def _remove_ro(f, path, _):
-    os.chmod(path, stat.S_IWRITE)
+    # Ensure the path is writable, and then try again
+    result = os.stat(path)
+    os.chmod(path, result.st_mode | stat.S_IWRITE)
     f(path)
 
 


### PR DESCRIPTION
## Description

Add helpful logs for clarity when build state is cleared (see chimera-linux#4288); while working on this, also fix unexpected permissions in build directory and tidy up use of deprecated argument to shutil.rmtree.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [ ] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
