### PR TITLE
user/tessen: update to 2.3.0

### DIFF
--- a/user/tessen/template.py
+++ b/user/tessen/template.py
@@ -1,20 +1,17 @@
 pkgname = "tessen"
-pkgver = "2.2.3"
+pkgver = "2.3.0"
 pkgrel = 0
 build_style = "makefile"
 hostmakedepends = ["scdoc"]
 depends = [
-    "fuzzel",
     "libnotify",
-    "pass-otp",
-    "password-store",
     "wl-clipboard",
     "wtype",
 ]
 pkgdesc = "Interactive menu to autotype and copy pass data"
 license = "GPL-2.0-only"
-url = "https://sr.ht/~ayushnix/tessen"
-source = f"https://git.sr.ht/~ayushnix/tessen/archive/v{pkgver}.tar.gz"
-sha256 = "a672b564527f5b50fce65b9c3ba7616c326d5bd6d1a2479888fd437b37ecde1e"
+url = "https://tangled.org/@jcg.re/tessen"
+source = f"https://tangled.org/@jcg.re/tessen/archive/v{pkgver}>{pkgver}.tar.gz"
+sha256 = "a19a15bfa1cedf802403168a60ecf3fa5a758d4ac88bdf32224661f239eb121b"
 # checks require shellcheck which isn't packaged (yet)
 options = ["!check"]


### PR DESCRIPTION
I have forked `tessen` because it was archived upstream. I have patched in support for `prs` as a backend and released that as 2.3.0, to go along with #4914.
