### PR TITLE
main/kiconthemes: add qt6-qtsvg dependency

### DIFF
--- a/main/kiconthemes/template.py
+++ b/main/kiconthemes/template.py
@@ -1,6 +1,6 @@
 pkgname = "kiconthemes"
 pkgver = "6.19.0"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # flaky tests when parallel
 make_check_args = ["-j1"]
@@ -23,6 +23,7 @@ makedepends = [
     "qt6-qtsvg-devel",
     "qt6-qttools-devel",
 ]
+depends = ["qt6-qtsvg"]
 pkgdesc = "KDE Icon GUI utilities"
 license = "LGPL-2.1-only"
 url = "https://api.kde.org/frameworks/kiconthemes/html"


### PR DESCRIPTION
## Description

This is necessary for Breeze icons to show up in KDE applications.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
