### PR TITLE
user/nilfs-utils: update to 2.2.12, fix mount helper option parsing

### DIFF
--- a/user/nilfs-utils/template.py
+++ b/user/nilfs-utils/template.py
@@ -1,5 +1,5 @@
 pkgname = "nilfs-utils"
-pkgver = "2.2.11"
+pkgver = "2.2.12"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--without-selinux"]
@@ -18,7 +18,7 @@ pkgdesc = "Userspace utilities for the NILFS filesystem"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://nilfs.sourceforge.io/en/index.html"
 source = f"https://github.com/nilfs-dev/nilfs-utils/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "5172adef1f4a66add0e4e2e733aef82c5b1fc2405473bcd335e516814b5f634f"
+sha256 = "6b6c0fcb3af420532192c96442133e82227012ee991a66788e7e00151ca6ee8a"
 
 
 @subpackage("nilfs-utils-devel")

--- a/user/nilfs-utils/template.py
+++ b/user/nilfs-utils/template.py
@@ -9,6 +9,7 @@ hostmakedepends = [
     "slibtool",
 ]
 makedepends = [
+    "gnu-getopt",
     "linux-headers",
     "util-linux-blkid-devel",
     "util-linux-mount-devel",
@@ -19,6 +20,10 @@ license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://nilfs.sourceforge.io/en/index.html"
 source = f"https://github.com/nilfs-dev/nilfs-utils/archive/refs/tags/v{pkgver}.tar.gz"
 sha256 = "6b6c0fcb3af420532192c96442133e82227012ee991a66788e7e00151ca6ee8a"
+tool_flags = {
+    "CFLAGS": ["-Dgetopt=gnu_getopt"],
+    "LDFLAGS": ["-lgnu_getopt"],
+}
 
 
 @subpackage("nilfs-utils-devel")


### PR DESCRIPTION
## Description

The NILFS2 mount helpers rely on GNU behaviour of getopt to parse
options correctly when invoked by mount. With posix getopt they silently
ignore mount options because mount from util-linux invokes helpers with
non-option arguments before option arguments which posix getopt then
ignores. This fixes it by linking the gnu-getopt compat package. It
could also be fixed by patching getopt_long in place of getopt.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
