### PR TITLE
user/tlpui: update to 1.8.1

### DIFF
--- a/user/tlpui/template.py
+++ b/user/tlpui/template.py
@@ -1,6 +1,6 @@
 pkgname = "tlpui"
-pkgver = "1.8.0"
-pkgrel = 1
+pkgver = "1.8.1"
+pkgrel = 0
 build_style = "python_pep517"
 hostmakedepends = [
     "python-build",
@@ -19,4 +19,4 @@ pkgdesc = "GTK user interface for TLP"
 license = "GPL-2.0-or-later"
 url = "https://github.com/d4nj1/TLPUI"
 source = f"{url}/archive/refs/tags/tlpui-{pkgver}.tar.gz"
-sha256 = "3c1f10ac4a7bbc6041c7e57875457b916f8b312c2988c217bf9d60a19ec636ce"
+sha256 = "658f3dcfa8ea080226dd2ec1419868fe195514aeac2b1ec8f4a8d2a4546ee2de"


### PR DESCRIPTION
## Description

Update `tlpui` to 1.8.1

Changelog from the package official repo:
- Add Italian and Hungarian translation
- Update German and Brazilian translation
- Set Python 3.10 as minimal supported version
- Add Python 3.14 test support
- Update Python dependencies
- Update to Gnome 49
- Fix pkexec admin selection via UI

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
