### PR TITLE
user/kotofetch: new package

### DIFF
--- a/user/kotofetch/template.py
+++ b/user/kotofetch/template.py
@@ -1,0 +1,16 @@
+pkgname = "kotofetch"
+pkgver = "0.2.18"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["rust-std"]
+pkgdesc = "Small, configurable CLI that displays Japanese quotes in the terminal"
+license = "MIT"
+url = "https://github.com/hxpe-dev/kotofetch"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "a1dc9ea996b4f026965c7413f1b7ec17abbd1e5108bd839da8e0fb4419f32399"
+# no tests
+options = ["!check"]
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

`kotofetch` is a small, configurable CLI that displays Japanese quotes in the terminal. It comes with built-in quotes and allows users to customize display options such as padding, width, translation display, and text styles.

https://github.com/hxpe-dev/kotofetch

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
