### PR TITLE
user/git-cliff: disable update-informer

### DIFF
--- a/user/git-cliff/template.py
+++ b/user/git-cliff/template.py
@@ -1,8 +1,14 @@
 pkgname = "git-cliff"
 pkgver = "2.10.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
+make_build_args = [
+    "--no-default-features",
+    "--features=integrations",
+]
+make_install_args = [*make_build_args]
 make_check_args = [
+    *make_build_args,
     "--",
     "--skip=repo::test::commit_search",
     "--skip=repo::test::get_latest_commit",


### PR DESCRIPTION
## Description

`update-informer` duplicates the job of update check scripts, so it's redundant for distro packages.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
