### PR TITLE
main/sqlite: update to 3.51.0, enable .recover command in cli

### DIFF
--- a/main/sqlite/template.py
+++ b/main/sqlite/template.py
@@ -1,6 +1,6 @@
 pkgname = "sqlite"
-pkgver = "3.50.4"
-_amalg = "3500400"
+pkgver = "3.51.0"
+_amalg = "3510000"
 pkgrel = 0
 build_style = "configure"
 configure_args = [
@@ -19,7 +19,7 @@ pkgdesc = "SQL Database Engine in a C library"
 license = "blessing"
 url = "https://sqlite.org"
 source = f"https://sqlite.org/2025/sqlite-autoconf-{_amalg}.tar.gz"
-sha256 = "a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18"
+sha256 = "42e26dfdd96aa2e6b1b1be5c88b0887f9959093f650d693cb02eb9c36d146ca5"
 # no tests
 options = ["!parallel", "!check"]
 

--- a/main/sqlite/template.py
+++ b/main/sqlite/template.py
@@ -1,7 +1,7 @@
 pkgname = "sqlite"
 pkgver = "3.51.0"
 _amalg = "3510000"
-pkgrel = 0
+pkgrel = 1
 build_style = "configure"
 configure_args = [
     "--prefix=/usr",
@@ -45,12 +45,26 @@ _cflags = [
     "-DSQLITE_SECURE_DELETE",
 ]
 
+# compile the cli with DBPAGE to get .recover command
+# not enabled globally for security reasons: sqlite.org/dbpage.html
+_extra_cflags_cli = ["-DSQLITE_ENABLE_DBPAGE_VTAB"]
+
 if self.profile().endian == "big":
     _cflags += ["-DSHA3_BYTEORDER=4321", "-DSQLITE_BYTEORDER=4321"]
 else:
     _cflags += ["-DSHA3_BYTEORDER=1234", "-DSQLITE_BYTEORDER=1234"]
 
 tool_flags = {"CFLAGS": _cflags}
+
+
+def build(self):
+    self.make.build(["libsqlite3.so", "libsqlite3.a"])
+    self.make.build(
+        [
+            "sqlite3",
+            f'CFLAGS="{" ".join(_extra_cflags_cli)}"',
+        ]
+    )
 
 
 @subpackage("sqlite-devel")


### PR DESCRIPTION
## Description

The ".recover" command allows you to attempt to recover data from
corrupted database files in situations where other commands like ".dump"
would not help.

Enabling .recover requires enabling the DBPAGE virtual table which is
dangerous and has security implications so this patch compiles the cli
with DBPAGE and the library without. The upstream binary releases of the
cli are also compiled with DBPAGE enabled, and the library without.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
