### PR TITLE
cbuild: refer to bootstrap instead of binary-bootstrap in hint

### DIFF
--- a/src/cbuild/core/chroot.py
+++ b/src/cbuild/core/chroot.py
@@ -29,7 +29,7 @@ def set_host(tgt):
 def _chroot_check(error):
     if error and not _chroot_ready:
         raise errors.CbuildException(
-            "working bldroot is required for this step (try binary-bootstrap)"
+            "working bldroot is required for this step (try bootstrap)"
         )
     return _chroot_ready
 


### PR DESCRIPTION
is shorter