### PR TITLE
main/shadow: update gnome login keyring with passwd

### DIFF
--- a/main/shadow/files/passwd.pam
+++ b/main/shadow/files/passwd.pam
@@ -1,1 +1,2 @@
 password	required	pam_unix.so	sha512 shadow nullok
+password	optional	pam_gnome_keyring.so


### PR DESCRIPTION
## Description

`passwd` does not currently update the gnome login keyring

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine