### PR TITLE
user/esbuild: new package

### DIFF
--- a/user/esbuild/template.py
+++ b/user/esbuild/template.py
@@ -1,0 +1,15 @@
+pkgname = "esbuild"
+pkgver = "0.27.2"
+pkgrel = 0
+build_style = "go"
+make_build_args = ["./cmd/esbuild"]
+hostmakedepends = ["go"]
+pkgdesc = "JavaScript and CSS bundler and minifier"
+license = "MIT"
+url = "https://esbuild.github.io"
+source = f"https://github.com/evanw/esbuild/archive/v{pkgver}.tar.gz"
+sha256 = "d16527a0b29c747d80afaa1cd362d7eee5814c0569af6cc2080e7343482b28d2"
+
+
+def post_install(self):
+    self.install_license("LICENSE.md")


### PR DESCRIPTION
## Description

Adds `esbuild`, which is a bundler for JavaScript, TypeScript, CSS and more. It is used for bundling assets for web projects into artefacts for publishing, performing transformations and optimisations in the process.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
