### PR TITLE
main/haproxy: update to 3.2.8

### DIFF
--- a/main/haproxy/template.py
+++ b/main/haproxy/template.py
@@ -1,5 +1,5 @@
 pkgname = "haproxy"
-pkgver = "3.2.7"
+pkgver = "3.2.8"
 pkgrel = 0
 build_style = "makefile"
 make_build_args = [
@@ -41,7 +41,7 @@ url = "https://www.haproxy.org"
 source = (
     f"{url}/download/{pkgver[: pkgver.rfind('.')]}/src/haproxy-{pkgver}.tar.gz"
 )
-sha256 = "1f0ae9dfb0b319e2d5cb6e4cdf931a0877ad88e0090c46cf16faf008fbf54278"
+sha256 = "46703fb94720f92cce2b08049a40d9176962037ba676885c55a56bd9d625e7c2"
 hardening = ["!vis", "!cfi", "!int"]
 # hard depends on vtest which doesn't have releases
 options = ["!check"]


### PR DESCRIPTION
## Description

updated haproxy to 3.2.8

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine