### PR TITLE
main/dinit: update to 0.20.0

### DIFF
--- a/main/dinit/template.py
+++ b/main/dinit/template.py
@@ -1,22 +1,19 @@
 pkgname = "dinit"
-pkgver = "0.19.3"
-# temporary so we get our features
-_gitrev = "712e1faa6e2faeb4e56d925334266976904096e9"
+pkgver = "0.20.0"
 pkgrel = 0
 build_style = "configure"
 configure_args = [
     "--sbindir=/usr/bin",
     "--syscontrolsocket=/run/dinitctl",
-    "LDFLAGS_EXTRA=-lcap",
-    "TEST_LDFLAGS_EXTRA=-lcap",
+    "--platform=Linux",
 ]
 make_check_args = ["check-igr"]  # additional target
 makedepends = ["libcap-devel"]
 pkgdesc = "Service manager and init system"
 license = "Apache-2.0"
 url = "https://davmac.org/projects/dinit"
-source = f"https://github.com/davmac314/dinit/archive/{_gitrev}.tar.gz"
-sha256 = "a1595c201ccaaa1af509221eefd20f8abd3f4a00c50e2184851e2fba606b53fb"
+source = f"https://github.com/davmac314/dinit/archive/v{pkgver}.tar.gz"
+sha256 = "cd75b572a2eab4a9bd0610a2bb8cc154da7e80074e61cb1059a996dfd977baae"
 # hand-rolled configure scripts/makefiles lol
 tool_flags = {"CXXFLAGS": ["-fno-rtti"]}
 hardening = ["vis", "cfi"]


### PR DESCRIPTION
## Description

Update to latest release. Also drop manual libcap link flags as auto libcap detection is fixed when providing custom LDFLAGS in this new release and also explicitly specify platform for configure to avoid 'unknown' platform in cross-builds.

@q66 I hope I can help for maintaining Dinit in Chimera Linux if you think having another person for maintaining Dinit related stuff is helpful.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements) (Mostly I hope I didn't miss anything important for this change)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
