### PR TITLE
user/halloy: update to 2025.11

### DIFF
--- a/user/halloy/template.py
+++ b/user/halloy/template.py
@@ -1,5 +1,5 @@
 pkgname = "halloy"
-pkgver = "2025.9"
+pkgver = "2025.11"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = [
@@ -18,7 +18,9 @@ pkgdesc = "IRC client"
 license = "GPL-3.0-or-later"
 url = "https://halloy.chat"
 source = f"https://github.com/squidowl/halloy/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "ac907172069035ab3058675f32a6c33419a8d77a5f8b5cfdae19f0ebf769a68e"
+sha256 = "19546fb2c49ea342e39c38b6771536089b16892b8de6ae4e4a09e4f25db3cd1b"
+# no tests in top-level project
+options = ["!check"]
 
 if self.profile().arch in ["loongarch64", "ppc", "ppc64", "ppc64le", "riscv64"]:
     broken = "ring 0.16.20 fails to build"


### PR DESCRIPTION
I disabled `check`. The check build takes ages to finish, but there's no actual tests to run at the end:

```
    Finished `test` profile [optimized + debuginfo] target(s) in 5m 48s
     Running unittests src/main.rs (target/x86_64-chimera-linux-musl/debug/deps/halloy-2eacedac0c7ccb25)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
