### PR TITLE
user/mollysocket: new package

### DIFF
--- a/src/cbuild/util/golang.py
+++ b/src/cbuild/util/golang.py
@@ -6,6 +6,7 @@ def get_go_env(pkg):
         pkg.error("unknown architecture for golang")
 
     env = {
+        "GOCACHE": "/cbuild_cache/golang/cache",
         "GOMODCACHE": "/cbuild_cache/golang/pkg/mod",
         "GOARCH": pkg.profile().goarch,
         "CGO_CFLAGS": pkg.get_cflags(shell=True),

--- a/user/mollysocket/files/mollysocket
+++ b/user/mollysocket/files/mollysocket
@@ -1,0 +1,7 @@
+# mollysocket webserver service
+
+type = process
+command = /usr/bin/mollysocket server
+run-as = _molly
+log-type = buffer
+depends-on: network.target

--- a/user/mollysocket/files/sysusers.conf
+++ b/user/mollysocket/files/sysusers.conf
@@ -1,0 +1,3 @@
+# Create mollysocket system user
+
+u _molly - "mollysocket user" /var/lib/mollysocket /usr/bin/nologin

--- a/user/mollysocket/files/tmpfiles.conf
+++ b/user/mollysocket/files/tmpfiles.conf
@@ -1,0 +1,3 @@
+# Create mollysocket state directory
+
+d /var/lib/mollysocket 0755 _molly _molly

--- a/user/mollysocket/template.py
+++ b/user/mollysocket/template.py
@@ -1,0 +1,27 @@
+pkgname = "mollysocket"
+pkgver = "1.7.1"
+pkgrel = 0
+build_style = "cargo"
+make_check_args = [
+    "--",
+    "--skip=config::tests::check_wildcard_endpoint",
+    "--skip=utils::post_allowed::tests::test_allowed",
+    "--skip=utils::post_allowed::tests::test_post",
+    "--skip=ws::tls::tests::connect_untrusted_server",
+    "--skip=ws::tls::tests::connect_trusted_server",
+]
+hostmakedepends = ["cargo-auditable", "pkgconf"]
+makedepends = ["dinit-chimera", "openssl3-devel", "rust-std", "sqlite-devel"]
+pkgdesc = "Get UnifiedPush notifications on Molly"
+license = "AGPL-3.0-only"
+url = "https://github.com/mollyim/mollysocket"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "b380faf8ca526e92bcbc121d8ac35b88945a6f62b4602dea0df6f7c1f6bfaac7"
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/mollysocket")
+    self.install_sysusers(self.files_path / "sysusers.conf")
+    self.install_tmpfiles(self.files_path / "tmpfiles.conf")
+    self.install_service(self.files_path / "mollysocket")
+    self.install_license("LICENSE.txt")


### PR DESCRIPTION
## Description

Added [mollysocket](https://github.com/mollyim/mollysocket), which can be used to send UnifiedPush notifications in coordination with a UnifiedPush distributor app, like ntfy, to the Molly-FOSS app on Android, a fork of Signal

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
