### PR TITLE
user/units: new package

### DIFF
--- a/user/units/template.py
+++ b/user/units/template.py
@@ -7,10 +7,8 @@ hostmakedepends = [
     "pkgconf",
 ]
 makedepends = [
+    "python",
     "readline-devel",
-]
-checkdepends = [
-    "python-requests",
 ]
 depends = [
     "python-requests",
@@ -20,3 +18,4 @@ license = "GPL-3.0-or-later"
 url = "https://www.gnu.org/software/units"
 source = f"http://ftp.gnu.org/gnu/units/units-{pkgver}.tar.gz"
 sha256 = "1e502c4edfacf20b29284716c72e5ddb51a495a2365d7b03e7960494c4a0c902"
+hardening = ["vis", "cfi"]

--- a/user/units/template.py
+++ b/user/units/template.py
@@ -1,0 +1,22 @@
+pkgname = "units"
+pkgver = "2.24"
+pkgrel = 0
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+    "pkgconf",
+]
+makedepends = [
+    "readline-devel",
+]
+checkdepends = [
+    "python-requests",
+]
+depends = [
+    "python-requests",
+]
+pkgdesc = "Units conversion and calculation program"
+license = "GPL-3.0-or-later"
+url = "https://www.gnu.org/software/units"
+source = f"http://ftp.gnu.org/gnu/units/units-{pkgver}.tar.gz"
+sha256 = "1e502c4edfacf20b29284716c72e5ddb51a495a2365d7b03e7960494c4a0c902"


### PR DESCRIPTION
## Description

New package: units, a pretty useful unit converter and calculator. 

python is set as a make dep because the configure script checks if it's installed to determine whether to install units_cur. It is not actually used during the make phase though.

The check phase wants network access for part of it, but the rest of the checking succeeds and it passes ok without network, so I left it enabled, not sure if this is desirable or not.

## Checklist
- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
- [X] I will take responsibility for my template and keep it up to date
