### PR TITLE
main/haproxy: update to 3.4.2

### DIFF
--- a/main/haproxy-cli-scripts
+++ b/main/haproxy-cli-scripts
@@ -1,0 +1,1 @@
+haproxy

--- a/main/haproxy/patches/cflags.patch
+++ b/main/haproxy/patches/cflags.patch
@@ -1,22 +1,20 @@
-diff --git a/Makefile b/Makefile
-index 71a82dd7b..01fdd331c 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1048,7 +1048,7 @@ else
  endif # non-empty target
- 
+
  haproxy: $(OPTIONS_OBJS) $(OBJS)
 -	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
 +	$(cmd_LD) $(COPTS) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
- 
+
  objsize: haproxy
  	$(Q)objdump -t $^|grep ' g '|grep -F '.text'|awk '{print $$5 FS $$6}'|sort
 @@ -1057,7 +1057,7 @@ objsize: haproxy
  	$(cmd_CC) $(COPTS) -c -o $@ $<
- 
+
  admin/halog/halog: admin/halog/halog.o admin/halog/fgets2.o src/ebtree.o src/eb32tree.o src/eb64tree.o src/ebmbtree.o src/ebsttree.o src/ebistree.o src/ebimtree.o
 -	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
 +	$(cmd_LD) $(COPTS) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
- 
+
  admin/dyncookie/dyncookie: admin/dyncookie/dyncookie.o
  	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)

--- a/main/haproxy/patches/cflags.patch
+++ b/main/haproxy/patches/cflags.patch
@@ -1,22 +1,33 @@
-diff --git a/Makefile b/Makefile
-index 71a82dd7b..01fdd331c 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1048,7 +1048,7 @@ else
+@@ -1009,28 +1009,30 @@ else
+ .build_opts:
+ endif # ignore_opts
+ else
+ .build_opts:
  endif # non-empty target
- 
+
  haproxy: $(OPTIONS_OBJS) $(OBJS)
--	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+ 	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
 +	$(cmd_LD) $(COPTS) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
- 
+
+ haterm: $(OPTIONS_OBJS) $(HATERM_OBJS)
+ 	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+
  objsize: haproxy
  	$(Q)objdump -t $^|grep ' g '|grep -F '.text'|awk '{print $$5 FS $$6}'|sort
-@@ -1057,7 +1057,7 @@ objsize: haproxy
+
+ %.o:	%.c $(DEP)
  	$(cmd_CC) $(COPTS) -c -o $@ $<
- 
+
  admin/halog/halog: admin/halog/halog.o admin/halog/fgets2.o src/ebtree.o src/eb32tree.o src/eb64tree.o src/ebmbtree.o src/ebsttree.o src/ebistree.o src/ebimtree.o
--	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+ 	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
 +	$(cmd_LD) $(COPTS) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
- 
+
  admin/dyncookie/dyncookie: admin/dyncookie/dyncookie.o
  	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+
+ dev/flags/flags: dev/flags/flags.o
+ 	$(cmd_LD) $(ARCH_FLAGS) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+
+ dev/gdb/libs-from-core: dev/gdb/libs-from-core.o

--- a/main/haproxy/patches/readiness.patch
+++ b/main/haproxy/patches/readiness.patch
@@ -1,24 +1,35 @@
-diff --git a/doc/haproxy.1 b/doc/haproxy.1
-index 4c2d78677..26f19f9e9 100644
 --- a/doc/haproxy.1
 +++ b/doc/haproxy.1
-@@ -85,7 +85,7 @@ mode.
- 
+@@ -80,17 +80,17 @@ Start in daemon mode.
+
+ .TP
+ \fB\-W\fP
+ Start in master-worker mode. Could be used either with foreground or daemon
+ mode.
+
  .TP
  \fB\-Ws\fP
 -Start in master-worker mode with systemd notify support. It tells systemd when
 +Start in master-worker mode with fd notify support. It tells dinit when
  the process is ready. This mode forces foreground.
- 
+
  .TP
-diff --git a/src/cli.c b/src/cli.c
-index 83d58f238..d4f2142ad 100644
+ \fB\-q\fP
+ Disable messages on output.
+
+ .TP
+ \fB\-V\fP
 --- a/src/cli.c
 +++ b/src/cli.c
-@@ -2648,8 +2648,16 @@ static int _send_status(char **args, char *payload, struct appctx *appctx, void
+@@ -2644,18 +2644,26 @@ static int _send_status(char **args, char *payload, struct appctx *appctx, void
+ 		}
+ 		close(daemon_fd[1]);
+ 		daemon_fd[1] = -1;
+ 	}
+
  	load_status = 1;
  	ha_notice("Loading success.\n");
- 
+
 -	if (global.tune.options & GTUNE_USE_SYSTEMD)
 -		sd_notifyf(0, "READY=1\nMAINPID=%lu\nSTATUS=Ready.\n", (unsigned long)getpid());
 +	if (global.tune.options & GTUNE_USE_SYSTEMD) {
@@ -31,14 +42,22 @@ index 83d58f238..d4f2142ad 100644
 +			}
 +		}
 +	}
- 
+
  	mworker_unblock_signals();
- 
-diff --git a/src/mworker.c b/src/mworker.c
-index 33b2318da..94641f1ba 100644
+
+ 	/* master and worker have successfully started, now we can set quiet mode
+ 	 * if MODE_DAEMON
+ 	 */
+ 	if ((!(global.mode & MODE_QUIET) || (global.mode & MODE_VERBOSE)) &&
+ 		(global.mode & MODE_DAEMON)) {
 --- a/src/mworker.c
 +++ b/src/mworker.c
-@@ -531,10 +531,13 @@ static void mworker_on_new_child_failure(int exitpid, int status)
+@@ -532,20 +532,23 @@ static void mworker_on_new_child_failure(int exitpid, int status)
+ 	}
+
+ 	/* do not keep unused FDs retrieved from the previous process */
+ 	sock_drop_unused_old_sockets();
+
  	usermsgs_clr(NULL);
  	load_status = 0;
  	ha_warning("Failed to load worker (%d) exited with code %d (%s)\n", exitpid, status, (status >= 128) ? strsignal(status - 128): "Exit");
@@ -51,6 +70,11 @@ index 33b2318da..94641f1ba 100644
  	if (global.tune.options & GTUNE_USE_SYSTEMD)
  		sd_notify(0, "READY=1\nSTATUS=Reload failed!\n");
 +	#endif
- }
- 
- /*
+
+ 	/* call a task to unblock the signals from outside the sig handler */
+ 	if ((t = task_new_here()) == NULL) {
+ 		ha_warning("Can't restore HAProxy signals!\n");
+ 		return;
+ 	}
+
+ 	t->process = mworker_task_child_failure;

--- a/main/haproxy/template.py
+++ b/main/haproxy/template.py
@@ -1,11 +1,12 @@
 pkgname = "haproxy"
-pkgver = "3.2.9"
+pkgver = "3.3.8"
 pkgrel = 0
 build_style = "makefile"
 make_build_args = [
     "EXTRA=admin/halog/halog",
     "TARGET=linux-musl",
     "USE_GETADDRINFO=1",
+    "USE_KTLS=1",
     "USE_LUA=1",
     "USE_NS=1",
     "USE_OPENSSL=1",
@@ -14,19 +15,15 @@ make_build_args = [
     "USE_PROMEX=1",
     "USE_PTHREAD_EMULATION=1",
     "USE_QUIC=1",
-    "USE_QUIC_OPENSSL_COMPAT=1",
+    "USE_SHM_OPEN=1",
     "USE_ZLIB=1",
     "V=1",
 ]
 make_install_args = [
     "EXTRA=admin/halog/halog",
     "SBINDIR=/usr/bin",
-    "DOCDIR=/usr/share/doc/haproxy",
 ]
-make_check_target = "reg-tests"
-hostmakedepends = [
-    "pkgconf",
-]
+hostmakedepends = ["pkgconf"]
 makedepends = [
     "dinit-chimera",
     "linux-headers",
@@ -41,7 +38,8 @@ url = "https://www.haproxy.org"
 source = (
     f"{url}/download/{pkgver[: pkgver.rfind('.')]}/src/haproxy-{pkgver}.tar.gz"
 )
-sha256 = "e660d141b29019f4d198785b0834cc3e9c96efceeb807c2fff2fc935bd3354c2"
+sha256 = "89b1fe73d54d5990f74997da837f5fd0da1627a1baa62b26f5d358a6f3c48295"
+# builds successfully but fails to run if enabled
 hardening = ["!vis", "!cfi", "!int"]
 # hard depends on vtest which doesn't have releases
 options = ["!check"]
@@ -54,8 +52,16 @@ def init_build(self):
 def post_install(self):
     self.install_file(self.files_path / "haproxy.cfg", "etc/haproxy")
     self.install_files("examples", "usr/share/haproxy")
-    self.install_files("doc", "usr/share/haproxy")
+    self.uninstall("usr/doc/haproxy")
     self.install_sysusers(self.files_path / "sysusers.conf")
     self.install_tmpfiles(self.files_path / "tmpfiles.conf")
     self.install_service(self.files_path / "haproxy")
     self.install_license("LICENSE")
+
+
+@subpackage("haproxy-cli-scripts")
+def _(self):
+    self.subdesc = "administration bash scripts"
+    self.depends = [self.parent, "bash"]
+    self.install_if = [self.parent, "bash"]
+    return ["cmd:haproxy-dump-certs", "cmd:haproxy-reload"]

--- a/main/haproxy/template.py
+++ b/main/haproxy/template.py
@@ -1,11 +1,12 @@
 pkgname = "haproxy"
-pkgver = "3.2.9"
+pkgver = "3.4.2"
 pkgrel = 0
 build_style = "makefile"
 make_build_args = [
     "EXTRA=admin/halog/halog",
     "TARGET=linux-musl",
     "USE_GETADDRINFO=1",
+    "USE_KTLS=1",
     "USE_LUA=1",
     "USE_NS=1",
     "USE_OPENSSL=1",
@@ -14,23 +15,19 @@ make_build_args = [
     "USE_PROMEX=1",
     "USE_PTHREAD_EMULATION=1",
     "USE_QUIC=1",
-    "USE_QUIC_OPENSSL_COMPAT=1",
+    "USE_SHM_OPEN=1",
     "USE_ZLIB=1",
     "V=1",
 ]
 make_install_args = [
     "EXTRA=admin/halog/halog",
     "SBINDIR=/usr/bin",
-    "DOCDIR=/usr/share/doc/haproxy",
 ]
-make_check_target = "reg-tests"
-hostmakedepends = [
-    "pkgconf",
-]
+hostmakedepends = ["pkgconf"]
 makedepends = [
     "dinit-chimera",
     "linux-headers",
-    "lua5.4-devel",
+    "lua5.5-devel",
     "openssl3-devel",
     "pcre2-devel",
     "zlib-ng-compat-devel",
@@ -41,7 +38,8 @@ url = "https://www.haproxy.org"
 source = (
     f"{url}/download/{pkgver[: pkgver.rfind('.')]}/src/haproxy-{pkgver}.tar.gz"
 )
-sha256 = "e660d141b29019f4d198785b0834cc3e9c96efceeb807c2fff2fc935bd3354c2"
+sha256 = "b1330dbb0d6e6bc4a72c4708a6a9e585579cd1156dfe5763c26305105bc12907"
+# builds successfully but fails to run if enabled
 hardening = ["!vis", "!cfi", "!int"]
 # hard depends on vtest which doesn't have releases
 options = ["etcfiles", "!check"]
@@ -54,8 +52,16 @@ def init_build(self):
 def post_install(self):
     self.install_file(self.files_path / "haproxy.cfg", "etc/haproxy")
     self.install_files("examples", "usr/share/haproxy")
-    self.install_files("doc", "usr/share/haproxy")
+    self.uninstall("usr/doc/haproxy")
     self.install_sysusers(self.files_path / "sysusers.conf")
     self.install_tmpfiles(self.files_path / "tmpfiles.conf")
     self.install_service(self.files_path / "haproxy")
     self.install_license("LICENSE")
+
+
+@subpackage("haproxy-cli-scripts")
+def _(self):
+    self.subdesc = "administration bash scripts"
+    self.depends = [self.parent, "bash"]
+    self.install_if = [self.parent, "bash"]
+    return ["cmd:haproxy-dump-certs", "cmd:haproxy-reload"]


### PR DESCRIPTION
## Description

updated haproxy to 3.4.2

- enabled `KTLS` and `SHM_OPEN`, new options in 3.3.0, SHM_OPEN is used for the [`shm_stats_file` feature](https://www.haproxy.com/blog/announcing-haproxy-3-3#persistent-stats)
- `QUIC_OPENSSL_COMPAT` is no longer needed according to build logs
- removed documentation installation
- removed check target declaration since tests are disabled
- replaced lua 5.4 with lua 5.5 introduced in haproxy 3.4.0

I made a subpackage for installing the `haproxy-reload` and `haproxy-dump-certs` experimental *bash* scripts added upstream. If I should instead add `depends = ["bash"]` and not make a subpackage, please let me know. 

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
