### PR TITLE
user/libp11: new package (0.4.16)

### DIFF
--- a/user/libp11/template.py
+++ b/user/libp11/template.py
@@ -1,0 +1,19 @@
+pkgname = "libp11"
+pkgver = "0.4.16"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = ["--disable-static"]
+hostmakedepends = ["pkgconf", "automake", "libtool"]
+makedepends = ["openssl3-devel", "pkcs11-helper-devel"]
+pkgdesc = "Library implementing a small layer between OpenSSL and PKCS#11"
+license = "LGPL-2.1-or-later"
+url = "https://github.com/OpenSC/libp11"
+source = f"{url}/releases/download/{pkgname}-{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "97777640492fa9e5831497e5892e291dfbf39a7b119d9cb6abb3ec8c56d17553"
+# test suite requires softhsm which is not in repo
+options = ["!check"]
+
+
+@subpackage("libp11-devel")
+def _(self):
+    return self.default_devel()


### PR DESCRIPTION
## Description

libp11 is a new prerequisite library for the Nextcloud Desktop Client.

PKCS#11 wrapper that allows it to securely access cryptographic tokens (like smart cards) for authentication and encryption,

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [ x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [x ] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
