### PR TITLE
cbuild: use GIT_CONFIG_{GLOBAL,SYSTEM} to ignore global and system gitconfigs

### DIFF
--- a/src/cbuild/core/git.py
+++ b/src/cbuild/core/git.py
@@ -1,14 +1,16 @@
 # silly wrapper around git so we can ignore ~/.gitconfig as needed
 
+import os
 import subprocess
 
 
 def call(args, gitconfig=False, foreground=False, cwd=None):
-    if gitconfig:
-        bcmd = ["git"]
-    else:
-        # still use the rest of the environment
-        bcmd = ["env", "-u", "HOME", "--", "git"]
+    if not gitconfig:
+        env = os.environ
+        env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+
+    bcmd = ["git"]
 
     ret = subprocess.run(bcmd + args, capture_output=not foreground, cwd=cwd)
 

--- a/src/early.py
+++ b/src/early.py
@@ -15,8 +15,11 @@ def fire():
     if not shutil.which("git"):
         sys.exit("Git is required")
 
+    env = os.environ
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
     # additionally cports must be a git repo
-    rcmd = ["env", "-u", "HOME", "git", "rev-parse", "--is-inside-work-tree"]
+    rcmd = ["git", "rev-parse", "--is-inside-work-tree"]
     if subprocess.run(rcmd, capture_output=True).returncode != 0:
         sys.exit("You have to run cbuild from a git clone")
 


### PR DESCRIPTION
Suggested-by: pj

## Description

This patch ignores system and global gitconfigs using `GIT_CONFIG_{GLOBAL,SYSTEM}` instead of unsetting `HOME`. Unsetting `HOME` would cause cbuild's Git repository check to error when the user includes a path in their gitconfig that uses `HOME`.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)

The following must be true for template/package changes:

- [ ] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date

Closes  #5427
