### PR TITLE
user/fht-compositor: new package

### DIFF
--- a/user/fht-compositor/patches/no-session.patch
+++ b/user/fht-compositor/patches/no-session.patch
@@ -1,0 +1,13 @@
+the -session wrapper is a systemd script, use the normal session startup that
+imports envs itself
+--
+--- a/res/systemd/fht-compositor.desktop
++++ b/res/systemd/fht-compositor.desktop
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=fht-compositor
+ Comment=A dynamic tiling Wayland compositor
+-Exec=fht-compositor-session
++Exec=/usr/bin/fht-compositor --session
+ Type=Application
+ DesktopNames=fht-compositor

--- a/user/fht-compositor/template.py
+++ b/user/fht-compositor/template.py
@@ -1,0 +1,40 @@
+pkgname = "fht-compositor"
+pkgver = "25.10.1"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = [
+    "cargo-auditable",
+    "pkgconf",
+]
+makedepends = [
+    "libdisplay-info-devel",
+    "libinput-devel",
+    "libseat-devel",
+    "libxkbcommon-devel",
+    "mesa-devel",
+    "pipewire-devel",
+    "pixman-devel",
+    "rust-std",
+    "udev-devel",
+]
+depends = ["so:libEGL.so.1!mesa-egl-libs", "xwayland-satellite"]
+pkgdesc = "Dynamic tiling Wayland compositor"
+license = "GPL-3.0-only"
+url = "https://github.com/nferhat/fht-compositor"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "6ed6816a8e003b2d0b1675475bd73f5da14e5c6bd255573f7e7c154acd9adb46"
+hardening = ["vis", "cfi"]
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/fht-compositor")
+    self.install_license("LICENSE")
+    self.install_file(
+        "res/systemd/fht-compositor.desktop", "usr/share/wayland-sessions"
+    )
+    self.install_file(
+        "res/fht-compositor.portal", "usr/share/xdg-desktop-portal/portals"
+    )
+    self.install_file(
+        "res/fht-compositor-portals.conf", "usr/share/xdg-desktop-portal"
+    )


### PR DESCRIPTION
## Description

fht-compositor is a dynamic tiling Wayland compositor based on the [Smithay](https://github.com/smithay) compositor library. It has a layout model inspired by popular X11 window managers such as [DWM](https://dwm.suckless.org/), [AwesomeWM](https://awesomewm.org/) and [XMonad](https://xmonad.org/). Each connected output has 9 workspaces, each workspace managing a bunch of windows.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
