### PR TITLE
main/tree-sitter, main/tree-sitter-{cli,markdown,vimdoc,query}: update

### DIFF
--- a/main/tree-sitter-cli/template.py
+++ b/main/tree-sitter-cli/template.py
@@ -1,6 +1,6 @@
 pkgname = "tree-sitter-cli"
 # match to tree-sitter
-pkgver = "0.25.8"
+pkgver = "0.25.10"
 pkgrel = 0
 build_style = "cargo"
 make_build_args = ["-p", "tree-sitter-cli"]
@@ -11,7 +11,7 @@ pkgdesc = "Parser generator tool for tree-sitter bindings"
 license = "MIT"
 url = "https://tree-sitter.github.io/tree-sitter"
 source = f"https://github.com/tree-sitter/tree-sitter/archive/v{pkgver}.tar.gz"
-sha256 = "178b575244d967f4920a4642408dc4edf6de96948d37d7f06e5b78acee9c0b4e"
+sha256 = "ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c"
 # requires fetching fixtures
 options = ["!check"]
 

--- a/main/tree-sitter-lua/template.py
+++ b/main/tree-sitter-lua/template.py
@@ -1,5 +1,5 @@
 pkgname = "tree-sitter-lua"
-pkgver = "0.4.0"
+pkgver = "0.4.1"
 pkgrel = 0
 build_style = "makefile"
 make_check_target = "test"
@@ -11,7 +11,7 @@ pkgdesc = "Lua grammar for tree-sitter"
 license = "MIT"
 url = "https://github.com/tree-sitter-grammars/tree-sitter-lua"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "b0977aced4a63bb75f26725787e047b8f5f4a092712c840ea7070765d4049559"
+sha256 = "cef44b8773bde69d427b5e50ca95e417c86c0be91caa37a6782c90d6f529da70"
 
 
 def post_install(self):

--- a/main/tree-sitter-markdown/template.py
+++ b/main/tree-sitter-markdown/template.py
@@ -1,5 +1,5 @@
 pkgname = "tree-sitter-markdown"
-pkgver = "0.5.0"
+pkgver = "0.5.1"
 pkgrel = 0
 build_style = "makefile"
 make_check_target = "test"
@@ -12,7 +12,7 @@ pkgdesc = "Markdown grammar for tree-sitter"
 license = "MIT"
 url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "14c2c948ccf0e9b606eec39b09286c59dddf28307849f71b7ce2b1d1ef06937e"
+sha256 = "acaffe5a54b4890f1a082ad6b309b600b792e93fc6ee2903d022257d5b15e216"
 
 
 def configure(self):

--- a/main/tree-sitter-query/template.py
+++ b/main/tree-sitter-query/template.py
@@ -1,5 +1,5 @@
 pkgname = "tree-sitter-query"
-pkgver = "0.6.2"
+pkgver = "0.8.0"
 pkgrel = 0
 build_style = "makefile"
 make_check_target = "test"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 url = "https://github.com/tree-sitter-grammars/tree-sitter-query"
 source = [
     f"{url}/archive/refs/tags/v{pkgver}.tar.gz",
-    "https://github.com/nvim-treesitter/nvim-treesitter/archive/9866036ec3c5db40700a9178494e0cfdcfe6ecfd.tar.gz",
-    "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/archive/71385f191ec06ffc60e80e6b0c9a9d5daed4824c.tar.gz",
+    "https://github.com/nvim-treesitter/nvim-treesitter/archive/42fc28ba918343ebfd5565147a42a26580579482.tar.gz",
+    "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/archive/5ca4aaa6efdcc59be46b95a3e876300cfead05ef.tar.gz",
 ]
 source_paths = [
     ".",
@@ -21,9 +21,9 @@ source_paths = [
     ".tests/nvim-treesitter-textobjects",
 ]
 sha256 = [
-    "90682e128d048fbf2a2a17edca947db71e326fa0b3dba4136e041e096538b4eb",
-    "e5d345447a560d50e8e926a657c772060b17665cf34ba296d413af46e3411c00",
-    "ff6435187774f11f846420de3a982d754c105c86cbab0cb1bd76384eb209bbfd",
+    "c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d",
+    "91c764237034be845648581b39e76f197a38b93e41199055400e2851076a1498",
+    "c38279bbfedd4a1859d5f3ebdb8641201b3140365c197b68d8a9be092ef7b686",
 ]
 
 

--- a/main/tree-sitter-vimdoc/template.py
+++ b/main/tree-sitter-vimdoc/template.py
@@ -1,5 +1,5 @@
 pkgname = "tree-sitter-vimdoc"
-pkgver = "4.0.0"
+pkgver = "4.1.0"
 pkgrel = 0
 build_style = "makefile"
 make_check_target = "test"
@@ -11,7 +11,7 @@ pkgdesc = "Vimdoc grammar for tree-sitter"
 license = "Apache-2.0"
 url = "https://github.com/neovim/tree-sitter-vimdoc"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "8096794c0f090b2d74b7bff94548ac1be3285b929ec74f839bd9b3ff4f4c6a0b"
+sha256 = "020e8f117f648c8697fca967995c342e92dbd81dab137a115cc7555207fbc84f"
 
 
 def post_install(self):

--- a/main/tree-sitter/template.py
+++ b/main/tree-sitter/template.py
@@ -1,6 +1,6 @@
 pkgname = "tree-sitter"
 # match to tree-sitter-cli
-pkgver = "0.25.8"
+pkgver = "0.25.10"
 pkgrel = 0
 build_style = "makefile"
 hostmakedepends = ["pkgconf"]
@@ -8,7 +8,7 @@ pkgdesc = "Incremental parsing library for language grammars"
 license = "MIT"
 url = "https://tree-sitter.github.io/tree-sitter"
 source = f"https://github.com/tree-sitter/tree-sitter/archive/v{pkgver}.tar.gz"
-sha256 = "178b575244d967f4920a4642408dc4edf6de96948d37d7f06e5b78acee9c0b4e"
+sha256 = "ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c"
 # check requires cargo/fixture stuff (from remote repositories)
 options = ["!check"]
 


### PR DESCRIPTION
## Description

updated tree-sitter packages

The primary tree-sitter and tree-sitter-cli packages were not updated to 0.26.x because [neovim 0.11.5 doesn't support it yet](https://github.com/neovim/neovim/issues/36914).

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
