### PR TITLE
main/emacs-*: update to 30.2, enable tests

### DIFF
--- a/main/emacs-console/patches/fix-tests.patch
+++ b/main/emacs-console/patches/fix-tests.patch
@@ -1,0 +1,49 @@
+--- a/test/src/emacs-module-resources/mod-test.c
++++ b/test/src/emacs-module-resources/mod-test.c
+@@ -46,7 +46,7 @@
+ #include <gmp.h>
+ #include <emacs-module.h>
+ 
+-extern int plugin_is_GPL_compatible;
++__attribute__((visibility("default")))
+ int plugin_is_GPL_compatible;
+ 
+ #if INTPTR_MAX <= 0
+@@ -765,7 +765,7 @@
+ }
+ 
+ /* Module init function.  */
+-int
++int __attribute__((visibility("default")))
+ emacs_module_init (struct emacs_runtime *ert)
+ {
+   /* These smoke tests don't use _Static_assert because too many
+
+--- a/test/src/process-tests.el
++++ b/test/src/process-tests.el
+@@ -416,10 +416,7 @@
+ 
+ ;; Check if the Internet seems to be working.  Mainly to pacify
+ ;; Debian's CI system.
+-(defvar internet-is-working
+-  (progn
+-    (require 'dns)
+-    (dns-query "google.com")))
++(defvar internet-is-working nil)
+ 
+ (ert-deftest lookup-family-specification ()
+   "`network-lookup-address-info' should only accept valid family symbols."
+
+--- a/test/lisp/wdired-tests.el
++++ b/test/lisp/wdired-tests.el
+@@ -141,9 +141,7 @@
+   ;; FIXME: Add a test for a door (indicator ">") only under Solaris?
+   (ert-with-temp-directory test-dir
+     (let* ((dired-listing-switches "-Fl")
+-           (dired-ls-F-marks-symlinks
+-            (or (eq system-type 'darwin)
+-                (featurep 'ls-lisp)))
++           (dired-ls-F-marks-symlinks t)
+            (buf (find-file-noselect test-dir))
+            proc)
+       (unwind-protect

--- a/main/emacs-console/template.py
+++ b/main/emacs-console/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-console"
-pkgver = "30.1"
-pkgrel = 13
+pkgver = "30.2"
+pkgrel = 0
 build_style = "gnu_configure"
 # TODO gccjit (cba to figure it out for now)
 configure_args = [
@@ -10,6 +10,11 @@ configure_args = [
     "--without-file-notification",
     "--without-sound",
     "--without-x",
+]
+make_check_args = [
+    "EXCLUDE_TESTS="
+    " %eglot-tests.el"  # requires a variety of lsp servers
+    " %tramp-tests.el"  # fails mysteriously TODO
 ]
 hostmakedepends = [
     "automake",
@@ -34,11 +39,9 @@ pkgdesc = "Extensible, customizable, self-documenting, real-time display editor"
 license = "GPL-3.0-or-later"
 url = "https://www.gnu.org/software/emacs/emacs.html"
 source = f"$(GNU_SITE)/emacs/emacs-{pkgver}.tar.xz"
-sha256 = "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
+sha256 = "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
 # CFI: breaks
 hardening = ["vis", "!cfi"]
-# no tests
-options = ["!check"]
 
 
 def post_install(self):

--- a/main/emacs-gtk3/template.py
+++ b/main/emacs-gtk3/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-gtk3"
-pkgver = "30.1"
-pkgrel = 4
+pkgver = "30.2"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--with-gameuser=:_games",
@@ -12,6 +12,12 @@ configure_args = [
     "--with-xft",
     "--without-tiff",
     "--without-toolkit-scroll-bars",
+]
+make_check_args = [
+    "EXCLUDE_TESTS="
+    " %eglot-tests.el"  # requires a variety of lsp servers
+    " %tramp-tests.el"  # TODO test18 and test21 fail
+    " %shr-tests.el"  # TODO zoom-image times out
 ]
 hostmakedepends = [
     "automake",
@@ -49,11 +55,9 @@ pkgdesc = "Extensible, customizable, self-documenting, real-time display editor"
 license = "GPL-3.0-or-later"
 url = "https://www.gnu.org/software/emacs/emacs.html"
 source = f"$(GNU_SITE)/emacs/emacs-{pkgver}.tar.xz"
-sha256 = "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
+sha256 = "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
 # CFI: breaks
 hardening = ["vis", "!cfi"]
-# no tests
-options = ["!check"]
 
 
 def post_install(self):

--- a/main/emacs-pgtk/template.py
+++ b/main/emacs-pgtk/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-pgtk"
-pkgver = "30.1"
-pkgrel = 4
+pkgver = "30.2"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--with-gameuser=:_games",
@@ -11,6 +11,12 @@ configure_args = [
     "--with-webp",
     "--with-x-toolkit=gtk3",
     "--without-tiff",
+]
+make_check_args = [
+    "EXCLUDE_TESTS="
+    " %eglot-tests.el"  # requires a variety of lsp servers
+    " %tramp-tests.el"  # fails mysteriously TODO
+    " %shr-tests.el"  # TODO zoom-image times out
 ]
 hostmakedepends = [
     "automake",
@@ -47,11 +53,9 @@ pkgdesc = "Extensible, customizable, self-documenting, real-time display editor"
 license = "GPL-3.0-or-later"
 url = "https://www.gnu.org/software/emacs/emacs.html"
 source = f"$(GNU_SITE)/emacs/emacs-{pkgver}.tar.xz"
-sha256 = "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
+sha256 = "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
 # CFI: breaks
 hardening = ["vis", "!cfi"]
-# no tests
-options = ["!check"]
 
 
 def post_install(self):


### PR DESCRIPTION
## Description
update emacs and enable testsuite  
the comment disabling tests mentioned that there are no tests.. AFAICT that is no longer true, so let's enable them?

Testsuite is passing on
- x86_64

> [!IMPORTANT]
> Other archs need testing.

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine