### PR TITLE
user/ai.robots.txt: new package

### DIFF
--- a/user/ai.robots.txt/template.py
+++ b/user/ai.robots.txt/template.py
@@ -1,0 +1,23 @@
+pkgname = "ai.robots.txt"
+pkgver = "1.44"
+pkgrel = 0
+pkgdesc = "List of AI agents and robots to block"
+license = "MIT"
+url = "https://github.com/ai-robots-txt/ai.robots.txt"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "67f14eef069e0fb261ce64215965b28331513512b94b2793bb09fd3e458a3b65"
+# no tests
+options = ["!check"]
+
+
+def install(self):
+    self.install_license("LICENSE")
+    for f in [
+        ".htaccess",
+        "Caddyfile",
+        "haproxy-block-ai-bots.txt",
+        "nginx-block-ai-bots.conf",
+        "robots.json",
+        "robots.txt",
+    ]:
+        self.install_file(f, "usr/share/ai.robots.txt")


### PR DESCRIPTION
## Description

This packages [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt), a repository containing user agents to help identify LLM scrapers which can be blocked using web servers and reverse proxies like nginx, apache, haproxy etc.

I have a local build of [iocaine](https://git.madhouse-project.org/iocaine/iocaine) and the version 3.1.0 needs `robots.json` from ai.robots.txt as a build dep. I'll raise a PR for iocaine soon after I'm done testing it locally.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
