### PR TITLE
user/xcur2png: new package

### DIFF
--- a/user/xcur2png/patches/fixed-png-encoding-int-overflow.patch
+++ b/user/xcur2png/patches/fixed-png-encoding-int-overflow.patch
@@ -1,0 +1,38 @@
+From 0080e9419337dfc673b1b9285b98d490b8644e9b Mon Sep 17 00:00:00 2001
+From: Curtis Barnhart <cbarnhart@westmont.edu>
+Date: Mon, 28 Jul 2025 09:05:14 -0700
+Subject: [PATCH] Fixed png encoding int overflow
+
+---
+ xcur2png.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/xcur2png.c b/xcur2png.c
+index 8723a10..c90c442 100644
+--- a/xcur2png.c
++++ b/xcur2png.c
+@@ -586,9 +586,12 @@ int writePngFileFromXcur (const XcursorDim width, const XcursorDim height,
+     unsigned int red = (pixels[i]>>16) & 0xff;
+     unsigned int green = (pixels[i]>>8) & 0xff;
+     unsigned int blue = pixels[i] & 0xff;
+-    red = (div (red * 256, alpha).quot) & 0xff;
+-    green = (div (green * 256,  alpha).quot) & 0xff;
+-    blue = (div (blue * 256, alpha).quot) & 0xff;
++    red = (div (red * 256, alpha).quot);
++    green = (div (green * 256,  alpha).quot);
++    blue = (div (blue * 256, alpha).quot);
++    red = (red > 0xff ? 0xff : red) & 0xff;
++    green = (green > 0xff ? 0xff : green) & 0xff;
++    blue = (blue > 0xff ? 0xff : blue) & 0xff;
+     pix[i] = (alpha << 24) + (red << 16) + (green << 8) + blue;
+   }
+ 
+@@ -671,7 +674,7 @@ int saveConfAndPNGs (const XcursorImages* xcIs, const char* xcurFilePart, int su
+   int ret;
+   int count = 0;
+   char pngName[PATH_MAX] = {0};
+-  extern dry_run;
++  extern int dry_run;
+   
+   //Write comment on config-file.
+   fprintf (conffp,"#size\txhot\tyhot\tPath to PNG image\tdelay\n");

--- a/user/xcur2png/template.py
+++ b/user/xcur2png/template.py
@@ -1,0 +1,22 @@
+pkgname = "xcur2png"
+pkgver = "0.7.1"
+pkgrel = 0
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+    "pkgconf",
+]
+makedepends = [
+    "libpng-devel",
+    "libxcursor-devel",
+]
+pkgdesc = "Convert X cursors to PNG images"
+license = "GPL-3.0-or-later"
+url = "https://github.com/eworm-de/xcur2png"
+source = f"{url}/releases/download/{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "bc6a062fdb48615a7159ed56ef3d2011168cd8a9decaf1d8a4e316d3064132c9"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_man("xcur2png.1")


### PR DESCRIPTION
## Description

xcur2png is a program that extracts PNG images from X cursors and generates a configuration file reusable by xcursorgen. In short, it converts X cursors into PNG images.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date