### PR TITLE
user/wlock: new package

### DIFF
--- a/user/wlock/template.py
+++ b/user/wlock/template.py
@@ -1,0 +1,27 @@
+pkgname = "wlock"
+pkgver = "1.0"
+pkgrel = 0
+build_style = "makefile"
+hostmakedepends = [
+    "pkgconf",
+]
+makedepends = [
+    "libxkbcommon-devel",
+    "wayland-devel",
+    "wayland-protocols",
+]
+pkgdesc = "Itsy-bitsy sessionlocker for Wayland"
+license = "GPL-3.0-only"
+url = "https://codeberg.org/sewn/wlock"
+source = f"{url}/archive/{pkgver}.tar.gz"
+sha256 = "f9b3b540f4f3973c702ad1b0cf4bfc7ac436fac6cb7383abc73cc93d9de8f145"
+file_modes = {
+    "usr/bin/wlock": ("root", "root", 0o4755),
+}
+hardening = ["vis", "cfi"]
+# no tests provided by upstream
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

wlock is a itsy-bitsy sessionlocker for Wayland compositors that support the `ext-session-lock-v1` protocol; an effective port of slock to Wayland, merging the alternate color patch to give a sense of feedback.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date