### PR TITLE
user/minicom: new package

### DIFF
--- a/user/minicom/template.py
+++ b/user/minicom/template.py
@@ -1,0 +1,18 @@
+pkgname = "minicom"
+pkgver = "2.10"
+pkgrel = 0
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+    "gettext-devel",
+    "pkgconf",
+]
+makedepends = [
+    "linux-headers",
+    "ncurses-devel",
+]
+pkgdesc = "Serial communication program"
+license = "GPL-2.0-or-later"
+url = "https://salsa.debian.org/minicom-team/minicom"
+source = f"{url}/-/archive/{pkgver}/minicom-{pkgver}.tar.gz"
+sha256 = "66ff82661c3cc49ab2e447f8a070ec1a64ba71d64219906d80a49da284a5d43e"


### PR DESCRIPTION
## Description

Adds minicom, a text-mode serial terminal emulator that can translate VT102 and ANSI to whatever $TERM and terminfo say it should be.

Note that if there are no serial device specified, and /dev/modem does not exist, the application will exit with no text and rc=1. I believe this to be intended upstream behavior. 

The default may be changed by either system-wide or per-user configuration.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

(Tested specifically with a USB Serial adapter, specified with -D/dev/serial/by-id/....)

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
