### PR TITLE
user/stow: new package

### DIFF
--- a/user/perl-capture-tiny/template.py
+++ b/user/perl-capture-tiny/template.py
@@ -1,0 +1,13 @@
+pkgname = "perl-capture-tiny"
+pkgver = "0.50"
+pkgrel = 0
+build_style = "perl_module"
+hostmakedepends = ["perl"]
+makedepends = ["perl"]
+checkdepends = ["perl"]
+depends = ["perl"]
+pkgdesc = "Capture::Tiny - Capture STDOUT and STDERR from perl or XS"
+license = "Artistic-1.0-Perl OR GPL-1.0-or-later"
+url = "https://metacpan.org/pod/Capture::Tiny"
+source = f"$(CPAN_SITE)/Mail/DAGOLDEN/Capture-Tiny-{pkgver}.tar.gz"
+sha256 = "ca6e8d7ce7471c2be54e1009f64c367d7ee233a2894cacf52ebe6f53b04e81e5"

--- a/user/perl-capture-tiny/update.py
+++ b/user/perl-capture-tiny/update.py
@@ -1,0 +1,1 @@
+pkgname = "Capture-Tiny"

--- a/user/perl-test-output/template.py
+++ b/user/perl-test-output/template.py
@@ -1,0 +1,13 @@
+pkgname = "perl-test-output"
+pkgver = "1.036"
+pkgrel = 0
+build_style = "perl_module"
+hostmakedepends = ["perl"]
+makedepends = ["perl"]
+checkdepends = ["perl-capture-tiny"]
+depends = ["perl"]
+pkgdesc = "Test::Output - Testing framework for checking STDOUT & STDERR"
+license = "Artistic-1.0-Perl OR GPL-1.0-or-later"
+url = "https://metacpan.org/dist/Test-Output"
+source = f"$(CPAN_SITE)/Test/Test-Output-{pkgver}.tar.gz"
+sha256 = "a3a95cb8c4d387fe079add4490757e69927ef0488bbb18b4d55e7fc6d25f1a63"

--- a/user/perl-test-output/update.py
+++ b/user/perl-test-output/update.py
@@ -1,0 +1,1 @@
+pkgname = "Test-Output"

--- a/user/stow/template.py
+++ b/user/stow/template.py
@@ -1,0 +1,14 @@
+pkgname = "stow"
+pkgver = "2.4.1"
+pkgrel = 0
+build_style = "configure"
+configure_args = ["--prefix=/usr/"]
+hostmakedepends = ["perl"]
+makedepends = ["perl"]
+checkdepends = ["perl-io-stringy", "perl-test-output", "perl-capture-tiny"]
+depends = ["perl", "perl-io-stringy"]
+pkgdesc = "Symlink Farm Manager / Dotfiles Manager"
+license = "GPL-3.0-or-later"
+url = "https://www.gnu.org/software/stow"
+source = f"https://ftp.gnu.org/gnu/stow/stow-{pkgver}.tar.gz"
+sha256 = "2a671e75fc207303bfe86a9a7223169c7669df0a8108ebdf1a7fe8cd2b88780b"


### PR DESCRIPTION
## Description
GNU Stow is a Symlink farm manager/Dotfiles manager written in perl. 

There was a previous [pull request](https://github.com/chimera-linux/cports/pull/4794) to add this package, but it needed to patch the build system to ignore warnings. Due to some upstream changes patching is no-longer required!

There is also 2 trivial dependencies included in this pull request(they are only needed for the unit testing of the build): `perl-test-output` and `perl-capture-tiny`

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
