### PR TITLE
user/wiremix: new package

### DIFF
--- a/user/wiremix/template.py
+++ b/user/wiremix/template.py
@@ -1,0 +1,24 @@
+pkgname = "wiremix"
+pkgver = "0.11.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = [
+    "cargo-auditable",
+    "pkgconf",
+]
+makedepends = [
+    "pipewire-devel",
+    "rust-std",
+]
+pkgdesc = "TUI audio mixer for PipeWire"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/tsowell/wiremix"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "62a7cace79c9af537e0917a6d4e5da66b2efe2b4abc5f08c0fbaed727acc8c9f"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")
+    self.install_file("wiremix.desktop", "usr/share/applications")
+    self.install_file("wiremix.toml", "usr/share/examples/wiremix")


### PR DESCRIPTION
## Description

wiremix is a simple TUI audio mixer for PipeWire. You can use it to adjust volumes, route audio between devices and applications, and configure audio device settings like input/output ports and profiles.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
