### PR TITLE
user/mpdris2-rs: new package

### DIFF
--- a/user/mpdris2-rs/files/mpdris2-rs.user
+++ b/user/mpdris2-rs/files/mpdris2-rs.user
@@ -1,0 +1,5 @@
+type = process
+command = /usr/bin/mpdris2-rs
+depends-on = mpd
+restart = true
+smooth-recovery = true

--- a/user/mpdris2-rs/template.py
+++ b/user/mpdris2-rs/template.py
@@ -1,0 +1,22 @@
+pkgname = "mpdris2-rs"
+pkgver = "1.1.2"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = [
+    "dinit-chimera",
+    "mpd",
+    "rust-std",
+]
+depends = ["mpd"]
+pkgdesc = "Exposing MPRIS V2.2 D-Bus interface for mpd"
+license = "GPL-3.0-or-later"
+url = "https://github.com/szclsya/mpdris2-rs"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "50ffaa10c47122921ca382beaffa399cb11fa67b42a25f2a117001121ff76662"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_license("COPYING")
+    self.install_service(self.files_path / "mpdris2-rs.user")


### PR DESCRIPTION
## Description

A lightweight implementation of MPD to D-Bus bridge, which exposes MPD player and playlist information onto [MPRIS2](https://specifications.freedesktop.org/mpris-spec/latest/index.html) interface so other programs can use this generic interface to retrieve MPD's playback state.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
