### PR TITLE
main/gnupg: update to 2.4.9

### DIFF
--- a/main/gnupg/template.py
+++ b/main/gnupg/template.py
@@ -1,5 +1,5 @@
 pkgname = "gnupg"
-pkgver = "2.4.8"
+pkgver = "2.4.9"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -28,4 +28,4 @@ pkgdesc = "GNU Privacy Guard 2.x"
 license = "GPL-3.0-or-later"
 url = "https://www.gnupg.org"
 source = f"https://gnupg.org/ftp/gcrypt/gnupg/gnupg-{pkgver}.tar.bz2"
-sha256 = "b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616"
+sha256 = "dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964"


### PR DESCRIPTION
## Description

Important fixes for the recently uncovered vulns:

  * gpg: Fix possible memory corruption in the armor parser.  [T7906]

  * gpg: Avoid potential downgrade to SHA1 in 3rd party key
    signatures.  [rGddb012be7f]

  * gpg: Error out on unverified output for non-detached signatures.
    [rG9d302f978b]

  * gpg: Do not allow compressed key packets on import.  [T7014]

  * scd: Fix a harmless read buffer over-read in a function used by
    PKCS#15 cards.  [T7662]

  * dirmngr: Do not require a keyserver for "gpg --fetch-key".
    [T7693]

  * agent: Fix ssh-agent's request_identities for skipped Brainpool
    keys.  [rG6bf5696c85]

  Release-info: https://dev.gnupg.org/T8001

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
