### PR TITLE
user/fish-shell: update to 4.4.0

### DIFF
--- a/user/fish-shell/patches/none-profile.patch
+++ b/user/fish-shell/patches/none-profile.patch
@@ -1,13 +1,23 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -54,8 +54,8 @@ function(CREATE_TARGET target)
-       "${CMAKE_COMMAND}" -E
-         env ${VARS_FOR_CARGO}
-           ${Rust_CARGO}
--            build --bin ${target}
--            $<$<CONFIG:Release>:--release>
-+            auditable build --bin ${target}
-+            $<$<CONFIG:None>:--release>
-             $<$<CONFIG:RelWithDebInfo>:--profile=release-with-debug>
-             --target ${Rust_CARGO_TARGET}
-             --no-default-features
+@@ -57,18 +57,18 @@ if(NOT "${CMAKE_BUILD_TYPE}" IN_LIST build_types)
+ endif()
+
+ add_custom_target(
+   fish ALL
+   COMMAND
+     "${CMAKE_COMMAND}" -E
+       env ${VARS_FOR_CARGO}
+         ${Rust_CARGO}
+-          build --bin fish
+-          $<$<CONFIG:Release>:--release>
++          auditable build --bin fish
++          $<$<CONFIG:None>:--release>
+           $<$<CONFIG:RelWithDebInfo>:--profile=release-with-debug>
+           --target ${Rust_CARGO_TARGET}
+           --no-default-features
+           --features=${FISH_CARGO_FEATURES}
+           ${CARGO_FLAGS}
+     &&
+     "${CMAKE_COMMAND}" -E
+       copy "${rust_target_dir}/${rust_profile}/fish" "${CMAKE_CURRENT_BINARY_DIR}"

--- a/user/fish-shell/template.py
+++ b/user/fish-shell/template.py
@@ -1,16 +1,25 @@
 pkgname = "fish-shell"
-pkgver = "4.2.1"
-pkgrel = 1
+pkgver = "4.4.0"
+pkgrel = 0
 build_style = "cmake"
 make_check_target = "fish_run_tests"
-hostmakedepends = ["cargo-auditable", "cmake", "gettext", "pkgconf", "ninja"]
+hostmakedepends = [
+    "cargo-auditable",
+    "cmake",
+    "gettext",
+    "ninja",
+    "pkgconf",
+    "python-sphinx",
+]
 makedepends = ["pcre2-devel", "rust-std"]
 checkdepends = ["procps", "python"]
 pkgdesc = "Friendly interactive command line shell"
 license = "GPL-2.0-only"
 url = "https://fishshell.com"
 source = f"https://github.com/fish-shell/fish-shell/releases/download/{pkgver}/fish-{pkgver}.tar.xz"
-sha256 = "0f99222a3063377c91fbf78d9850edab7a0b91bdbed201cf79da48ea3a41f393"
+sha256 = "529e1072c034f6c9d21a922c359886df75129c3d81a15bd8656a3c4860993ad5"
+# uses a compiled binary to build docs
+options = ["!cross"]
 
 
 def prepare(self):


### PR DESCRIPTION
## Description

updated fish-shell to 4.4.0

The none-profile.patch is the same as before but created with
git-format-patch.

cross-compilation doesn't really work because a native binary is used to
build man pages and docs during build, partially fixed by defining
Rust_CARGO_TARGET introduced in the following commit

https://github.com/fish-shell/fish-shell/commit/205d80c75aa8fb2e11dbf477e2f377ca2b98ace2

python-sphinx is now needed to build man pages and documentation but it
doesn't work when cross compiling fish as mentioned earlier

https://github.com/fish-shell/fish-shell/commit/135fc73191dc8d7d39ead030f033e071ca05dc23

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
