### PR TITLE
user/broot: update to 1.54.0

### DIFF
--- a/user/broot/template.py
+++ b/user/broot/template.py
@@ -1,5 +1,5 @@
 pkgname = "broot"
-pkgver = "1.53.0"
+pkgver = "1.54.0"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "pkgconf"]
@@ -13,7 +13,7 @@ pkgdesc = "Filesystem visualization and traversal tool"
 license = "MIT"
 url = "https://dystroy.org/broot"
 source = f"https://github.com/Canop/broot/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "cd675a81222ac82a238778325a51e3f14b971df32ceedf9bb892f3a1d012e10e"
+sha256 = "92f88c6051c8ed7276d43a4ab45aacfe7b0dd1d65b3503d45ba1f9dad5e95cf1"
 
 
 def install(self):


### PR DESCRIPTION
## Description

Update broot to the 1.54.0 version
- fix crash on rendering B&W images with Kitty image protocol
- don't match directories when a composite pattern has a content pattern, even negated (eg `/js$/&!c/;`: it's clear the user wants to match js *files* not containing a semicolon)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
