### PR TITLE
main/wireguard-tools: wg-quick-all should start AFTER network.target

### DIFF
--- a/main/wireguard-tools/files/wg-quick-all
+++ b/main/wireguard-tools/files/wg-quick-all
@@ -1,5 +1,4 @@
 type = scripted
 command = /usr/libexec/wg-quick-all up
 stop-command = /usr/libexec/wg-quick-all down
-before = pre-network.target
-depends-on = pre-local.target
+depends-on = network.target


### PR DESCRIPTION
`wg-quick-all` consistently fails to start on boot. This also delays the ability for my device to establish an internet connection, as it has to wait a minute for wg-quick-all to return an error first. The solution is to make wg-quick-all depend on `network.target` instead of starting before `pre-network.target`. It has to depend on `network.target` specifically, as it also fails with `depends-on = pre-network.target`

Before change, from syslog:
```
2026-01-10 13:00:00 notice dinit[1]: service wg-quick-all started.
# [...]
2026-01-10 13:01:16 warning dinit[1]: Service wg-quick-all with pid 559 exceeded allowed start time; cancelling.
2026-01-10 13:01:16 warning dinit[1]: Interrupting start of service wg-quick-all with pid 559 (with SIGINT).
2026-01-10 13:01:16 notice dinit[1]: service wg-quick-all failed to start.
2026-01-10 13:01:16 notice dinit[1]: Service wg-quick-all start cancelled; exit code 1
2026-01-10 13:01:16 notice dinit[1]: service pre-network.target started.
```
After change, from syslog:
```
2026-01-10 13:14:37 notice dinit[1]: service network.target started.
# [...]
2026-01-10 13:14:43 notice dinit[1]: service wg-quick-all started.
```
No error, and I can ping the other device connected via wireguard successfully.