### PR TITLE
user/halloy: update to 2026.1.1

### DIFF
--- a/user/halloy/template.py
+++ b/user/halloy/template.py
@@ -1,5 +1,5 @@
 pkgname = "halloy"
-pkgver = "2025.12"
+pkgver = "2026.1.1"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = [
@@ -18,12 +18,9 @@ pkgdesc = "IRC client"
 license = "GPL-3.0-or-later"
 url = "https://halloy.chat"
 source = f"https://github.com/squidowl/halloy/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "106689f15aeca87e88c7249812b0c8383c6c8f2746df4f5bbd83b579e2ebb756"
+sha256 = "a4b3421feb8f5cf1f609bcccab4252b48518664209a5719863c42fcaea3b71be"
 # no tests in top-level project
 options = ["!check"]
-
-if self.profile().arch in ["loongarch64", "ppc", "ppc64", "ppc64le", "riscv64"]:
-    broken = "ring 0.16.20 fails to build"
 
 
 def install(self):


### PR DESCRIPTION
## Description

I dropped the `broken` directive as it now depends on ring 0.17. I did a native build on `loongarch64` & `x86_64`, cross-build for `riscv64`, and `ppc64`, and bin-fmt-misc build for `ppc`. All worked, so should be ok on all archs that were previously broken.

It's probably the hardware I have, but it fails to start on my loongarch machine with a DRI3 error. I get other graphics related errors trying to run Wayland compositors on it too. Not sure if this is a limitation of the Loonson GPU, or what.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
