### PR TITLE
user/nwg-drawer: new package

### DIFF
--- a/user/nwg-drawer/template.py
+++ b/user/nwg-drawer/template.py
@@ -1,0 +1,21 @@
+pkgname = "nwg-drawer"
+pkgver = "0.7.4"
+pkgrel = 0
+build_style = "go"
+hostmakedepends = ["go", "pkgconf"]
+makedepends = ["xdg-utils", "gtk+3-devel", "gtk-layer-shell-devel", "gobject-introspection-devel"]
+pkgdesc = "Application drawer for wlroots-based Wayland compositors"
+license = "MIT AND MPL-2.0"
+url = "https://nwg-piotr.github.io/nwg-shell/nwg-drawer"
+source = (
+    f"https://github.com/nwg-piotr/nwg-drawer/archive/refs/tags/v{pkgver}.tar.gz"
+)
+sha256 = "0caa9f3a5efbd7492ce57fc6952e7f78e2d6ee71d4a430aeb0aa7535abecdab5"
+env = {"CGO_ENABLED": "1"}
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+    self.install_files("desktop-directories", "usr/share/nwg-drawer")
+    self.install_files("img", "usr/share/nwg-drawer")
+    self.install_files("drawer.css", "usr/share/nwg-drawer")


### PR DESCRIPTION
## Description

Add a package for nwg-drawer. nwg-drawer is a full screen application chooser for wayland compositors. 
It does this by using a more conventional category system, similar to the default Gnome Shell Launcher.

<img width="2560" height="1600" alt="nwg" src="https://github.com/user-attachments/assets/c3565970-a860-41ac-b499-b35acb8feede" />

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
  - Screenshot above is from running it on a pretty new system.

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
