### PR TITLE
user/vttest: new package

### DIFF
--- a/user/vttest/template.py
+++ b/user/vttest/template.py
@@ -1,0 +1,21 @@
+pkgname = "vttest"
+pkgver = "20251205"
+pkgrel = 1
+pkgdesc = "Tool for testing VT100 compatibility of terminals"
+license = "MIT"
+url = "https://invisible-island.net/vttest"
+hardening = ["vis", "cfi"] # 'sst' results in SIGSEGV (address boundary error)
+
+source = f"https://invisible-island.net/archives/vttest/vttest-{pkgver}.tgz"
+sha256 = "cd6886f9aefe6a3f6c566fa61271a55710901a71849c630bf5376aa984bf77cc"
+
+
+def build(self):
+    self.do("./configure", "--prefix=/usr")
+    self.do("make")
+
+
+def install(self):
+    self.install_bin("vttest")
+    self.install_man("vttest.1")
+    self.install_license("COPYING")


### PR DESCRIPTION
## Description

Vttest tests the compatibility (demonstrates the non-compatibility) of 
so-called "VT100-compatible" terminals. 

Vttest was written in 1983-1985 by Per Lindberg at the Stockholm University 
Computing Center. It was adopted by Thomas E. Dickey (the long-time maintainer
of xterm) in May 1996 to support changes he was making to xterm.  The program 
has grown from about 2400 lines to more than 18,000 lines of code.
(more information on Vttest's history at https://invisible-island.net/vttest/ )

The is a useful command-line program for inspecting various properties of terminal
emulators. Including running tests of a terminal emulator's support of different DEC
VT features, and for examining a terminal emulator's self-reporting of VT-feature
compatibility-levels. See for instance https://tomscii.sig7.se/2020/12/A-totally-biased-comparison-of-Zutty#features-and-correctness for examples of use.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
