### PR TITLE
user/cagebreak: new package

### DIFF
--- a/user/cagebreak/patches/00_fix_etc.patch
+++ b/user/cagebreak/patches/00_fix_etc.patch
@@ -1,0 +1,45 @@
+diff --git a/cagebreak.c b/cagebreak.c
+index 878d5b9..b513d74 100644
+--- a/cagebreak.c
++++ b/cagebreak.c
+@@ -682,6 +682,14 @@ main(int argc, char *argv[]) {
+ 			conf_ret = set_configuration(&server, default_conf);
+ 		}
+ 
++		// Fallback Chimera
++		if(conf_ret == 1) {
++			char *default_conf = "/usr/share/etc/cagebreak/config";
++			wlr_log(WLR_INFO, "Loading fallback distro config: \"%s\"",
++			        default_conf);
++			conf_ret = set_configuration(&server, default_conf);
++		}
++
+ 		if(conf_ret != 0 || !server.running) {
+ 			ret = 1;
+ 			goto end;
+diff --git a/man/cagebreak-config.5.md b/man/cagebreak-config.5.md
+index f6de22a..d3500db 100644
+--- a/man/cagebreak-config.5.md
++++ b/man/cagebreak-config.5.md
+@@ -8,6 +8,8 @@ cagebreak-config(5) "Version 3.1.0" "Cagebreak Manual"
+ 
+ *\$XDG_CONFIG_PATH/cagebreak/config*
+ 
++Default fallback config at */usr/share/etc/cagebreak/config*.
++
+ # DESCRIPTION
+ 
+ The cagebreak configuration is a plain text file.
+diff --git a/man/cagebreak.1.md b/man/cagebreak.1.md
+index f89c063..b9c8d80 100644
+--- a/man/cagebreak.1.md
++++ b/man/cagebreak.1.md
+@@ -22,6 +22,8 @@ the keyboard.
+ 
+ Configuration of this behaviour is specified in the
+ *\$XDG_CONFIG_PATH/cagebreak/config* file (See *cagebreak-config(5)*).
++A default configuration is needed to run cagebreak. It can be found at
++*/usr/share/etc/cagebreak/config*.
+ 
+ Scripting support is provided through the IPC
+ socket specified in the environment variable *\$CAGEBREAK_SOCKET*.

--- a/user/cagebreak/patches/00_fix_etc.patch
+++ b/user/cagebreak/patches/00_fix_etc.patch
@@ -1,8 +1,17 @@
 diff --git a/cagebreak.c b/cagebreak.c
-index 878d5b9..b513d74 100644
+index 878d5b9..2741048 100644
 --- a/cagebreak.c
 +++ b/cagebreak.c
-@@ -682,6 +682,14 @@ main(int argc, char *argv[]) {
+@@ -198,6 +198,8 @@ set_configuration(struct cg_server *server,
+                   const char *const config_file_path) {
+ 	FILE *config_file = fopen(config_file_path, "r");
+ 	if(config_file == NULL) {
++        #include <stdio.h>
++        fprintf(stderr, "file: %s", config_file_path);
+ 		wlr_log(WLR_ERROR, "Could not open config file \"%s\"",
+ 		        config_file_path);
+ 		return 1;
+@@ -682,6 +684,14 @@ main(int argc, char *argv[]) {
  			conf_ret = set_configuration(&server, default_conf);
  		}
  
@@ -43,3 +52,16 @@ index f89c063..b9c8d80 100644
  
  Scripting support is provided through the IPC
  socket specified in the environment variable *\$CAGEBREAK_SOCKET*.
+diff --git a/meson.build b/meson.build
+index 1c1077f..9471b8d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -256,7 +256,7 @@ executable(
+   c_args: fuzz_compile_args,
+ )
+ 
+-install_data('examples/config', install_dir : '/etc/xdg/cagebreak')
++install_data('examples/config', install_dir : '/usr/share/etc/cagebreak')
+ install_data('LICENSE', install_dir : '/usr/share/licenses/' + meson.project_name() + '/')
+ 
+ if get_option('man-pages')

--- a/user/cagebreak/template.py
+++ b/user/cagebreak/template.py
@@ -1,0 +1,39 @@
+pkgname = "cagebreak"
+pkgver = "3.1.0"
+pkgrel = 0
+build_style = "meson"
+configure_args = ["-Dman-pages=true", "-Dxwayland=true", "--buildtype=release"]
+hostmakedepends = [
+    "meson",
+    "pkgconf",
+    "scdoc",
+    "wayland",
+]
+makedepends = [
+    "cairo-devel",
+    "pango-devel",
+    "wayland-devel",
+    "wayland-protocols",
+    "wlroots0.19-devel",
+]
+depends = ["wayland", "libxkbcommon", "wlroots0.19", "pango-view"]
+pkgdesc = "Wayland Tiling Compositor inspred by Ratpoison"
+license = "MIT"
+url = "https://github.com/project-repo/cagebreak"
+source = f"https://github.com/project-repo/cagebreak/releases/download/{pkgver}/release_{pkgver}.tar.gz"
+sha256 = "2b62c32da739668f0d99e41144ad721c0fc02b184a9c451458644071bb335770"
+# check requires
+# a) gsed dep, patching tests to use that with shopt -s expand_aliases,
+#    alias sed=gsed
+# b) patching some bad paths in test/arguments ~> build-arguments{/,}
+# c) patching missing XDG_RUNTIME_DIR=$(pwd)
+# fixing the above is not worth it downstream because:
+# d) it still doesn't work because missing drm backend in bldroot so wlroots
+#    explodes, and well i think all hope is lost to test this in cbuild
+# this would also only be the basic test suite.
+# !check is the reason for no hardening opts
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_file("examples/config", "usr/share/etc/cagebreak")

--- a/user/cagebreak/template.py
+++ b/user/cagebreak/template.py
@@ -16,7 +16,7 @@ makedepends = [
     "wayland-protocols",
     "wlroots0.19-devel",
 ]
-depends = ["pango-view"]
+depends = ["pango-view", "xwayland"]
 pkgdesc = "Wayland Tiling Compositor inspred by Ratpoison"
 license = "MIT"
 url = "https://github.com/project-repo/cagebreak"

--- a/user/cagebreak/template.py
+++ b/user/cagebreak/template.py
@@ -33,7 +33,3 @@ sha256 = "2b62c32da739668f0d99e41144ad721c0fc02b184a9c451458644071bb335770"
 # this would also only be the basic test suite.
 # !check is the reason for no hardening opts
 options = ["!check"]
-
-
-def post_install(self):
-    self.install_file("examples/config", "usr/share/etc/cagebreak")

--- a/user/cagebreak/template.py
+++ b/user/cagebreak/template.py
@@ -16,7 +16,7 @@ makedepends = [
     "wayland-protocols",
     "wlroots0.19-devel",
 ]
-depends = ["wayland", "libxkbcommon", "wlroots0.19", "pango-view"]
+depends = ["pango-view"]
 pkgdesc = "Wayland Tiling Compositor inspred by Ratpoison"
 license = "MIT"
 url = "https://github.com/project-repo/cagebreak"


### PR DESCRIPTION
## Description

cagebreak is a Wayland compositor in the spirit of ratpoison on X.
i have been using this package for a while now and haven't ran into non-self-caused issues.
Upstream does have some bugs, and the tests don't really work in a cbuild build root.
I spent a bit of time trying to get the checks to work. That would require:
a) gsed dep, patching tests to use that or fixing it upsream.
b) patching some bad paths in test/arguments ~> build-arguments{/,}
    pretty sure this is not some gnu behavior but just a bug in the tests.
c) patching missing XDG_RUNTIME_DIR=$(pwd)
a through c could be fixed upstream but its hardly worth the effort since
d) tests still won't work because missing drm backend in bldroot
   so wlroots explodes, and well i think all hope is lost to test this in cbuild.
this is just for testing the basic test suite.
thats also why no hardening opts since no tests.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
