### PR TITLE
cbuild: output full package name in failed update check

### DIFF
--- a/src/cbuild/core/update_check.py
+++ b/src/cbuild/core/update_check.py
@@ -525,7 +525,7 @@ def update_check(pkg, verbose=False, error=False):
         if error:
             return None
 
-        print(f"CAUTION: no version found for '{pkg.pkgname}'")
+        print(f"CAUTION: no version found for '{pkg.full_pkgname}'")
 
     for v in vers:
         if verbose:


### PR DESCRIPTION
## Description

When an update check fails to find any versions the error only has the package name, and not the repo. Include the repo too. This in-turn improves the output when collected on `cports-updates.txt`.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
