### PR TITLE
user/fonts-monaspace-otf: update to 1.301

### DIFF
--- a/user/fonts-monaspace-otf/template.py
+++ b/user/fonts-monaspace-otf/template.py
@@ -1,13 +1,15 @@
 pkgname = "fonts-monaspace-otf"
-pkgver = "1.200"
+pkgver = "1.301"
 pkgrel = 0
 pkgdesc = "GitHub Next Monaspace fonts"
 license = "OFL-1.1"
 url = "https://github.com/githubnext/monaspace"
 source = f"{url}/archive/refs/tags/v{pkgver}.zip"
-sha256 = "e72ae4dacfa7268ef75abca32fba01cc92ec187897d4deb99ecb843c088d3307"
+sha256 = "de66c90030b20e78a9421fe2645824f47b9dec9cf1f3e600b9713fdccaa1ac0d"
 
 
 def install(self):
-    self.install_file("fonts/otf/*.otf", "usr/share/fonts/monaspace", glob=True)
+    self.install_file(
+        "fonts/Static Fonts/*/*.otf", "usr/share/fonts/monaspace", glob=True
+    )
     self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Updates to the latest release. The fonts have been changed such that the versions with nerd fonts baked in have been split out. I've included the versions without nerd fonts here. This makes the package much smaller:

```
The following packages will be upgraded:
  fonts-monaspace-otf
After this operation, 321.3 MiB of disk space will be freed.
Do you want to continue [Y/n]? 
(1/1) Upgrading fonts-monaspace-otf (1.200-r0 -> 1.301-r0)
```

Given we have [fonts-nerd-monaspace](https://pkgs.chimera-linux.org/package/current/user/x86_64/fonts-nerd-monaspace) this seemed reasonable.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
