### PR TITLE
main/libexpat: update to 2.7.4

### DIFF
--- a/main/libexpat/template.py
+++ b/main/libexpat/template.py
@@ -1,5 +1,5 @@
 pkgname = "libexpat"
-pkgver = "2.7.3"
+pkgver = "2.7.4"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--without-examples"]
@@ -10,7 +10,7 @@ pkgdesc = "XML parser library written in C"
 license = "MIT"
 url = "https://libexpat.github.io"
 source = f"https://github.com/libexpat/libexpat/releases/download/R_{pkgver.replace('.', '_')}/expat-{pkgver}.tar.xz"
-sha256 = "71df8f40706a7bb0a80a5367079ea75d91da4f8c65c58ec59bcdfbf7decdab9f"
+sha256 = "9e9cabb457c1e09de91db2706d8365645792638eb3be1f94dbb2149301086ac0"
 # CFI: crash reproducible e.g. with graphene build
 hardening = ["vis", "!cfi"]
 


### PR DESCRIPTION
## Description

Fixes a couple of CVEs amongst the other bug fixes.

           #1131  CVE-2026-24515 -- Function XML_ExternalEntityParserCreate
                    failed to copy the encoding handler data passed to
                    XML_SetUnknownEncodingHandler from the parent to the new
                    subparser. This can cause a NULL dereference (CWE-476) from
                    external entities that declare use of an unknown encoding.
                    The expected impact is denial of service. It takes use of
                    both functions XML_ExternalEntityParserCreate and
                    XML_SetUnknownEncodingHandler for an application to be
                    vulnerable.
           #1075  CVE-2026-25210 -- Add missing check for integer overflow
                    related to buffer size determination in function doContent

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
