### PR TITLE
main/c-ares: update to 1.34.6

### DIFF
--- a/main/c-ares/template.py
+++ b/main/c-ares/template.py
@@ -1,15 +1,15 @@
 pkgname = "c-ares"
-pkgver = "1.34.5"
+pkgver = "1.34.6"
 pkgrel = 0
 build_style = "gnu_configure"
 # circular gtest
 configure_args = ["--disable-tests"]
-hostmakedepends = ["pkgconf", "automake", "libtool"]
+hostmakedepends = ["pkgconf", "automake", "slibtool"]
 pkgdesc = "C library for asynchronous DNS requests"
 license = "MIT"
 url = "https://c-ares.haxx.se"
 source = f"https://github.com/c-ares/c-ares/releases/download/v{pkgver}/c-ares-{pkgver}.tar.gz"
-sha256 = "7d935790e9af081c25c495fd13c2cfcda4792983418e96358ef6e7320ee06346"
+sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5"
 hardening = ["vis", "!cfi"]
 # does not like the sandbox
 options = ["!check"]


### PR DESCRIPTION
Security fix [1]:

- CVE-2025-62408. A use-after-free bug has been uncovered in read_answers() that was introduced in v1.32.3. Please see https://github.com/c-ares/c-ares/security/advisories/GHSA-jq53-42q6-pqr5

[1]: https://c-ares.org/changelog.html

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
