### PR TITLE
main/nghttp2: update to 1.68.0

### DIFF
--- a/main/nghttp2/template.py
+++ b/main/nghttp2/template.py
@@ -1,5 +1,5 @@
 pkgname = "nghttp2"
-pkgver = "1.66.0"
+pkgver = "1.68.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_gen = []
@@ -18,7 +18,7 @@ pkgdesc = "HTTP/2 C Library"
 license = "MIT"
 url = "https://nghttp2.org"
 source = f"https://github.com/tatsuhiro-t/nghttp2/releases/download/v{pkgver}/nghttp2-{pkgver}.tar.xz"
-sha256 = "00ba1bdf0ba2c74b2a4fe6c8b1069dc9d82f82608af24442d430df97c6f9e631"
+sha256 = "5511d3128850e01b5b26ec92bf39df15381c767a63441438b25ad6235def902c"
 # CFI; reproduces in e.g. libsoup
 hardening = ["vis", "!cfi"]
 


### PR DESCRIPTION
Important changes [1]:

- TLSv1.0 and TLSv1.1 support has been dropped.
- ML-DSA certificates are now selected over ECDSA and RSA. ML-DSA certificates are supported by OpenSSL and wolfSSL TLS backends.

[1]: https://nghttp2.org/blog/2025/10/25/nghttp2-v1-68-0/

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
