### PR TITLE
user/nwg-look: new package, user/xcur2png: new package

### DIFF
--- a/user/nwg-look/template.py
+++ b/user/nwg-look/template.py
@@ -1,0 +1,29 @@
+pkgname = "nwg-look"
+pkgver = "1.1.1"
+pkgrel = 0
+build_style = "go"
+hostmakedepends = [
+    "go",
+    "pkgconf",
+]
+makedepends = [
+    "gtk+3-devel",
+]
+depends = ["gsettings-desktop-schemas", "xcur2png"]
+pkgdesc = "GTK3 settings editor adapted to work in the wlroots environment"
+license = "MIT"
+url = "https://github.com/nwg-piotr/nwg-look"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "568c5efe443892d74ffce6cf8ac7db2aea6071be70d97d3ba7c5efd8b351e601"
+
+
+def install(self):
+    self.install_bin(f"build/{pkgname}")
+    self.install_license("LICENSE")
+    self.install_file("stuff/main.glade", f"usr/share/{pkgname}")
+    self.install_files("langs", f"usr/share/{pkgname}", name="langs")
+    self.install_file(f"stuff/{pkgname}.desktop", "usr/share/applications")
+    self.install_file(
+        f"stuff/{pkgname}.svg",
+        "usr/share/icons/hicolor/scalable/apps",
+    )

--- a/user/xcur2png/patches/fixed-png-encoding-int-overflow.patch
+++ b/user/xcur2png/patches/fixed-png-encoding-int-overflow.patch
@@ -1,0 +1,38 @@
+From 0080e9419337dfc673b1b9285b98d490b8644e9b Mon Sep 17 00:00:00 2001
+From: Curtis Barnhart <cbarnhart@westmont.edu>
+Date: Mon, 28 Jul 2025 09:05:14 -0700
+Subject: [PATCH] Fixed png encoding int overflow
+
+---
+ xcur2png.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/xcur2png.c b/xcur2png.c
+index 8723a10..c90c442 100644
+--- a/xcur2png.c
++++ b/xcur2png.c
+@@ -586,9 +586,12 @@ int writePngFileFromXcur (const XcursorDim width, const XcursorDim height,
+     unsigned int red = (pixels[i]>>16) & 0xff;
+     unsigned int green = (pixels[i]>>8) & 0xff;
+     unsigned int blue = pixels[i] & 0xff;
+-    red = (div (red * 256, alpha).quot) & 0xff;
+-    green = (div (green * 256,  alpha).quot) & 0xff;
+-    blue = (div (blue * 256, alpha).quot) & 0xff;
++    red = (div (red * 256, alpha).quot);
++    green = (div (green * 256,  alpha).quot);
++    blue = (div (blue * 256, alpha).quot);
++    red = (red > 0xff ? 0xff : red) & 0xff;
++    green = (green > 0xff ? 0xff : green) & 0xff;
++    blue = (blue > 0xff ? 0xff : blue) & 0xff;
+     pix[i] = (alpha << 24) + (red << 16) + (green << 8) + blue;
+   }
+ 
+@@ -671,7 +674,7 @@ int saveConfAndPNGs (const XcursorImages* xcIs, const char* xcurFilePart, int su
+   int ret;
+   int count = 0;
+   char pngName[PATH_MAX] = {0};
+-  extern dry_run;
++  extern int dry_run;
+   
+   //Write comment on config-file.
+   fprintf (conffp,"#size\txhot\tyhot\tPath to PNG image\tdelay\n");

--- a/user/xcur2png/template.py
+++ b/user/xcur2png/template.py
@@ -1,0 +1,22 @@
+pkgname = "xcur2png"
+pkgver = "0.7.1"
+pkgrel = 0
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+    "pkgconf",
+]
+makedepends = [
+    "libpng-devel",
+    "libxcursor-devel",
+]
+pkgdesc = "Convert X cursors to PNG images"
+license = "GPL-3.0-or-later"
+url = "https://github.com/eworm-de/xcur2png"
+source = f"{url}/releases/download/{pkgver}/{pkgname}-{pkgver}.tar.gz"
+sha256 = "bc6a062fdb48615a7159ed56ef3d2011168cd8a9decaf1d8a4e316d3064132c9"
+hardening = ["vis", "cfi"]
+
+
+def post_install(self):
+    self.install_man("xcur2png.1")


### PR DESCRIPTION
## Description

Nwg-look is a GTK settings editor, designed to work properly in wlroots-based Wayland environment.
The look and feel is strongly influenced by [LXAppearance](https://wiki.lxde.org/en/LXAppearance), but nwg-look is intended to free the user from a few inconveniences:

- It works natively on Wayland. You no longer need Xwayland, nor strange env variables for it to run.
- It applies gsettings directly, with no need to use [workarounds](https://github.com/swaywm/sway/wiki/GTK-3-settings-on-Wayland).

I've also packaged `xcur2png`, an optional dependency for `nwg-look` for cursor previews.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
