### PR TITLE
user/forgejo-runner: new package

### DIFF
--- a/user/forgejo-runner/template.py
+++ b/user/forgejo-runner/template.py
@@ -1,0 +1,23 @@
+pkgname = "forgejo-runner"
+pkgver = "12.7.3"
+pkgrel = 0
+build_style = "go"
+make_build_args = [
+    f"-ldflags=-X code.forgejo.org/forgejo/runner/v12/internal/pkg/ver.version={pkgver}"
+]
+hostmakedepends = ["go"]
+pkgdesc = "Task runner for Forgejo"
+license = "GPL-3.0-only"
+url = "https://code.forgejo.org/forgejo/runner"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "a9a9b37adb6aa44707be90d3003870f5940424b54b0ad39a808a8e60dbfd649a"
+# check: needs network access
+options = ["!check"]
+
+
+def install(self):
+    self.install_bin("build/runner", name="forgejo-runner")
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/forgejo-runner/update.py
+++ b/user/forgejo-runner/update.py
@@ -1,0 +1,2 @@
+url = "https://code.forgejo.org/forgejo/runner/info/refs"
+pattern = r"refs/tags/v([0-9.]+)(?!^)"


### PR DESCRIPTION
This is a package so Chimera hosts can be utilized as self-hosted runners on Forgejo and Codeberg instances to lint, build Docker containers, package things, etc cetera.

With the rise of Codeberg and self-hosted Forgejo, this might be very helpful.

Tested to work on an x86_64 VPS of mine that runs Chimera Linux.

https://code.forgejo.org/forgejo/runner/

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
