### PR TITLE
main/*: add missing dependencies on plasma5support

### DIFF
--- a/main/kscreen/template.py
+++ b/main/kscreen/template.py
@@ -1,6 +1,6 @@
 pkgname = "kscreen"
 pkgver = "6.6.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 # XXX drop libexec
 configure_args = ["-DCMAKE_INSTALL_LIBEXECDIR=/usr/lib"]
@@ -31,7 +31,10 @@ makedepends = [
     "wayland-protocols",
     "xcb-util-devel",
 ]
-depends = ["kdeclarative"]
+depends = [
+    "kdeclarative",
+    "plasma5support",
+]
 pkgdesc = "KDE screen management"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://invent.kde.org/plasma/kscreen"

--- a/main/plasma-desktop/template.py
+++ b/main/plasma-desktop/template.py
@@ -95,6 +95,7 @@ depends = [
     "plasma-pa",
     "plasma-welcome",  # welcome!
     "plasma-workspace-wallpapers",
+    "plasma5support",
     "polkit-kde-agent-1",
     "powerdevil",
     "qqc2-breeze-style",

--- a/main/plasma-welcome/template.py
+++ b/main/plasma-welcome/template.py
@@ -1,6 +1,6 @@
 pkgname = "plasma-welcome"
 pkgver = "6.6.4"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 hostmakedepends = [
     "cmake",
@@ -30,7 +30,10 @@ makedepends = [
     "qt6-qtdeclarative-devel",
     "qt6-qtsvg-devel",
 ]
-depends = ["kuserfeedback"]
+depends = [
+    "kuserfeedback",
+    "plasma5support",
+]
 pkgdesc = "KDE onboarding wizard"
 license = "GPL-3.0-only"
 url = "https://invent.kde.org/plasma/plasma-welcome"


### PR DESCRIPTION
These packages depend on the QML modules from plasma5support, otherwise basic functionality like the application launcher will not work and show an error message instead. This issue can only be observed when explicitly adding a constraint on !plasma-desktop-x11-meta, as otherwise it is papered over by the plasma-desktop-x11-meta -> wacomtablet -> plasma5support dependency chain.

## Description

Describe what your pull request does here. For new packages, this is the
purpose of the package, for other changes this is what your change does,
for trivial package updates you may remove this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
