### PR TITLE
user/simdutf: new package

### DIFF
--- a/user/simdutf-devel
+++ b/user/simdutf-devel
@@ -1,0 +1,1 @@
+simdutf

--- a/user/simdutf/patches/loongarch_include_hwcap.patch
+++ b/user/simdutf/patches/loongarch_include_hwcap.patch
@@ -1,0 +1,10 @@
+--- a/include/simdutf/internal/isadetection.h
++++ b/include/simdutf/internal/isadetection.h
+@@ -72,6 +72,7 @@
+
+ #if defined(__loongarch__) && defined(__linux__)
+   #include <sys/auxv.h>
++  #include <asm/hwcap.h>
+ // bits/hwcap.h
+ // #define HWCAP_LOONGARCH_LSX             (1 << 4)
+ // #define HWCAP_LOONGARCH_LASX            (1 << 5)

--- a/user/simdutf/template.py
+++ b/user/simdutf/template.py
@@ -1,0 +1,20 @@
+pkgname = "simdutf"
+pkgver = "8.2.0"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DBUILD_SHARED_LIBS=ON"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+pkgdesc = "Library of SIMD-accelerated Unicode routines"
+license = "MIT"
+url = "https://github.com/simdutf/simdutf"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "033a91b1d7d1cb818c1eff49e61faaa1b64a3a530d59ef9efef0195e56bda8b1"
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")
+
+
+@subpackage("simdutf-devel")
+def _(self):
+    return self.default_devel()


### PR DESCRIPTION
## Description
simdutf is a library used by many other projects. I'm interested in it for Ladybird.

Doing a `grep simdutf` shows that we have a few packages that vendor simdutf, and we also have a few patches for those, but I hope they aren't required in latest simdutf anymore...

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
