### PR TITLE
user/flameshot: new package

### DIFF
--- a/user/flameshot/template.py
+++ b/user/flameshot/template.py
@@ -1,0 +1,41 @@
+pkgname = "flameshot"
+pkgver = "13.3.0"
+pkgrel = 0
+_qt_color_widgets_rev = "352bc8f99bf2174d5724ee70623427aa31ddc26a"
+build_style = "cmake"
+configure_args = ["-DUSE_BUNDLED_KDSINGLEAPPLICATION=OFF"]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+    "qt6-qtbase",
+    "qt6-qttools",
+]
+makedepends = [
+    "kdsingleapplication-devel",
+    "kguiaddons-devel",
+    "qt6-qtbase-devel",
+    "qt6-qtsvg-devel",
+    "qt6-qttools-devel",
+]
+pkgdesc = "Powerful screenshot software"
+license = "GPL-3.0-or-later AND LGPL-3.0-or-later"
+url = "https://flameshot.org"
+source = [
+    f"https://github.com/flameshot-org/flameshot/archive/refs/tags/v{pkgver}.tar.gz",
+    f"https://gitlab.com/mattbas/Qt-Color-Widgets/-/archive/{_qt_color_widgets_rev}/Qt-Color-Widgets-{_qt_color_widgets_rev}.tar.gz",
+]
+source_paths = [".", "qt-color-widgets"]
+sha256 = [
+    "bd1666313c875400e9588b47eb3fd2f4d0828460b3705a215b97746ea654c1b4",
+    "fba0319194bd99649be6646f3f4c39d6b5467e3d0eceb0b8a53a48ae6b9fdcb2",
+]
+
+
+def post_extract(self):
+    self.mkdir("external")
+    self.mv("qt-color-widgets", "external/Qt-Color-Widgets")
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Package Flameshot 13.3.0 for Chimera Linux.

  Notes:
  - uses system `kdsingleapplication`
  - vendors `Qt-Color-Widgets` as an extra source for now
  - `Qt-Color-Widgets` is not currently packaged separately in `cports`
  - build and template checks passed:
    - `ruff format user/flameshot`
    - `ruff format --check user/flameshot`
    - `./cbuild lint user/flameshot`
    - `./cbuild prepare-upgrade user/flameshot`
    - `./cbuild -A x86_64 pkg user/flameshot`

  `Qt-Color-Widgets` is kept as a bundled extra source in this initial packaging
  because Flameshot still expects it in-tree and there is no standalone
  `Qt-Color-Widgets` package in `cports` yet. `KDSingleApplication` is already
  unbundled and linked against the system package. If preferred by reviewers,
  `Qt-Color-Widgets` can be split into a separate package in a follow-up change.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
