### PR TITLE
main/libpng: update to 1.6.56

### DIFF
--- a/main/libpng/template.py
+++ b/main/libpng/template.py
@@ -1,5 +1,5 @@
 pkgname = "libpng"
-pkgver = "1.6.53"
+pkgver = "1.6.56"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -12,7 +12,7 @@ pkgdesc = "Library for manipulating PNG images"
 license = "Libpng"
 url = "https://www.libpng.org/pub/png/libpng.html"
 source = f"$(SOURCEFORGE_SITE)/libpng/libpng-{pkgver}.tar.xz"
-sha256 = "1d3fb8ccc2932d04aa3663e22ef5ef490244370f4e568d7850165068778d98d4"
+sha256 = "f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18"
 
 
 def post_install(self):


### PR DESCRIPTION
This is pretty urgent because right on LIBPNG's front page notes three security vulnerabilities, two which are high severity, that have been fixed in this latest release.

<img width="1459" height="254" alt="three security vulnerabilites" src="https://github.com/user-attachments/assets/05cba138-c2ac-461d-83a9-4919662a3d1f" />


## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
