### PR TITLE
user/emptty: update to 0.16.1

### DIFF
--- a/user/emptty/template.py
+++ b/user/emptty/template.py
@@ -1,15 +1,15 @@
 pkgname = "emptty"
-pkgver = "0.15.0"
-pkgrel = 1
+pkgver = "0.16.1"
+pkgrel = 0
 build_style = "go"
 make_env = {"CGO_ENABLED": "1"}
 hostmakedepends = ["go"]
-makedepends = ["dinit-chimera", "libx11-devel", "linux-pam-devel"]
+makedepends = ["dinit-chimera", "linux-pam-devel"]
 pkgdesc = "TTY display manager"
 license = "MIT"
 url = "https://github.com/tvrzna/emptty"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "fae7c04afeeb9ef3dcbb9bca67e9a2fa940e99a91872ebc0775e10253972c7f3"
+sha256 = "e85d0658fd793ad97be90af241451a9374b299d9525d2aeb57a6f83f10ad4931"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Upgrade emptty to 0.16.1. This version drops a make dependency on X11 (and contains related bugfix).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
