### PR TITLE
user/dnsproxy: new package

### DIFF
--- a/user/dnsproxy/files/dnsproxy
+++ b/user/dnsproxy/files/dnsproxy
@@ -1,0 +1,5 @@
+# dnsproxy service
+type = process
+command = /usr/libexec/dnsproxy.wrapper
+depends-on = network.target
+logfile = /var/log/dnsproxy.log

--- a/user/dnsproxy/files/dnsproxy.wrapper
+++ b/user/dnsproxy/files/dnsproxy.wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+conf="--config-path=/usr/share/etc/dnsproxy/config.yaml"
+if [ -f /etc/dnsproxy/config.yaml ]; then
+    conf="--config-path=/etc/dnsproxy/config.yaml"
+fi
+
+exec /usr/bin/dnsproxy ${conf}

--- a/user/dnsproxy/template.py
+++ b/user/dnsproxy/template.py
@@ -1,0 +1,24 @@
+pkgname = "dnsproxy"
+pkgver = "0.81.0"
+pkgrel = 0
+build_style = "go"
+hostmakedepends = ["go"]
+makedepends = ["dinit-chimera"]
+pkgdesc = "Simple DNS proxy server that supports all existing DNS protocols"
+license = "Apache-2.0"
+url = "https://github.com/AdguardTeam/dnsproxy"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "d7a1b9d5b6a1f9bb3b3ecc51e8cb61d38f3e35e3b956fe65abd26ef5fd2ee862"
+# TODO: Figure out how to make networking work in check phase...
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_service(self.files_path / "dnsproxy")
+    self.install_file(
+        "config.yaml.dist", "usr/share/etc/dnsproxy/", name="config.yaml"
+    )
+    self.install_file(
+        self.files_path / "dnsproxy.wrapper", "usr/libexec", mode=0o755
+    )
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This adds [AdGuards dnsproxy program](https://github.com/AdguardTeam/dnsproxy/) and dinit service files.
dnsproxy is a DNS proxy that supports basically all DNS protocols.
From their README:
> A simple DNS proxy server that supports all existing DNS protocols including DNS-over-TLS, DNS-over-HTTPS, DNSCrypt, and DNS-over-QUIC. Moreover, it can work as a DNS-over-HTTPS, DNS-over-TLS or DNS-over-QUIC server.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
