### PR TITLE
main/php8.3: fix memory corruption on aarch64 and ppc64

### DIFF
--- a/main/libtool/template.py
+++ b/main/libtool/template.py
@@ -1,6 +1,6 @@
 pkgname = "libtool"
 pkgver = "2.5.4"
-pkgrel = 3
+pkgrel = 4
 build_style = "gnu_configure"
 configure_gen = []
 hostmakedepends = [

--- a/main/php8.3/patches/fix-clobbered-registers.patch
+++ b/main/php8.3/patches/fix-clobbered-registers.patch
@@ -1,0 +1,24 @@
+this is https://github.com/php/php-src/commit/93d32eae2751089ed0d255ba2cf37d5c8a7353e5
+backported to 8.3.
+--- a/Zend/zend_multiply.h	2026-04-05 00:24:14.250604523 +1000
++++ b/Zend/zend_multiply.h	2026-04-05 00:28:54.242121268 +1000
+@@ -267,7 +267,8 @@
+ 		: "=&r"(res), "=&r"(m_overflow)
+ 		: "r"(nmemb),
+ 		  "r"(size),
+-		  "r"(offset));
++		  "r"(offset)
++		: "cc");
+ 
+ 	if (UNEXPECTED(m_overflow)) {
+ 		*overflow = 1;
+@@ -291,7 +292,8 @@
+              : "=&r"(res), "=&r"(m_overflow)
+              : "r"(nmemb),
+                "r"(size),
+-               "r"(offset));
++               "r"(offset)
++             : "xer");
+ 
+         if (UNEXPECTED(m_overflow)) {
+                 *overflow = 1;

--- a/main/php8.3/patches/fix-sni-tests.patch
+++ b/main/php8.3/patches/fix-sni-tests.patch
@@ -1,0 +1,207 @@
+From 178a30b9e700d32a8aac4f49864838829bedd389 Mon Sep 17 00:00:00 2001
+From: Jakub Zelenka <bukka@php.net>
+Date: Sat, 4 Apr 2026 00:28:29 +0200
+Subject: [PATCH] Fix SNI tests for bugs #80770 and #74796
+
+---
+ ext/openssl/tests/bug74796.phpt | 29 ++++++++++++++++++++------
+ ext/openssl/tests/bug80770.phpt | 31 ++++++++++++++++------------
+ php-8.3.30.manifest             | 36 +++++++++++++++++++++++++++++++++
+ 3 files changed, 77 insertions(+), 19 deletions(-)
+ create mode 100644 php-8.3.30.manifest
+
+diff --git a/ext/openssl/tests/bug74796.phpt b/ext/openssl/tests/bug74796.phpt
+index b3f594d5e60f4..8ec5590c064f8 100644
+--- a/ext/openssl/tests/bug74796.phpt
++++ b/ext/openssl/tests/bug74796.phpt
+@@ -12,13 +12,24 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
+ --FILE--
+ <?php
+ 
++include 'CertificateGenerator.inc';
++$certificateGenerator = new CertificateGenerator();
++$caFile = __DIR__ . '/bug74796_ca.pem.tmp';
++$csFile = __DIR__ . '/bug74796_cs.pem.tmp';
++$ukFile = __DIR__ . '/bug74796_uk.pem.tmp';
++$usFile = __DIR__ . '/bug74796_us.pem.tmp';
++$certificateGenerator->saveCaCert($caFile);
++$certificateGenerator->saveNewCertAsFileWithKey('cs.php.net', $csFile);
++$certificateGenerator->saveNewCertAsFileWithKey('uk.php.net', $ukFile);
++$certificateGenerator->saveNewCertAsFileWithKey('us.php.net', $usFile);
++
+ $serverCode = <<<'CODE'
+     $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
+     $ctx = stream_context_create(['ssl' => [
+         'SNI_server_certs' => [
+-            "cs.php.net" => __DIR__ . "/sni_server_cs.pem",
+-            "uk.php.net" => __DIR__ . "/sni_server_uk.pem",
+-            "us.php.net" => __DIR__ . "/sni_server_us.pem"
++            "cs.php.net" => '%s',
++            "uk.php.net" => '%s',
++            "us.php.net" => '%s',
+         ]
+     ]]);
+ 
+@@ -33,6 +44,7 @@ $serverCode = <<<'CODE'
+ 
+     phpt_wait();
+ CODE;
++$serverCode = sprintf($serverCode, $csFile, $ukFile, $usFile);
+ 
+ $proxyCode = <<<'CODE'
+     function parse_sni_from_client_hello($data) {
+@@ -134,7 +146,7 @@ CODE;
+ $clientCode = <<<'CODE'
+     $clientCtx = stream_context_create([
+         'ssl' => [
+-            'cafile' => __DIR__ . '/sni_server_ca.pem',
++            'cafile' => '%s',
+             'verify_peer' => true,
+             'verify_peer_name' => true,
+         ],
+@@ -155,16 +167,21 @@ $clientCode = <<<'CODE'
+ 
+     phpt_notify('server');
+ CODE;
++$clientCode = sprintf($clientCode, $caFile);
+ 
+ include 'ServerClientTestCase.inc';
+ ServerClientTestCase::getInstance()->run($clientCode, [
+-    'server' => $serverCode,
+-    'proxy' => $proxyCode,
++        'server' => $serverCode,
++        'proxy' => $proxyCode,
+ ]);
+ ?>
+ --CLEAN--
+ <?php
+ @unlink(__DIR__ . "/bug74796_proxy_sni.log");
++@unlink(__DIR__ . '/bug74796_ca.pem.tmp');
++@unlink(__DIR__ . '/bug74796_cs.pem.tmp');
++@unlink(__DIR__ . '/bug74796_uk.pem.tmp');
++@unlink(__DIR__ . '/bug74796_us.pem.tmp');
+ ?>
+ --EXPECT--
+ string(19) "Hello from server 0"
+diff --git a/ext/openssl/tests/bug80770.phpt b/ext/openssl/tests/bug80770.phpt
+index 9100aaa5aa188..21860dc78eb7a 100644
+--- a/ext/openssl/tests/bug80770.phpt
++++ b/ext/openssl/tests/bug80770.phpt
+@@ -11,14 +11,25 @@ if (OPENSSL_VERSION_NUMBER < 0x10101000) die("skip OpenSSL v1.1.1 required");
+ <?php
+ $clientCertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug80770_client.pem.tmp';
+ $caCertFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug80770_ca.pem.tmp';
++$csFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug80770_cs.pem.tmp';
++$ukFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug80770_uk.pem.tmp';
++$usFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug80770_us.pem.tmp';
++
++include 'CertificateGenerator.inc';
++$certificateGenerator = new CertificateGenerator();
++$certificateGenerator->saveCaCert($caCertFile);
++$certificateGenerator->saveNewCertAsFileWithKey('cs.php.net', $csFile);
++$certificateGenerator->saveNewCertAsFileWithKey('uk.php.net', $ukFile);
++$certificateGenerator->saveNewCertAsFileWithKey('us.php.net', $usFile);
++$certificateGenerator->saveNewCertAsFileWithKey('Bug80770 Test Client', $clientCertFile);
+ 
+ $serverCode = <<<'CODE'
+     $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+     $ctx = stream_context_create(['ssl' => [
+         'SNI_server_certs' => [
+-            "cs.php.net" => __DIR__ . "/sni_server_cs.pem",
+-            "uk.php.net" => __DIR__ . "/sni_server_uk.pem",
+-            "us.php.net" => __DIR__ . "/sni_server_us.pem"
++            "cs.php.net" => '%s',
++            "uk.php.net" => '%s',
++            "us.php.net" => '%s',
+         ],
+         'verify_peer' => true,
+         'cafile' => '%s',
+@@ -28,7 +39,6 @@ $serverCode = <<<'CODE'
+     ]]);
+     $server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr, $flags, $ctx);
+     phpt_notify_server_start($server);
+-
+     $client = stream_socket_accept($server, 30);
+     if ($client) {
+         $success = stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLS_SERVER);
+@@ -43,7 +53,7 @@ $serverCode = <<<'CODE'
+         phpt_notify(message: "ACCEPT_FAILED");
+     }
+ CODE;
+-$serverCode = sprintf($serverCode, $caCertFile);
++$serverCode = sprintf($serverCode, $csFile, $ukFile, $usFile, $caCertFile);
+ 
+ $clientCode = <<<'CODE'
+     $flags = STREAM_CLIENT_CONNECT;
+@@ -58,19 +68,11 @@ $clientCode = <<<'CODE'
+     if ($client) {
+         stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+     }
+-
+     $result = phpt_wait();
+     echo trim($result);
+ CODE;
+ $clientCode = sprintf($clientCode, $clientCertFile);
+ 
+-include 'CertificateGenerator.inc';
+-
+-// Generate CA and client certificate signed by that CA
+-$certificateGenerator = new CertificateGenerator();
+-$certificateGenerator->saveCaCert($caCertFile);
+-$certificateGenerator->saveNewCertAsFileWithKey('Bug80770 Test Client', $clientCertFile);
+-
+ include 'ServerClientTestCase.inc';
+ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+ ?>
+@@ -78,6 +80,9 @@ ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+ <?php
+ @unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug80770_client.pem.tmp');
+ @unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug80770_ca.pem.tmp');
++@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug80770_cs.pem.tmp');
++@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug80770_uk.pem.tmp');
++@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug80770_us.pem.tmp');
+ ?>
+ --EXPECTF--
+ CLIENT_CERT_CAPTURED
+diff --git a/php-8.3.30.manifest b/php-8.3.30.manifest
+new file mode 100644
+index 0000000000000..ef6ffe8aa803f
+--- /dev/null
++++ b/php-8.3.30.manifest
+@@ -0,0 +1,36 @@
++php-8.3.30.tar.bz2
++SHA256 hash: 800b7b6ed50b73c8ee7844ee5f2f7cc612faa7875a0aa7c4529e8ed5866a5030
++PGP signature:
++-----BEGIN PGP SIGNATURE-----
++
++iHUEABYKAB0WIQTCjZN1dWA+tKu3JYYcB3ncXAqd5AUCaWbJsAAKCRAcB3ncXAqd
++5FioAPwK1gjqwBbGr5g3y1TikqxgKVWMHCtir1n46yGN2hYvtwD/flOR9EqRejNU
++wW4RMkmRwXGsXY28V1DH+NKnDKTEWQ8=
++=jkCu
++-----END PGP SIGNATURE-----
++
++
++php-8.3.30.tar.gz
++SHA256 hash: e587dc95fb7f62730299fa7b36b6e4f91e6708aaefa2fff68a0098d320c16386
++PGP signature:
++-----BEGIN PGP SIGNATURE-----
++
++iHUEABYKAB0WIQTCjZN1dWA+tKu3JYYcB3ncXAqd5AUCaWbJsAAKCRAcB3ncXAqd
++5F4eAP44IkpP3p3FRq3S9pDm9Y6bJnrpzxafqfXlZ949ECmUIgEAxFb+m5Tz7gcb
++DSU+taIv2W6EQeijjaXPvAE2t1dGswo=
++=kn1U
++-----END PGP SIGNATURE-----
++
++
++php-8.3.30.tar.xz
++SHA256 hash: 67f084d36852daab6809561a7c8023d130ca07fc6af8fb040684dd1414934d48
++PGP signature:
++-----BEGIN PGP SIGNATURE-----
++
++iHUEABYKAB0WIQTCjZN1dWA+tKu3JYYcB3ncXAqd5AUCaWbJsQAKCRAcB3ncXAqd
++5NYpAP9Is0pCLlEuLiSRdAbgWPDee0jPA5JGoriGOFNkdMk67AD/WTzYCx7+dEVG
++8Gb54wK005bk9nRGYQqwvZb+r1gqaQU=
++=vSr4
++-----END PGP SIGNATURE-----
++
++

--- a/main/php8.3/template.py
+++ b/main/php8.3/template.py
@@ -1,7 +1,7 @@
 pkgname = "php8.3"
 pkgver = "8.3.30"
 _majver = pkgver[0 : pkgver.rfind(".")]
-pkgrel = 0
+pkgrel = 1
 _apiver = "20230831"
 build_style = "gnu_configure"
 configure_args = [
@@ -158,6 +158,8 @@ def post_patch(self):
         "ext/iconv/tests/iconv_mime_encode.phpt",
         "ext/opcache/tests/issue0115.phpt",
         "ext/opcache/tests/issue0149.phpt",
+        "ext/openssl/tests/sni_server.phpt",
+        "ext/openssl/tests/sni_server_key_cert.phpt",
         "ext/pcntl/tests/pcntl_setpriority_error_linux.phpt",
         "ext/soap/tests/bug73037.phpt",
         "ext/soap/tests/server009.phpt",
@@ -189,15 +191,6 @@ def post_patch(self):
     ]
 
     match self.profile().arch:
-        case "aarch64":
-            # all related to chunked encoding?
-            failing_tests += [
-                "ext/soap/tests/bug47021.phpt",
-                "ext/standard/tests/filters/chunked_001.phpt",
-                "ext/standard/tests/http/bug47021.phpt",
-                "ext/standard/tests/http/bug80256.phpt",
-            ]
-
         case "ppc64le":
             # all related to fibers?
             failing_tests += [

--- a/main/php8.3/update.py
+++ b/main/php8.3/update.py
@@ -1,2 +1,2 @@
-pkgname = "php"
-pattern = r"8\.3\.\d+"
+url = "https://www.php.net/releases/feed.php"
+pattern = r"php:version>(8\.3\.\d+)"


### PR DESCRIPTION
## Description

Running a PHP application on a ROCK64 (`aarch64`) I was seeing the `php-fpm` workers aborting as follows:

```
[04-Apr-2026 20:02:22] WARNING: [pool www] child 6775 said into stderr: "zend_mm_heap corrupted"
[04-Apr-2026 20:02:42] WARNING: [pool www] child 6775 exited on signal 6 (SIGABRT) after 62.634257 seconds from start
```

I found https://github.com/php/php-src/commit/93d32eae2751089ed0d255ba2cf37d5c8a7353e5 in the PHP repo which addresses an issue identified on aarch64 with LTO. Applying it seems to have resolved it. I can at least now access pages that previously aborted. I have not tested the ppc change, only pulled it in from the upstream commit.

Some tests were also failing prior to this change:

- Bug #74796: TLS encryption fails behind HTTP proxy [ext/openssl/tests/bug74796.phpt]
- sni_server [ext/openssl/tests/sni_server.phpt]
- sni_server with separate pk and cert [ext/openssl/tests/sni_server_key_cert.phpt]

The two sni ones are also disabled on Alpine, so they've been added to the skip list. A patch has been pulled in from upstream that addresses bug74796.phpt.

The clobbered registers patch seems to have resolved the tests that were being skipped on aarch64 as these now pass for me, so these have been re-enabled. It's possible that the tests being skipped on ppc64le also pass now, but I don't have an easy way to test this—binfmt-misc builds of this package are super slow.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

