### PR TITLE
user/fonts-maple-mono: new package

### DIFF
--- a/user/fonts-maple-mono-nf
+++ b/user/fonts-maple-mono-nf
@@ -1,0 +1,1 @@
+fonts-maple-mono

--- a/user/fonts-maple-mono/template.py
+++ b/user/fonts-maple-mono/template.py
@@ -1,0 +1,13 @@
+pkgname = "fonts-maple-mono"
+pkgver = "7.9"
+pkgrel = 0
+pkgdesc = "Monospace font with round corners and ligatures"
+license = "OFL-1.1"
+url = "https://font.subf.dev"
+source = f"https://github.com/subframe7536/maple-font/releases/download/v{pkgver}/MapleMono-OTF.zip"
+sha256 = "ecf47b851ae4001b00564399511af8dc9615339d3ae9ded54e8547d6d1ad3da1"
+
+
+def install(self):
+    self.install_file("*.otf", "usr/share/fonts/maple-mono", glob=True)
+    self.install_license("LICENSE.txt")

--- a/user/fonts-maple-mono/template.py
+++ b/user/fonts-maple-mono/template.py
@@ -4,10 +4,32 @@ pkgrel = 0
 pkgdesc = "Monospace font with round corners and ligatures"
 license = "OFL-1.1"
 url = "https://font.subf.dev"
-source = f"https://github.com/subframe7536/maple-font/releases/download/v{pkgver}/MapleMono-OTF.zip"
-sha256 = "ecf47b851ae4001b00564399511af8dc9615339d3ae9ded54e8547d6d1ad3da1"
+source = [
+    f"https://github.com/subframe7536/maple-font/releases/download/v{pkgver}/MapleMono-OTF.zip",
+    f"https://github.com/subframe7536/maple-font/releases/download/v{pkgver}/MapleMono-NF-unhinted.zip",
+]
+source_paths = ["maple-otf", "maple-nf"]
+sha256 = [
+    "ecf47b851ae4001b00564399511af8dc9615339d3ae9ded54e8547d6d1ad3da1",
+    "8248d6260660be1066b5ebe90d25131582df8383f38db1c284dd1f2dc9d2b46e",
+]
 
 
 def install(self):
-    self.install_file("*.otf", "usr/share/fonts/maple-mono", glob=True)
-    self.install_license("LICENSE.txt")
+    self.install_file(
+        "maple-otf/*.otf", "usr/share/fonts/maple-mono", glob=True
+    )
+    self.install_file(
+        "maple-nf/*.ttf", "usr/share/fonts/maple-mono-nf", glob=True
+    )
+    self.install_license("maple-otf/LICENSE.txt")
+    self.install_license("maple-nf/LICENSE.txt", pkgname="fonts-maple-mono-nf")
+
+
+@subpackage("fonts-maple-mono-nf")
+def _(self):
+    self.pkgdesc = "Maple Mono with Nerd Font patches"
+    return [
+        "usr/share/fonts/maple-mono-nf",
+        "?usr/share/licenses/fonts-maple-mono-nf",
+    ]


### PR DESCRIPTION
## Description

This adds the MapleMono font int the ligature (default) version. There are additional versions  (No-Ligature,Normal-Ligature,Normal-No-Ligature) and different formats (CN, NerdFont, etc.) which could also be added as subpackages later as well. For now, this just serves as baseline.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
