### PR TITLE
user/toml-bombadil: new package

### DIFF
--- a/user/toml-bombadil/template.py
+++ b/user/toml-bombadil/template.py
@@ -1,0 +1,19 @@
+pkgname = "toml-bombadil"
+pkgver = "4.2.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo", "pkgconf"]
+makedepends = ["gnupg", "libgit2-devel", "openssl3-devel"]
+depends = ["gnupg"]
+pkgdesc = "Dotfile manager written in Rust"
+license = "MIT"
+url = "https://oknozor.github.io/toml-bombadil"
+source = f"https://github.com/oknozor/toml-bombadil/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "b911678642a1229908dfeabbdd7f799354346c0e37f3ac999277655e01b6f229"
+# Needs network access during check phase and weird permission problems when
+# running gpg in the bubblewrap container. All other tests pass though
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This adds [toml-bombadil](https://oknozor.github.io/toml-bombadil), a dotfiles manager written in rust. I've disabled checks for now, since they require internet access and some strange gpg permissions which conflict with the bubblewrap container cports runs tests in. All other tests work fine though.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
