### PR TITLE
main/libtool: rebuild for llvm 22

### DIFF
--- a/main/libtool/template.py
+++ b/main/libtool/template.py
@@ -1,6 +1,6 @@
 pkgname = "libtool"
 pkgver = "2.5.4"
-pkgrel = 3
+pkgrel = 4
 build_style = "gnu_configure"
 configure_gen = []
 hostmakedepends = [


### PR DESCRIPTION
## Description

`/usr/bin/libtool` had a bunch of references to `/usr/lib/clang/21/`, which was causing the `main/php8.3` build to fail for me.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
