### PR TITLE
user/cargo-deny: update to 0.19.4

### DIFF
--- a/user/cargo-deny/template.py
+++ b/user/cargo-deny/template.py
@@ -1,10 +1,7 @@
 pkgname = "cargo-deny"
-pkgver = "0.18.6"
+pkgver = "0.19.4"
 pkgrel = 0
 build_style = "cargo"
-make_build_args = ["--no-default-features", "--features=native-certs"]
-make_install_args = [*make_build_args]
-make_check_args = [*make_build_args]
 hostmakedepends = ["cargo-auditable", "pkgconf"]
 makedepends = ["rust-std", "zstd-devel"]
 depends = ["ca-certificates"]
@@ -12,7 +9,7 @@ pkgdesc = "Cargo plugin for linting dependencies"
 license = "MIT OR Apache-2.0"
 url = "https://github.com/EmbarkStudios/cargo-deny"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "9f4227c5eb94011cc32601e8f2acbf6651ab7ee632cda2e5e05e242207a07d73"
+sha256 = "f69e6472a02c6059c2813170d9767ff7305862c82d7b6a09dea8cb1e67648b73"
 # TODO
 options = ["!check"]
 


### PR DESCRIPTION
[For context on why Native certs was removed:](https://github.com/EmbarkStudios/cargo-deny/blob/cfe589ec21d70996a3e44d76a8e2b9369f7e0a2f/CHANGELOG.md)

> https://github.com/EmbarkStudios/cargo-deny/pull/825 updated gix, reqwest, and tame-index to newer versions. The reqwest 0.13 changes means it is no longer possible to choose the source of root certificates for gix, so that decision is now left to rustls-platform-verifier. The native-certs feature has thus been removed, and cargo-deny no longer defaults to using webpki-roots.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
