### PR TITLE
main/fonts-source-serif-otf: new package

### DIFF
--- a/main/fonts-source-serif-otf/template.py
+++ b/main/fonts-source-serif-otf/template.py
@@ -1,0 +1,17 @@
+pkgname = "fonts-source-serif-otf"
+pkgver = "4.005"
+pkgrel = 0
+pkgdesc = "Companion serif font family for Source Sans"
+license = "OFL-1.1"
+url = "https://adobe-fonts.github.io/source-serif"
+source = f"https://github.com/adobe-fonts/source-serif/releases/download/{pkgver}R/source-serif-{pkgver}_Desktop.zip"
+sha256 = "549fdb8f9a682bd06944298621404969f6de77c2e422ff3b8244a1dcd6a0c425"
+
+
+def install(self):
+    self.install_file(
+        f"source-serif-{pkgver}_Desktop/OTF/*.otf",
+        "usr/share/fonts/source-serif",
+        glob=True,
+    )
+    self.install_license(f"source-serif-{pkgver}_Desktop/LICENSE.md")


### PR DESCRIPTION
## Description

[Source Serif 4](https://adobe-fonts.github.io/source-serif) is the companion serif font for Source Sans which is already in cports.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date