### PR TITLE
user/github-cli: update to 2.92.0

### DIFF
--- a/user/github-cli/template.py
+++ b/user/github-cli/template.py
@@ -1,5 +1,5 @@
 pkgname = "github-cli"
-pkgver = "2.87.3"
+pkgver = "2.92.0"
 pkgrel = 0
 build_style = "go"
 make_build_args = [
@@ -14,7 +14,7 @@ pkgdesc = "GitHub CLI tool"
 license = "MIT"
 url = "https://cli.github.com"
 source = f"https://github.com/cli/cli/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "8aa3458df7204c8b788e3d05c1363fefd899f8a53de22b067d924f24a8ae75ea"
+sha256 = "ad18928ce4e2695d7fc1adefa0f5e0496e570a430016cee4c22d7bf87e5d9c1d"
 # cross: uses native binary to generate completions
 # check: needs network access
 options = ["!cross", "!check"]


### PR DESCRIPTION
## Description

updated github-cli to 2.92.0

executing `gh config set telemetry disabled` might be a good idea after this update

https://cli.github.com/telemetry#how-to-opt-out

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine