### PR TITLE
main/curl, main/ngtcp2: update to 8.20.0 and 1.22.1 respectively

### DIFF
--- a/main/curl/template.py
+++ b/main/curl/template.py
@@ -1,5 +1,5 @@
 pkgname = "curl"
-pkgver = "8.18.0"
+pkgver = "8.20.0"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -16,7 +16,7 @@ configure_args = [
     "--with-libssh2",
     "--with-nghttp2",
     "--with-nghttp3",
-    "--with-openssl-quic",
+    "--with-ngtcp2",
     "--with-ssl",
     "--with-zlib",
     "--with-zsh-functions-dir=/usr/share/zsh/site-functions/",
@@ -32,6 +32,7 @@ makedepends = [
     "libssh2-devel",
     "nghttp2-devel",
     "nghttp3-devel",
+    "ngtcp2-devel",
     "openssl3-devel",
     "zlib-ng-compat-devel",
     "zstd-devel",
@@ -45,9 +46,9 @@ checkdepends = [
 depends = ["ca-certificates"]
 pkgdesc = "Command line tool for transferring data with URL syntax"
 license = "MIT"
-url = "https://curl.haxx.se"
+url = "https://curl.se"
 source = f"{url}/download/curl-{pkgver}.tar.xz"
-sha256 = "40df79166e74aa20149365e11ee4c798a46ad57c34e4f68fd13100e2c9a91946"
+sha256 = "63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896"
 hardening = ["vis", "!cfi"]
 
 

--- a/main/ngtcp2/template.py
+++ b/main/ngtcp2/template.py
@@ -1,20 +1,20 @@
 pkgname = "ngtcp2"
-pkgver = "1.14.0"
+pkgver = "1.22.1"
 pkgrel = 0
 build_style = "cmake"
-configure_args = ["-DENABLE_GNUTLS=ON", "-DENABLE_OPENSSL=OFF"]
+configure_args = ["-DENABLE_GNUTLS=ON", "-DENABLE_OPENSSL=ON"]
 make_check_target = "check"
 hostmakedepends = [
     "cmake",
     "ninja",
     "pkgconf",
 ]
-makedepends = ["gnutls-devel"]
+makedepends = ["gnutls-devel", "openssl3-devel"]
 pkgdesc = "C IETF QUIC protocol implementation"
 license = "MIT"
 url = "https://github.com/ngtcp2/ngtcp2"
 source = f"{url}/releases/download/v{pkgver}/ngtcp2-{pkgver}.tar.xz"
-sha256 = "d1fbf9eae92921bfd33154dab2574bc4b7d7936f486396d6c78bfff90ed5b35d"
+sha256 = "dfd2c68bd64b89847c611425b9487105c46e8447b5c21e6aeb00642c8fbe2ca8"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Bumping curl to 8.20.0 required setting `ENABLE_OPENSSL=ON` in ngtcp2, so I did. I wasn't sure whether to set `ENABLE_GNUTLS=OFF` because I thought it might break things, so I left it. I also took the opportunity to bump the version of ngtcp2.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine