### PR TITLE
main/fontconfig: update to 2.17.1

### DIFF
--- a/main/fontconfig/template.py
+++ b/main/fontconfig/template.py
@@ -1,5 +1,5 @@
 pkgname = "fontconfig"
-pkgver = "2.16.0"
+pkgver = "2.17.1"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -20,8 +20,8 @@ triggers = ["/usr/share/fonts/*"]
 pkgdesc = "Library for configuring and customizing font access"
 license = "MIT"
 url = "https://www.fontconfig.org"
-source = f"$(FREEDESKTOP_SITE)/fontconfig/release/fontconfig-{pkgver}.tar.xz"
-sha256 = "6a33dc555cc9ba8b10caf7695878ef134eeb36d0af366041f639b1da9b6ed220"
+source = f"https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/{pkgver}/fontconfig-{pkgver}.tar.xz"
+sha256 = "9f5cae93f4fffc1fbc05ae99cdfc708cd60dfd6612ffc0512827025c026fa541"
 
 
 def post_install(self):

--- a/main/fontconfig/update.py
+++ b/main/fontconfig/update.py
@@ -1,1 +1,4 @@
-ignore = ["*.9[0-9]"]
+url = "https://gitlab.freedesktop.org/fontconfig/fontconfig/-/tags?format=atom"
+pattern = (
+    "https://gitlab.freedesktop.org/fontconfig/fontconfig/-/tags/([0-9.]+)"
+)


### PR DESCRIPTION
## Description

Switches the source to GitLab as per [notes](https://www.freedesktop.org/wiki/Software/fontconfig/#:~:text=Releases):

> The current stable series is 2.17.1. Releases until 2.16.0 are available in the [release](http://fontconfig.org/release) directory and Releases after that are available in the [GitLab](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/releases).

The new source is the tarball attached to the release.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
