### PR TITLE
user/luanti: update to 5.16.1, fix OGLES2 crash

### DIFF
--- a/user/luanti/template.py
+++ b/user/luanti/template.py
@@ -1,5 +1,5 @@
 pkgname = "luanti"
-pkgver = "5.15.2"
+pkgver = "5.16.1"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -48,7 +48,7 @@ url = "https://www.luanti.org"
 source = (
     f"https://github.com/luanti-org/luanti/archive/refs/tags/{pkgver}.tar.gz"
 )
-sha256 = "1fdfa8b973968f8fcf5a264ce3fb3a170c3882105f953498a64d6415eff83471"
+sha256 = "57926752365a17d3bf64945ea04dc63cc446a8863037b043b97799af30126b6b"
 tool_flags = {"CFLAGS": ["-DNDEBUG"], "CXXFLAGS": ["-DNDEBUG"]}
 hardening = ["!int"]
 # see below
@@ -70,8 +70,6 @@ def post_install(self):
         "etc/luanti",
         name="minetest.conf",
     )
-    # dead symlink
-    self.uninstall("usr/share/luanti/client/shaders/Irrlicht")
 
 
 @subpackage("luanti-common")


### PR DESCRIPTION
## Description

Update `user/luanti` to version 5.16.1
Remove deletion of Irrlicht dir which is needed under OpenGL ES driver

Crash log:
```
> luanti
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open vertex shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.vsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open pixel shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.fsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open vertex shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.vsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open pixel shader program file: /usr/share/luanti/client/shaders/Irrlicht/TransparentAlphaChannel.fsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open vertex shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.vsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open pixel shader program file: /usr/share/luanti/client/shaders/Irrlicht/TransparentAlphaChannelRef.fsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open vertex shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.vsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open pixel shader program file: /usr/share/luanti/client/shaders/Irrlicht/TransparentVertexAlpha.fsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open vertex shader program file: /usr/share/luanti/client/shaders/Irrlicht/Solid.vsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Could not open pixel shader program file: /usr/share/luanti/client/shaders/Irrlicht/OneTextureBlend.fsh
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Warning: Missing shader files needed to simulate fixed function materials:
/usr/share/luanti/client/shaders/Irrlicht/Renderer2D.vsh
Shaderpath can be changed in SIrrCreationParamters::OGLES2ShaderPath
2026-05-17 02:28:55: WARNING[Main]: Irrlicht: Warning: Missing shader files needed to simulate fixed function materials:
/usr/share/luanti/client/shaders/Irrlicht/Renderer2D.vsh
Shaderpath can be changed in SIrrCreationParamters::OGLES2ShaderPath

fish: Job 1, 'luanti' terminated by signal SIGSEGV (Address boundary error)
```

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
