### PR TITLE
main/dinit: restore Linux-specific functionality

### DIFF
--- a/main/dinit/template.py
+++ b/main/dinit/template.py
@@ -1,16 +1,15 @@
 pkgname = "dinit"
 pkgver = "0.21.0"
-pkgrel = 0
+pkgrel = 1
 # has some fixes on top of 0.21.0 and feature i want to try
 _gitrev = "3aa6f0392034f3e28773b7e90013defd94cb5cfd"
 build_style = "configure"
 configure_args = [
     "--disable-strip",
     "--enable-shutdown",
+    "--platform=Linux",
     "--sbindir=/usr/bin",
     "--syscontrolsocket=/run/dinitctl",
-    "LDFLAGS_EXTRA=-lcap",
-    "TEST_LDFLAGS_EXTRA=-lcap",
 ]
 make_check_args = ["check-igr"]  # additional target
 makedepends = ["libcap-devel"]


### PR DESCRIPTION
The configure script of previous versions, when detecting "cross-compiling" (with false positive for a native build in cports), would (inappropriately) default to the host platform, which was accidentally correct for cports because it only supports Linux. Now the platform defaults to "unknown", losing all Linux-specific functionality (capabilities, cgroups, I/O priority, OOM adjustment). This leads to a failure to process service descriptions using the functionality (right now the only in-tree example is caddy), and further to a boot failure if such a service is actually enabled.

Pass the correct platform to restore the functionality. Also remove the code to explicitly link against libcap because evidently that's now neither necessary nor sufficient.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
