### PR TITLE
main/bubblewrap: update to 0.11.2

### DIFF
--- a/main/bubblewrap/template.py
+++ b/main/bubblewrap/template.py
@@ -1,5 +1,5 @@
 pkgname = "bubblewrap"
-pkgver = "0.11.1"
+pkgver = "0.11.2"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = ["meson", "pkgconf", "libxslt-progs", "docbook-xsl-nons"]
@@ -9,7 +9,7 @@ pkgdesc = "Unprivileged sandboxing tool"
 license = "LGPL-2.0-or-later"
 url = "https://github.com/containers/bubblewrap"
 source = f"{url}/releases/download/v{pkgver}/bubblewrap-{pkgver}.tar.xz"
-sha256 = "c1b7455a1283b1295879a46d5f001dfd088c0bb0f238abb5e128b3583a246f71"
+sha256 = "69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6"
 hardening = ["vis", "cfi"]
 
 # efault instead of econnrefused for various assertions


### PR DESCRIPTION
## Description

updated bubblewrap to 0.11.2

upstream has a new build option `-Dsupport_setuid` but since Chimera hasn't enabled setuid builds of bwrap so far, I haven't enabled it either

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine