### PR TITLE
user/xwallpaper: new package

### DIFF
--- a/user/xwallpaper/template.py
+++ b/user/xwallpaper/template.py
@@ -1,0 +1,33 @@
+pkgname = "xwallpaper"
+pkgver = "0.7.6"
+pkgrel = 0
+
+build_style = "gnu_configure"
+configure_gen = ["./autogen.sh"]
+
+hostmakedepends = [
+    "automake",
+    "pkgconf",
+]
+
+makedepends = [
+    "libjpeg-turbo-devel",
+    "libpng-devel",
+    "libseccomp-devel",
+    "libxcb-devel",
+    "libxpm-devel",
+    "linux-headers",
+    "pixman-devel",
+    "xcb-util-devel",
+    "xcb-util-image-devel",
+]
+
+pkgdesc = "Wallpaper setting utility for X"
+license = "ISC"
+url = "https://github.com/stoeckmann/xwallpaper"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "380aae8762a296f5e0284eff87ac92babd9c68e3e7612a8208f86b0dea814750"
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Add xwallpaper to user.
The xwallpaper utility allows you to set image files as your X wallpaper.

Tested with:

- ./cbuild -f pkg -v user/xwallpaper
- ./cbuild lint user/xwallpaper
- installed and ran successfully in a Chimera VM

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
