### PR TITLE
user/wl-clip-persist: new package

### DIFF
--- a/user/wl-clip-persist/files/wl-clip-persist.user
+++ b/user/wl-clip-persist/files/wl-clip-persist.user
@@ -1,0 +1,4 @@
+type = process
+command = /usr/bin/wl-clip-persist --clipboard regular --disable-timestamps
+log-type = buffer
+depends-on: graphical.target

--- a/user/wl-clip-persist/template.py
+++ b/user/wl-clip-persist/template.py
@@ -1,0 +1,23 @@
+pkgname = "wl-clip-persist"
+pkgver = "0.5.0"
+pkgrel = 0
+build_style = "cargo"
+
+hostmakedepends = ["cargo-auditable"]
+makedepends = [
+    "dinit-chimera",
+    "rust-std",
+    "turnstile",
+]
+
+pkgdesc = "Keep Wayland clipboard contents after source programs close"
+license = "MIT"
+url = "https://github.com/Linus789/wl-clip-persist"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "fdd2506e6556dda943a164d891fe498985838fdd0e94c54e595a8f1cd8c49b66"
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/wl-clip-persist")
+    self.install_service(self.files_path / "wl-clip-persist.user")
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

Add wl-clip-persist to user.

wl-clip-persist keeps Wayland clipboard contents available after the source
application exits. This also includes an optional user dinit service for running
it in graphical sessions.

Tested with:

- ./cbuild -f pkg -v user/wl-clip-persist
- ./cbuild lint user/wl-clip-persist
- installed and tested package + user dinit service in a Chimera VM

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
