### PR TITLE
user/quickshell: new package

### DIFF
--- a/user/cli11/template.py
+++ b/user/cli11/template.py
@@ -1,0 +1,18 @@
+pkgname = "cli11"
+pkgver = "2.6.2"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DCLI11_BUILD_EXAMPLES=OFF",
+    "-DCLI11_BUILD_TESTS=OFF",
+]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+pkgdesc = "Command line parser for C++11"
+license = "BSD-3-Clause"
+url = "https://github.com/CLIUtils/CLI11"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "c6ea6b2e5608b3ea8617999bd5f47420c71b2ebdb8dc4767c1034d1da5785711"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/cpptrace-devel
+++ b/user/cpptrace-devel
@@ -1,0 +1,1 @@
+cpptrace

--- a/user/cpptrace/template.py
+++ b/user/cpptrace/template.py
@@ -1,0 +1,28 @@
+pkgname = "cpptrace"
+pkgver = "1.0.4"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DCPPTRACE_BUILD_SHARED=ON",
+    "-DCPPTRACE_GET_SYMBOLS_WITH_LIBDWARF=ON",
+    "-DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON",
+    "-DCPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG=ON",
+    "-DCPPTRACE_USE_EXTERNAL_ZSTD=ON",
+    "-DCPPTRACE_UNWIND_WITH_LIBUNWIND=ON",
+]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = ["libdwarf-devel", "libunwind-devel", "zstd-devel"]
+pkgdesc = "Stacktrace library for C++11 and newer"
+license = "MIT"
+url = "https://github.com/jeremy-rifkin/cpptrace"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "5c9f5b301e903714a4d01f1057b9543fa540f7bfcc5e3f8bd1748e652e24f9ea"
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+
+
+@subpackage("cpptrace-devel")
+def _(self):
+    return self.default_devel()

--- a/user/libdwarf-devel
+++ b/user/libdwarf-devel
@@ -1,0 +1,1 @@
+libdwarf

--- a/user/libdwarf/template.py
+++ b/user/libdwarf/template.py
@@ -1,0 +1,21 @@
+pkgname = "libdwarf"
+pkgver = "2.3.1"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DBUILD_SHARED=ON"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = ["zlib-ng-compat-devel", "zstd-devel"]
+pkgdesc = "Library to access DWARF debugging information"
+license = "LGPL-2.1-only AND GPL-2.0-only AND BSD-2-Clause AND BSD-3-Clause"
+url = "https://www.prevanders.net/dwarf.html"
+source = f"https://github.com/davea42/libdwarf-code/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "0caec41d0a6294de5548273d7d47d7944a0d25b003b64b119bf2580c2ee49ad9"
+
+
+def post_install(self):
+    self.install_license("COPYING")
+
+
+@subpackage("libdwarf-devel")
+def _(self):
+    return self.default_devel()

--- a/user/libdwarf/update.py
+++ b/user/libdwarf/update.py
@@ -1,0 +1,4 @@
+# template url points to prevanders.net, which pollutes the check with
+# legacy date tags (YYYYMMDD) and an old 0.x series. Restrict to GitHub tags.
+url = "https://github.com/davea42/libdwarf-code/tags"
+pattern = r"/tag/v([\d.]+)"

--- a/user/quickshell/template.py
+++ b/user/quickshell/template.py
@@ -1,0 +1,51 @@
+pkgname = "quickshell"
+pkgver = "0.3.0"
+pkgrel = 0
+build_style = "cmake"
+configure_args = [
+    "-DDISTRIBUTOR=Chimera Linux",
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+    "-DINSTALL_QML_PREFIX=lib/qt6/qml",
+    # PCH breaks polkit build with clang, see
+    # https://github.com/quickshell-mirror/quickshell/issues/491
+    "-DNO_PCH=ON",
+]
+hostmakedepends = [
+    "cmake",
+    "ninja",
+    "pkgconf",
+    "qt6-qtshadertools",
+    "spirv-tools",
+    "wayland-progs",
+]
+makedepends = [
+    "cli11",
+    "cpptrace-devel",
+    "glib-devel",
+    "jemalloc-devel",
+    "libdrm-devel",
+    "libxcb-devel",
+    "linux-pam-devel",
+    "mesa-gbm-devel",
+    "pipewire-devel",
+    "polkit-devel",
+    "qt6-qtbase-private-devel",
+    "qt6-qtdeclarative-devel",
+    "vulkan-headers",
+    "wayland-devel",
+    "wayland-protocols",
+]
+depends = ["qt6-qtsvg"]
+pkgdesc = "QtQuick toolkit for making desktop shells on Wayland and X11"
+license = "LGPL-3.0-only"
+url = "https://quickshell.org"
+source = (
+    f"https://git.outfoxxed.me/quickshell/quickshell/archive/v{pkgver}.tar.gz"
+)
+sha256 = "f4821f9084cab04bd2b5384cc92b9726aecc4ce3eb27200dca24edc67da3b6e5"
+# TODO
+options = ["!cross"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/quickshell/update.py
+++ b/user/quickshell/update.py
@@ -1,0 +1,2 @@
+url = "https://git.outfoxxed.me/quickshell/quickshell/tags.atom"
+pattern = r">v([\d.]+)<"


### PR DESCRIPTION
## Description

Quickshell is a toolkit for building status bars, widgets, lockscreens, and other desktop components using QtQuick. It can be used alongside your wayland compositor or window manager to build a complete desktop environment.

Adds quickshell plus its three new dependencies:

- cli11 — command line parser for C++11
- libdwarf — library to access DWARF debugging information
- cpptrace — stacktrace library for C++11 and newer (used by quickshell's crash handler; depends on libdwarf)

cpptrace and quickshell use the system libunwind, which quickshell's crash handler requires.

## Checklist

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date