### PR TITLE
main/networkmanager-openvpn: remove unused sysusers and tmpfiles

### DIFF
--- a/main/networkmanager-openvpn/template.py
+++ b/main/networkmanager-openvpn/template.py
@@ -1,6 +1,6 @@
 pkgname = "networkmanager-openvpn"
 pkgver = "1.12.5"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--libexecdir=/usr/libexec",  # TODO switch libexec
@@ -33,3 +33,5 @@ options = ["linkundefver"]
 
 def post_install(self):
     self.install_sysusers(self.files_path / "sysusers.conf")
+    self.uninstall("usr/lib/sysusers.d/nm-openvpn-sysusers.conf")
+    self.uninstall("usr/lib/tmpfiles.d/nm-openvpn-tmpfiles.conf")


### PR DESCRIPTION
## Description

networkmanager-openvpn was creating its own unused sysusers and tmpfiles

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine