### PR TITLE
cbuild: update XORG_URL

### DIFF
--- a/src/cbuild/core/template.py
+++ b/src/cbuild/core/template.py
@@ -576,7 +576,7 @@ sites = {
     "nongnu": "https://download.savannah.nongnu.org/releases",
     "kernel": "https://www.kernel.org/pub/linux",
     "gnome": "https://download.gnome.org/sources",
-    "xorg": "https://www.x.org/releases/individual",
+    "xorg": "https://xorg.freedesktop.org/releases/individual",
     "cpan": "https://www.cpan.org/modules/by-module",
     "pypi": "https://files.pythonhosted.org/packages/source",
     "gnu": "https://ftpmirror.gnu.org/gnu",


### PR DESCRIPTION
## Description

this pr changes the xorg url to https://xorg.freedesktop.org which unbreaks the update check and downloading packages as the old url now redirects to https://www.x.org/archive/individual which 404s

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
