### PR TITLE
xdelta: new package

### DIFF
--- a/user/xdelta/template.py
+++ b/user/xdelta/template.py
@@ -1,0 +1,13 @@
+pkgname = "xdelta"
+pkgver = "3.1.0"
+pkgrel = 0
+build_wrksrc = "xdelta3"
+build_style = "gnu_configure"
+hostmakedepends = [
+    "automake",
+]
+pkgdesc = "Delta compression using VCDIFF/RFC 3284 streams"
+license = "GPL-2.0-only"
+url = "https://github.com/jmacd/xdelta"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "7515cf5378fca287a57f4e2fee1094aabc79569cfe60d91e06021a8fd7bae29d"


### PR DESCRIPTION
## Description

Adds xdelta, a diff tool that implements RFC3284

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date

Note: this version is licensed GPL-2.0-only. The repo was relicensed to Apache, but there have been no tags since.