### PR TITLE
cbuild: add bash completion

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -2482,6 +2482,12 @@ class InteractiveCompleter:
         return None
 
 
+def do_compgen():
+    pass
+
+def do_shell_completion():
+    pass
+
 def do_commit(tgt):
     from cbuild.core import errors, chroot, paths, template, logger, git
     import tempfile
@@ -2807,6 +2813,11 @@ command_handlers = {
     ),
     "update-check": (do_update_check, "Check a template for upstream updates"),
     "zap": (do_zap, "Remove the bldroot"),
+    "compgen": (do_compgen, "Generate bash completions"),
+    "complete": (
+        do_shell_completion,
+        "Preform completion on the arguments, Intended for internal use only",
+    ),
     "interactive": (do_interactive, "Enter interactive prompt"),
 }
 


### PR DESCRIPTION
## Description

creates two new commands, compgen, which will generate a script suitable
for bash completion, and complete, which will preform completion on the
arguments.

I intend to model it after 'gh's (github cli) and 'cargo''s (rust) completion

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [ ] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
