### PR TITLE
main/emacs-*: add tree-sitter query patch

### DIFF
--- a/main/emacs-console/patches/tree-sitter-query.patch
+++ b/main/emacs-console/patches/tree-sitter-query.patch
@@ -1,0 +1,277 @@
+Fix query predicate names for tree-sitter-0.26
+Patch backported from master branch
+https://bugs.gentoo.org/971731
+
+commit b01435306a36e4e75671fbe7bacea351f89947d5
+Author: Yuan Fu <casouri@gmail.com>
+Date:   Sun, 2 Nov 2025 16:16:50 -0800
+
+    Change tree-sitter query predicate names (bug#79687)
+
+--- emacs-30.2/doc/lispref/parsing.texi
++++ emacs-30.2/doc/lispref/parsing.texi
+@@ -1375,7 +1375,7 @@
+ @group
+ (
+  (array :anchor (_) @@first (_) @@last :anchor)
+- (:equal @@first @@last)
++ (:eq? @@first @@last)
+ )
+ @end group
+ @end example
+@@ -1384,24 +1384,32 @@
+ tree-sitter only matches arrays where the first element is equal to
+ the last element.  To attach a predicate to a pattern, we need to
+ group them together.  Currently there are three predicates:
+-@code{:equal}, @code{:match}, and @code{:pred}.
++@code{:eq?}, @code{:match?}, and @code{:pred?}.
+ 
+-@deffn Predicate :equal arg1 arg2
++@deffn Predicate :eq? arg1 arg2
+ Matches if @var{arg1} is equal to @var{arg2}.  Arguments can be either
+ strings or capture names.  Capture names represent the text that the
+-captured node spans in the buffer.
++captured node spans in the buffer.  Note that this is more like
++@code{equal} in Elisp, but @code{eq?} is the convention used by
++tree-sitter.  Previously we supported the @code{:equal} predicate but
++it's now considered deprecated.
+ @end deffn
+ 
+-@deffn Predicate :match regexp capture-name
++@deffn Predicate :match? capture-name regexp
+ Matches if the text that @var{capture-name}'s node spans in the buffer
+ matches regular expression @var{regexp}, given as a string literal.
+-Matching is case-sensitive.
++Matching is case-sensitive.  The ordering of the arguments doesn't
++matter.  Previously we supported the @code{:match} predicate but it's
++now considered deprecated.
+ @end deffn
+ 
+-@deffn Predicate :pred fn &rest nodes
++@deffn Predicate :pred? fn &rest nodes
+ Matches if function @var{fn} returns non-@code{nil} when passed each
+ node in @var{nodes} as arguments.  The function runs with the current
+-buffer set to the buffer of node being queried.
++buffer set to the buffer of node being queried.  Be very careful when
++using this predicate, since it can be expensive when used in a tight
++loop.  Previously we supported the @code{:pred} predicate but it's now
++considered deprecated.
+ @end deffn
+ 
+ Note that a predicate can only refer to capture names that appear in
+@@ -1456,9 +1464,9 @@
+ @item
+ @samp{:+} is written as @samp{+}.
+ @item
+-@code{:equal}, @code{:match} and @code{:pred} are written as
+-@code{#equal}, @code{#match} and @code{#pred}, respectively.
+-In general, predicates change their @samp{:} to @samp{#}.
++@code{:eq?}, @code{:match?} and @code{:pred?} are written as
++@code{#eq?}, @code{#match?} and @code{#pred?}, respectively.  In
++general, predicates change the @samp{:} to @samp{#}.
+ @end itemize
+ 
+ For example,
+@@ -1467,7 +1475,7 @@
+ @group
+ '((
+    (compound_expression :anchor (_) @@first (_) :* @@rest)
+-   (:match "love" @@first)
++   (:match? "love" @@first)
+    ))
+ @end group
+ @end example
+@@ -1479,7 +1487,7 @@
+ @group
+ "(
+   (compound_expression . (_) @@first (_)* @@rest)
+-  (#match \"love\" @@first)
++  (#match? \"love\" @@first)
+   )"
+ @end group
+ @end example
+--- emacs-30.2/src/treesit.c
++++ emacs-30.2/src/treesit.c
+@@ -415,17 +415,17 @@
+ static Lisp_Object Vtreesit_str_question_mark;
+ static Lisp_Object Vtreesit_str_star;
+ static Lisp_Object Vtreesit_str_plus;
+-static Lisp_Object Vtreesit_str_pound_equal;
+-static Lisp_Object Vtreesit_str_pound_match;
+-static Lisp_Object Vtreesit_str_pound_pred;
++static Lisp_Object Vtreesit_str_pound_eq_question_mark;
++static Lisp_Object Vtreesit_str_pound_match_question_mark;
++static Lisp_Object Vtreesit_str_pound_pred_question_mark;
+ static Lisp_Object Vtreesit_str_open_bracket;
+ static Lisp_Object Vtreesit_str_close_bracket;
+ static Lisp_Object Vtreesit_str_open_paren;
+ static Lisp_Object Vtreesit_str_close_paren;
+ static Lisp_Object Vtreesit_str_space;
+-static Lisp_Object Vtreesit_str_equal;
+-static Lisp_Object Vtreesit_str_match;
+-static Lisp_Object Vtreesit_str_pred;
++static Lisp_Object Vtreesit_str_eq_question_mark;
++static Lisp_Object Vtreesit_str_match_question_mark;
++static Lisp_Object Vtreesit_str_pred_question_mark;
+ static Lisp_Object Vtreesit_str_empty;
+ 
+ /* This is the limit on recursion levels for some tree-sitter
+@@ -2620,12 +2620,12 @@
+     return Vtreesit_str_star;
+   if (BASE_EQ (pattern, QCplus))
+     return Vtreesit_str_plus;
+-  if (BASE_EQ (pattern, QCequal))
+-    return Vtreesit_str_pound_equal;
+-  if (BASE_EQ (pattern, QCmatch))
+-    return Vtreesit_str_pound_match;
+-  if (BASE_EQ (pattern, QCpred))
+-    return Vtreesit_str_pound_pred;
++  if (BASE_EQ (pattern, QCequal) || BASE_EQ (pattern, QCeq_q))
++    return Vtreesit_str_pound_eq_question_mark;
++  if (BASE_EQ (pattern, QCmatch) || BASE_EQ (pattern, QCmatch_q))
++    return Vtreesit_str_pound_match_question_mark;
++  if (BASE_EQ (pattern, QCpred) || BASE_EQ (pattern, QCpred_q))
++    return Vtreesit_str_pound_pred_question_mark;
+   Lisp_Object opening_delimeter
+     = VECTORP (pattern)
+       ? Vtreesit_str_open_bracket : Vtreesit_str_open_paren;
+@@ -2656,7 +2656,9 @@
+     :*
+     :+
+     :equal
++    :eq?
+     :match
++    :match?
+     (TYPE PATTERN...)
+     [PATTERN...]
+     FIELD-NAME:
+@@ -2819,7 +2821,7 @@
+   return !NILP (Fstring_equal (text1, text2));
+ }
+ 
+-/* Handles predicate (#match "regexp" @node).  Return true if "regexp"
++/* Handles predicate (#match? "regexp" @node).  Return true if "regexp"
+    matches the text spanned by @node; return false otherwise.
+    Matching is case-sensitive.  If everything goes fine, don't touch
+    SIGNAL_DATA; if error occurs, set it to a suitable signal data.  */
+@@ -2829,26 +2831,24 @@
+ {
+   if (list_length (args) != 2)
+     {
+-      *signal_data = list2 (build_string ("Predicate `match' requires two "
++      *signal_data = list2 (build_string ("Predicate `match?' requires two "
+ 					  "arguments but got"),
+ 			    Flength (args));
+       return false;
+     }
+-  Lisp_Object regexp = XCAR (args);
+-  Lisp_Object capture_name = XCAR (XCDR (args));
++  Lisp_Object arg1 = XCAR (args);
++  Lisp_Object arg2 = XCAR (XCDR (args));
++  Lisp_Object regexp = SYMBOLP (arg2) ? arg1 : arg2;
++  Lisp_Object capture_name = SYMBOLP (arg2) ? arg2 : arg1;
+ 
+-  /* It's probably common to get the argument order backwards.  Catch
+-     this mistake early and show helpful explanation, because Emacs
+-     loves you.  (We put the regexp first because that's what
+-     string-match does.)  */
+-  if (!STRINGP (regexp))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The first argument to `match' should "
+-		            "be a regexp string, not a capture name"));
+-  if (!SYMBOLP (capture_name))
+-    xsignal1 (Qtreesit_query_error,
+-	      build_string ("The second argument to `match' should "
+-		            "be a capture name, not a string"));
++  if (!STRINGP (regexp) || !SYMBOLP (capture_name))
++    {
++      *signal_data = list2 (build_string ("Predicate `match?' takes a regexp "
++	                                  "and a node capture (order doesn't "
++					  "matter), but got"),
++			    Flength (args));
++      return false;
++    }
+ 
+   Lisp_Object node = Qnil;
+   if (!treesit_predicate_capture_name_to_node (capture_name, captures, &node,
+@@ -2932,11 +2932,11 @@
+       Lisp_Object predicate = XCAR (tail);
+       Lisp_Object fn = XCAR (predicate);
+       Lisp_Object args = XCDR (predicate);
+-      if (!NILP (Fstring_equal (fn, Vtreesit_str_equal)))
++      if (!NILP (Fstring_equal (fn, Vtreesit_str_eq_question_mark)))
+ 	pass &= treesit_predicate_equal (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_match_question_mark)))
+ 	pass &= treesit_predicate_match (args, captures, signal_data);
+-      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred)))
++      else if (!NILP (Fstring_equal (fn, Vtreesit_str_pred_question_mark)))
+ 	pass &= treesit_predicate_pred (args, captures, signal_data);
+       else
+ 	{
+@@ -4208,8 +4208,11 @@
+   DEFSYM (QCstar, ":*");
+   DEFSYM (QCplus, ":+");
+   DEFSYM (QCequal, ":equal");
++  DEFSYM (QCeq_q, ":eq?");
+   DEFSYM (QCmatch, ":match");
++  DEFSYM (QCmatch_q, ":match?");
+   DEFSYM (QCpred, ":pred");
++  DEFSYM (QCpred_q, ":pred?");
+ 
+   DEFSYM (Qnot_found, "not-found");
+   DEFSYM (Qsymbol_error, "symbol-error");
+@@ -4340,12 +4343,12 @@
+   Vtreesit_str_star = build_pure_c_string ("*");
+   staticpro (&Vtreesit_str_plus);
+   Vtreesit_str_plus = build_pure_c_string ("+");
+-  staticpro (&Vtreesit_str_pound_equal);
+-  Vtreesit_str_pound_equal = build_pure_c_string ("#equal");
+-  staticpro (&Vtreesit_str_pound_match);
+-  Vtreesit_str_pound_match = build_pure_c_string ("#match");
+-  staticpro (&Vtreesit_str_pound_pred);
+-  Vtreesit_str_pound_pred = build_pure_c_string ("#pred");
++  staticpro (&Vtreesit_str_pound_eq_question_mark);
++  Vtreesit_str_pound_eq_question_mark = build_pure_c_string ("#eq?");
++  staticpro (&Vtreesit_str_pound_match_question_mark);
++  Vtreesit_str_pound_match_question_mark = build_pure_c_string ("#match?");
++  staticpro (&Vtreesit_str_pound_pred_question_mark);
++  Vtreesit_str_pound_pred_question_mark = build_pure_c_string ("#pred?");
+   staticpro (&Vtreesit_str_open_bracket);
+   Vtreesit_str_open_bracket = build_pure_c_string ("[");
+   staticpro (&Vtreesit_str_close_bracket);
+@@ -4356,12 +4359,12 @@
+   Vtreesit_str_close_paren = build_pure_c_string (")");
+   staticpro (&Vtreesit_str_space);
+   Vtreesit_str_space = build_pure_c_string (" ");
+-  staticpro (&Vtreesit_str_equal);
+-  Vtreesit_str_equal = build_pure_c_string ("equal");
+-  staticpro (&Vtreesit_str_match);
+-  Vtreesit_str_match = build_pure_c_string ("match");
+-  staticpro (&Vtreesit_str_pred);
+-  Vtreesit_str_pred = build_pure_c_string ("pred");
++  staticpro (&Vtreesit_str_eq_question_mark);
++  Vtreesit_str_eq_question_mark = build_pure_c_string ("eq?");
++  staticpro (&Vtreesit_str_match_question_mark);
++  Vtreesit_str_match_question_mark = build_pure_c_string ("match?");
++  staticpro (&Vtreesit_str_pred_question_mark);
++  Vtreesit_str_pred_question_mark = build_pure_c_string ("pred?");
+   staticpro (&Vtreesit_str_empty);
+   Vtreesit_str_empty = build_pure_c_string ("");
+ 
+--- emacs-30.2/test/src/treesit-tests.el
++++ emacs-30.2/test/src/treesit-tests.el
+@@ -434,10 +434,10 @@
+                ;; String query.
+                '("(string) @string
+ (pair key: (_) @keyword)
+-((_) @bob (#match \"\\\\`B.b\\\\'\" @bob))
++((_) @bob (#match? \"\\\\`B.b\\\\'\" @bob))
+ (number) @number
+-((number) @n3 (#equal \"3\" @n3))
+-((number) @n3p (#pred treesit--ert-pred-last-sibling @n3p))"
++((number) @n3 (#eq? \"3\" @n3))
++((number) @n3p (#pred? treesit--ert-pred-last-sibling @n3p))"
+                  ;; Sexp query.
+                  ((string) @string
+                   (pair key: (_) @keyword)

--- a/main/emacs-console/template.py
+++ b/main/emacs-console/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-console"
 pkgver = "30.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 # TODO gccjit (cba to figure it out for now)
 configure_args = [

--- a/main/emacs-gtk3/template.py
+++ b/main/emacs-gtk3/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-gtk3"
 pkgver = "30.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--libexecdir=/usr/libexec",  # TODO switch libexec

--- a/main/emacs-pgtk/template.py
+++ b/main/emacs-pgtk/template.py
@@ -1,6 +1,6 @@
 pkgname = "emacs-pgtk"
 pkgver = "30.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--libexecdir=/usr/libexec",  # TODO switch libexec


### PR DESCRIPTION
## Description

Fixes #5669.

This PR adds a backport patch from Emacs master branch to ensure correct tree-sitter query generation. The actual patch itself was taken from Arch Linux, since they had brief explanation and correct attribution to the author of the commit.

See [this email archive](https://lists.gnu.org/archive/html/emacs-bug-tracker/2025-11/msg00017.html) for more information.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
