### PR TITLE
user/opam: new package

### DIFF
--- a/user/opam/template.py
+++ b/user/opam/template.py
@@ -1,5 +1,5 @@
 pkgname = "opam"
-pkgver = "2.5.1"
+pkgver = "2.5.2"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -16,6 +16,6 @@ pkgdesc = "OCaml package manager"
 license = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 url = "https://opam.ocaml.org"
 source = f"https://github.com/ocaml/opam/releases/download/{pkgver}/opam-full-{pkgver}.tar.gz"
-sha256 = "48c5bfaf5f5c4048cc5f40025de7385f5bad3a8269756216cd6dd2f2150033ed"
+sha256 = "b3623809567f19ed6b5d679b8c7bbc0bdec9418bff4a875ff0799d446d8555c3"
 # check requires bubblewrap and fails within containers
 options = ["!check", "!cross", "!parallel"]

--- a/user/opam/template.py
+++ b/user/opam/template.py
@@ -1,0 +1,21 @@
+pkgname = "opam"
+pkgver = "2.5.1"
+pkgrel = 0
+build_style = "gnu_configure"
+configure_args = [
+    "--with-vendored-deps",
+    "--with-mccs",
+]
+make_dir = "."
+make_build_target = "all"
+make_check_target = "tests"
+hostmakedepends = ["automake"]
+makedepends = ["ocaml-compiler-libs"]
+depends = ["bash", "bubblewrap", "curl", "libarchive-progs", "unzip"]
+pkgdesc = "OCaml package manager"
+license = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+url = "https://opam.ocaml.org"
+source = f"https://github.com/ocaml/opam/releases/download/{pkgver}/opam-full-{pkgver}.tar.gz"
+sha256 = "48c5bfaf5f5c4048cc5f40025de7385f5bad3a8269756216cd6dd2f2150033ed"
+# check requires bubblewrap and fails within containers
+options = ["!check", "!cross", "!parallel"]


### PR DESCRIPTION
## Description

opam is the package manager for OCaml programming language.

Some notes regarding dependencies:
- `bash` is required to detect the isolation method. You can force it to work without, but then `bubblewrap` is useless, and you'd have to encounter big error message, so...
- `curl`, `libarchive-progs`, and `unzip` are used to download and extract OCaml sources, and are listed as hard dependencies.
- Since it compiles OCaml for every switch, `clang` and `gmake` are pretty much requirements, but _technically_ one can use opam without, so they are not listed as hard dependencies.

Supersedes #4557.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
