### PR TITLE
main/bubblejail: update to 0.10.3

### DIFF
--- a/main/bubblejail/template.py
+++ b/main/bubblejail/template.py
@@ -1,6 +1,6 @@
 pkgname = "bubblejail"
-pkgver = "0.10.1"
-pkgrel = 1
+pkgver = "0.10.3"
+pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
     "meson",
@@ -27,4 +27,4 @@ pkgdesc = "Bubblewrap based sandboxing for desktop applications"
 license = "GPL-3.0-or-later"
 url = "https://github.com/igo95862/bubblejail"
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "c86c621dfce1a9ad14bd29a34aad6270f9099a7da38cc2dd99d304c64088d1cd"
+sha256 = "e7bb533b2bd8dd19bbecfb46e919642c80bd528bcd11c2f9b180a983ee853358"

--- a/user/flatpak-xdg-utils/template.py
+++ b/user/flatpak-xdg-utils/template.py
@@ -1,0 +1,18 @@
+pkgname = "flatpak-xdg-utils"
+pkgver = "1.0.6"
+pkgrel = 0
+build_style = "meson"
+configure_args = ["--bindir=/usr/lib/flatpak-xdg-utils"]
+hostmakedepends = [
+    "meson",
+    "pkgconf",
+]
+makedepends = ["glib-devel"]
+checkdepends = ["dbus"]
+pkgdesc = "Launch programs outside of containers"
+license = "LGPL-2.1-or-later"
+url = "https://github.com/flatpak/flatpak-xdg-utils"
+source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
+sha256 = "a48e3e4b5591f2c13e867ac095035c0b5ba8c89e1a38058d46312ae7df972b84"
+# FIXME cfi, sigill on tests
+hardening = ["vis", "!cfi"]


### PR DESCRIPTION
## Description

Updates bubblejail to 0.10.3 and adds packages flatpak-xdg-utils, a new optional runtime dependency.

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
