### PR TITLE
main/gstreamer: update to 1.28.4

### DIFF
--- a/main/gst-libav/template.py
+++ b/main/gst-libav/template.py
@@ -1,5 +1,5 @@
 pkgname = "gst-libav"
-pkgver = "1.28.2"
+pkgver = "1.28.4"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Ddefault_library=shared"]
@@ -15,6 +15,6 @@ pkgdesc = "GStreamer FFmpeg plugin"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gst-libav/gst-libav-{pkgver}.tar.xz"
-sha256 = "45ba65535870aa7c026119d2e90b35dc760e1cf6f50bffbfe8d71223a3043a4e"
+sha256 = "bd17a5df2874a7a58bcbaf7b940223379ad9613624db8ead783db03e74bb904b"
 # FIXME int
 hardening = ["!int"]

--- a/main/gst-plugins-bad/template.py
+++ b/main/gst-plugins-bad/template.py
@@ -1,5 +1,5 @@
 pkgname = "gst-plugins-bad"
-pkgver = "1.28.2"
+pkgver = "1.28.4"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -152,7 +152,7 @@ pkgdesc = "GStreamer bad plugins"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gst-plugins-bad/gst-plugins-bad-{pkgver}.tar.xz"
-sha256 = "6467e3964828f4d7d08bfe1fbb4d76287a1c8fa76674e59e101a149c020fefd7"
+sha256 = "332b7320f30c60f2d5941446d03b9d05e3781f2c2561befbe88718bd777f0e47"
 # FIXME int
 hardening = ["!int"]
 # TODO: a few fails, debug later

--- a/main/gst-plugins-base/template.py
+++ b/main/gst-plugins-base/template.py
@@ -1,5 +1,5 @@
 pkgname = "gst-plugins-base"
-pkgver = "1.28.2"
+pkgver = "1.28.4"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -60,7 +60,7 @@ pkgdesc = "GStreamer base plugins"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gst-plugins-base/gst-plugins-base-{pkgver}.tar.xz"
-sha256 = "4db76b3619280037a4047de7d9dbb38613a4272dcc40efb333257124635a888d"
+sha256 = "a898afd5766172b0049e6781558e0689098bf87b9d82b846c652e571c01d60d8"
 # FIXME int
 hardening = ["!int"]
 # gobject-introspection

--- a/main/gst-plugins-good/template.py
+++ b/main/gst-plugins-good/template.py
@@ -1,6 +1,6 @@
 pkgname = "gst-plugins-good"
-pkgver = "1.28.2"
-pkgrel = 1
+pkgver = "1.28.4"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "--auto-features=enabled",
@@ -74,7 +74,7 @@ pkgdesc = "GStreamer good plugins"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gst-plugins-good/gst-plugins-good-{pkgver}.tar.xz"
-sha256 = "1ace2d8ec74f632d82eab5006753a27fe0c2402db4ca94d63271e494b62f50bf"
+sha256 = "c825ea737c59cea0e4a0c41da2388045ff5dd32d162220ac93a7a82ee4a04e61"
 # FIXME int (extra tests fail, look for SIGILL)
 # in 1.24.4, pipelines_effectv only
 hardening = ["!int"]

--- a/main/gst-plugins-ugly/template.py
+++ b/main/gst-plugins-ugly/template.py
@@ -1,5 +1,5 @@
 pkgname = "gst-plugins-ugly"
-pkgver = "1.28.2"
+pkgver = "1.28.4"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -32,4 +32,4 @@ pkgdesc = "GStreamer ugly plugins"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gst-plugins-ugly/gst-plugins-ugly-{pkgver}.tar.xz"
-sha256 = "fe39a5ee7115e37de9eb65d899ec84c93e6e26ed3ffe25c6d5176cececbab572"
+sha256 = "5486cd145c5af43259fd37caca59d048e2a67ddb07082ea8f50ef0f02a85f8a5"

--- a/main/gstreamer/template.py
+++ b/main/gstreamer/template.py
@@ -1,6 +1,6 @@
 pkgname = "gstreamer"
-pkgver = "1.28.2"
-pkgrel = 1
+pkgver = "1.28.4"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Dptp-helper-permissions=none",  # manual
@@ -34,7 +34,7 @@ pkgdesc = "Core GStreamer libraries and elements"
 license = "LGPL-2.1-or-later"
 url = "https://gstreamer.freedesktop.org"
 source = f"{url}/src/gstreamer/gstreamer-{pkgver}.tar.xz"
-sha256 = "ce5cd44d4ffeafdcc3dddaa072b2179c0b7cb1abf4e6c5d18d4375f8a39fe491"
+sha256 = "f5adc7e8f448c10260b3b25aa101c9d540674c8d9a54c2b77a86d04f2b3b50dd"
 tool_flags = {"LDFLAGS": ["-Wl,-z,stack-size=0x200000"]}
 file_modes = {
     "usr/lib/gstreamer-1.0/gst-ptp-helper": ("root", "root", 0o755),


### PR DESCRIPTION
The update to 1.28.2 has introduced a regression where in some combinations of
media player and codec, video would be completely corrupted. (Reproduced bad
combinations are GNOME Video Player (showtime) with DVCAM or AV1 codec.) This
issue seems to be fixed in 1.28.4.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
