### PR TITLE
user/alsa-utils: update to 1.2.16

### DIFF
--- a/user/alsa-utils/patches/downgrade-required-gettext.patch
+++ b/user/alsa-utils/patches/downgrade-required-gettext.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 6294be3..1eb64c4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -8,7 +8,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
+ AM_MAINTAINER_MODE([enable])
+ 
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.25.1])
++AM_GNU_GETTEXT_VERSION([0.23.2])
+ 
+ dnl Checks for programs.
+ 

--- a/user/alsa-utils/template.py
+++ b/user/alsa-utils/template.py
@@ -1,5 +1,5 @@
 pkgname = "alsa-utils"
-pkgver = "1.2.14"
+pkgver = "1.2.16"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--with-udev-rules-dir=no"]
@@ -16,4 +16,4 @@ pkgdesc = "ALSA utilities"
 license = "LGPL-2.1-or-later"
 url = "https://www.alsa-project.org"
 source = f"{url}/files/pub/utils/alsa-utils-{pkgver}.tar.bz2"
-sha256 = "0794c74d33fed943e7c50609c13089e409312b6c403d6ae8984fc429c0960741"
+sha256 = "092399d5e8749a1d5e188e393157521cec4b75693b60ebb79bbce728cff2232c"


### PR DESCRIPTION
## Description

Added `downgrade-required-gettext.patch`:

alsa-utils updated their autoconf requirement to 2.72 which requires
fixed autopoint/aclocal (?) behaviour. This was backported to gettext
0.23.2, so we're good.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
