### PR TITLE
main/curl: stop disabling optimization

### DIFF
--- a/main/curl/template.py
+++ b/main/curl/template.py
@@ -1,9 +1,8 @@
 pkgname = "curl"
 pkgver = "8.20.0"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
-    "--disable-optimize",
     "--enable-ares",
     "--enable-httpsrr",
     "--enable-ipv6",


### PR DESCRIPTION
In commit b68f9dabac85fae5715b683a15ea1c5f1e361e25, the default compiler optimization was disabled. As no explicit reason was given, this was likely either a temporary hack or a mistake (such as a belief that it just disables extra optimization flags added by curl). Remove the offending flag to restore optimization, which does not seem to break anything.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
