### PR TITLE
main/libseat: update to 0.9.3

### DIFF
--- a/main/libseat/template.py
+++ b/main/libseat/template.py
@@ -1,6 +1,6 @@
 pkgname = "libseat"
-pkgver = "0.9.1"
-pkgrel = 2
+pkgver = "0.9.3"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Dexamples=disabled",
@@ -12,7 +12,7 @@ pkgdesc = "Universal seat management library"
 license = "MIT"
 url = "https://sr.ht/~kennylevinsen/seatd"
 source = f"https://git.sr.ht/~kennylevinsen/seatd/archive/{pkgver}.tar.gz"
-sha256 = "819979c922a0be258aed133d93920bce6a3d3565a60588d6d372ce9db2712cd3"
+sha256 = "302564d54d8e28191fadfd734f2675ecb0c9e0615a58011b89ef15dfa4dbaa96"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Update libseat (seatd) from 0.9.1 to 0.9.3.

This release fixes a bug where `close_device` in the seatd backend could
return -1 with errno set to an incorrect value. On failure, errno was
recorded as `res = -1` instead of `res = -errno` before subsequent
housekeeping calls that may clobber it.

On Chimera Linux, this caused niri to panic when receiving SIGHUP:
smithay's `LibSeatSession::close` passes the errno value to
`rustix::Errno::from_raw_os_error`, which asserts `encoded >= 0xf001`
and panics when given 0. The panic drops the Wayland socket, causing
connected Wayland clients to crash.

Fixed upstream in seatd commit `03f7644` (libseat/seatd: Ensure errno
is not clobbered).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I have read Packaging.md
- [x] I have built and tested my changes on my machine