### PR TITLE
user/ntpd-rs: new package

### DIFF
--- a/user/ntpd-rs/files/ntp-daemon
+++ b/user/ntpd-rs/files/ntp-daemon
@@ -1,0 +1,8 @@
+type = process
+command = /usr/bin/ntp-daemon
+run-as = _ntp-daemon
+logfile = /var/log/ntp-daemon.log
+capabilities = ^cap_sys_time
+smooth-recovery = true
+depends-on: network.target
+depends-on: local.target

--- a/user/ntpd-rs/files/sysusers.conf
+++ b/user/ntpd-rs/files/sysusers.conf
@@ -1,0 +1,3 @@
+# Create ntp-daemon system user
+
+u _ntp-daemon - "ntp-daemon user" /var/empty /usr/bin/nologin

--- a/user/ntpd-rs/files/tmpfiles.conf
+++ b/user/ntpd-rs/files/tmpfiles.conf
@@ -1,0 +1,3 @@
+# Create /run/ntpd-rs
+
+d /run/ntpd-rs 0755 _ntp-daemon _ntp-daemon -

--- a/user/ntpd-rs/template.py
+++ b/user/ntpd-rs/template.py
@@ -1,0 +1,49 @@
+pkgname = "ntpd-rs"
+pkgver = "1.9.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["dinit-chimera"]
+pkgdesc = "Full-featured implementation of NTP, including NTS support"
+license = "Apache-2.0 OR MIT"
+url = "https://trifectatech.org/projects/ntpd-rs"
+source = f"https://github.com/pendulum-project/{pkgname}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "b25d560c4ae5a704d9509984b040123675052d27fe7a3e7cbc5bedc9e392c932"
+
+
+def check(self):
+    # Reported here:
+    # https://github.com/pendulum-project/ntpd-rs/issues/2286
+    self.cargo.check(
+        args=[
+            "--",
+            "--skip",
+            "daemon::spawn::nts::tests::allow_srv_direct_name_resolution",
+            "--skip",
+            "daemon::ntp_source::tests::test_deny_stops_poll",
+            "--skip",
+            "daemon::ntp_source::tests::test_timeroundtrip",
+        ]
+    )
+
+
+def install(self):
+    self.install_bin(f"target/{self.profile().triplet}/release/ntp-daemon")
+    self.install_bin(f"target/{self.profile().triplet}/release/ntp-ctl")
+
+    self.install_sysusers("^/sysusers.conf")
+    self.install_tmpfiles("^/tmpfiles.conf")
+    self.install_service("^/ntp-daemon")
+
+    self.install_file(
+        "docs/examples/conf/ntp.toml.default",
+        "etc/ntpd-rs",
+        name="ntp.toml",
+    )
+
+    self.install_man("docs/precompiled/man/ntp-ctl.8")
+    self.install_man("docs/precompiled/man/ntp-daemon.8")
+    self.install_man("docs/precompiled/man/ntp.toml.5")
+
+    self.install_license("LICENSE-APACHE")
+    self.install_license("LICENSE-MIT")


### PR DESCRIPTION
## Description

NTP server and client with NTS support, written in Rust.

Sponsored by NLnet/ISRG/Sovereign Tech Fund, and looks like Ubuntu will
be switching to it.

Development seems more active than chrony and it already has NTPv5
support (experimental?).

I haven't packaged the ntp-metrics-exporter binary and service, as I
don't need or want Prometheus/OpenMetrics metrics. Happy to include it
if there's demand for it, though.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
