### PR TITLE
main/linux-pam: update to 1.7.2

### DIFF
--- a/main/linux-pam/template.py
+++ b/main/linux-pam/template.py
@@ -1,6 +1,6 @@
 pkgname = "linux-pam"
-pkgver = "1.7.0"
-pkgrel = 1
+pkgver = "1.7.2"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Ddocdir=/usr/share/doc/pam",
@@ -23,7 +23,7 @@ pkgdesc = "Pluggable Authentication Modules for Linux"
 license = "BSD-3-Clause"
 url = "https://github.com/linux-pam/linux-pam"
 source = f"{url}/releases/download/v{pkgver}/Linux-PAM-{pkgver}.tar.xz"
-sha256 = "57dcd7a6b966ecd5bbd95e1d11173734691e16b68692fa59661cdae9b13b1697"
+sha256 = "3d86b6383fb5fd9eb9578d2cd47d92801191f4bf3f9bc61419bfefc8aa1e531a"
 file_modes = {
     "usr/bin/unix_chkpwd": ("root", "root", 0o4755),
     # other stuff in there is owned by the package so...


### PR DESCRIPTION
## Description

Fixes a couple of CVEs (CVE-2024-10963, CVE-2025-6020):

```
Release 1.7.2
* build: enabled vendordir by default.
* pam_access: fixed stack overflow with huge configuration files.
* pam_env: enhanced error diagnostics when ignoring backslash at end of string.
* pam_faillock: skip clearing user's failed attempt when auth stack is not run.
* pam_mkhomedir: added support for vendordir skeleton directory.
* pam_unix: added support for pwaccessd.
* pam_unix: added support for PAM_CHANGE_EXPIRED_AUTHTOK.
* pam_unix: fixed password expiration warnings for large day values.
* pam_unix: hardened temporary file handling.
* Multiple minor bug fixes, build fixes, portability fixes,
  documentation improvements, and translation updates.

Release 1.7.1
* pam_access: do not resolve ttys or display variables as hostnames.
* pam_access: added "nodns" option to disallow resolving of tokens as hostnames
  (CVE-2024-10963).
* pam_limits: added support for rttime (RLIMIT_RTTIME).
* pam_namespace: fixed potential privilege escalation (CVE-2025-6020).
* meson: added support of elogind as a logind provider.
* Multiple minor bug fixes, build fixes, portability fixes,
  documentation improvements, and translation updates.
```

Tested fine on x86_64 (as are all of my PRs).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
