### PR TITLE
main/libssh: update to 0.11.4

### DIFF
--- a/main/libssh/template.py
+++ b/main/libssh/template.py
@@ -1,5 +1,5 @@
 pkgname = "libssh"
-pkgver = "0.11.3"
+pkgver = "0.11.4"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -22,7 +22,7 @@ pkgdesc = "Library for accessing ssh client services through C libraries"
 license = "LGPL-2.1-or-later WITH custom:openssl-exception AND BSD-2-Clause"
 url = "https://www.libssh.org"
 source = f"https://www.libssh.org/files/{pkgver[: pkgver.rfind('.')]}/libssh-{pkgver}.tar.xz"
-sha256 = "7d8a1361bb094ec3f511964e78a5a4dba689b5986e112afabe4f4d0d6c6125c3"
+sha256 = "002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701"
 hardening = ["vis", "cfi"]
 
 


### PR DESCRIPTION
## Description

Fixes a few CVEs
```
[CVE-2026-0964]: SCP Protocol Path Traversal in ssh_scp_pull_request()
[CVE-2026-0965]: Possible Denial of Service when parsing unexpected configuration files
[CVE-2026-0966]: Buffer underflow in ssh_get_hexa() on invalid input
[CVE-2026-0967]: Specially crafted patterns could cause DoS
[CVE-2026-0968]: OOB Read in sftp_parse_longname()
[libssh-2026-sftp-extensions]: Read buffer overrun when handling SFTP extensions
```

Upstream test suite completed successfully. Tested wireshark which depends on it and it seems to work fine.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine