### PR TITLE
main/blender: update to 5.1.2 and fixed wayland support

### DIFF
--- a/main/blender/template.py
+++ b/main/blender/template.py
@@ -1,6 +1,6 @@
 pkgname = "blender"
-pkgver = "5.1.1"
-pkgrel = 1
+pkgver = "5.1.2"
+pkgrel = 0
 build_style = "cmake"
 configure_args = [
     "-DCMAKE_BUILD_TYPE=Release",
@@ -50,6 +50,7 @@ makedepends = [
     "libsndfile-devel",
     "libtiff-devel",
     "libwebp-devel",
+    "libxkbcommon-devel",
     "llvm-devel",
     "onetbb-devel",
     "openal-soft-devel",
@@ -68,6 +69,7 @@ makedepends = [
     "shaderc-devel",
     "vulkan-loader-devel",
     "wayland-devel",
+    "wayland-protocols",
     "zstd-devel",
 ]
 depends = [
@@ -79,7 +81,7 @@ pkgdesc = "3D creation suite"
 license = "GPL-2.0-or-later"
 url = "https://www.blender.org"
 source = f"https://download.blender.org/source/blender-{pkgver}.tar.xz"
-sha256 = "fae57dd7273d76e21712abfba43a85fffba00e8bf3e3cf9a874b993b8ac4857d"
+sha256 = "aedfd030231979b629b18049d93b92fd2794952ca0cf39ebde54e84438bed05a"
 tool_flags = {
     "CFLAGS": ["-D_GNU_SOURCE"],
     # guilty until proven innocent


### PR DESCRIPTION
## Description

This pull request updates blender from 5.1.1 to 5.1.2. it also fixes the wayland support problem that i pointed out here: #5694 . the problem was due to missing dependencies i believe. also I'm not sure if 'libxkbcommon' should be in the depends section or 'libxkbcommon-devel' in 'makedepends' is enough. and I tested blender on my machine and can confirm that it works.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements) (not fully. i felt like it was important to mention that)
- [x] I have built and tested my changes on my machine

