### PR TITLE
main/appstream: update to 1.1.3

### DIFF
--- a/main/appstream/template.py
+++ b/main/appstream/template.py
@@ -1,5 +1,5 @@
 pkgname = "appstream"
-pkgver = "1.1.1"
+pkgver = "1.1.3"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -9,8 +9,24 @@ configure_args = [
     "-Dstemming=false",
     "-Dsystemd=false",
 ]
+# exclude as-test_yaml - fails with latest libfyaml even:
+# https://github.com/ximion/appstream/issues/756
+make_check_args = [
+    "AppStream:as-validate_metainfo.cli",
+    "AppStream:as-validate_metainfo.compose",
+    "AppStream:as-test_basic",
+    "AppStream:as-test_xml",
+    "AppStream:as-test_validate",
+    "AppStream:as-test_perf",
+    "AppStream:as-test_misc",
+    "AppStream:as-test_qt-misc",
+    "AppStream:as-test_qt-pool",
+    "AppStream:as-test_compose",
+    "AppStream:as-test_pool",
+]
 hostmakedepends = [
-    "docbook-xsl-nons",
+    "bash-completion",
+    "docbook-xsl",
     "gettext",
     "gobject-introspection",
     "gperf",
@@ -20,6 +36,7 @@ hostmakedepends = [
     "pkgconf",
 ]
 makedepends = [
+    "blake3-devel",
     "cairo-devel",
     "curl-devel",
     "fontconfig-devel",
@@ -39,7 +56,7 @@ url = "https://www.freedesktop.org/wiki/Distributions/AppStream"
 source = (
     f"https://github.com/ximion/appstream/archive/refs/tags/v{pkgver}.tar.gz"
 )
-sha256 = "1615468b8d1e5edb9a9081f81841c8a22439c64bee5f02b008b3b8d5a5204c91"
+sha256 = "437c0564facc63f36b7b7907293182446a9c535619a09ec93840147f685c2f64"
 # gir
 options = ["!cross"]
 


### PR DESCRIPTION
## Description

Changes:

- Now creates hashes with Blake3 instead of MD5 (added dep)
- Rudimentary bash completions
- Convert to Docbook 5 (`docbook-xsl` needed)

Questions:

- Switch added to disable CLI tools - I assume we keep them in?
  - Or split them off into -progs?
- Create -compose subpkg ala Alpine?

Had to disable as-test_yaml test: https://github.com/ximion/appstream/issues/756

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
