### PR TITLE
main/e2fsprogs: update to 1.47.4

### DIFF
--- a/main/e2fsprogs/template.py
+++ b/main/e2fsprogs/template.py
@@ -1,6 +1,6 @@
 pkgname = "e2fsprogs"
-pkgver = "1.47.2"
-pkgrel = 2
+pkgver = "1.47.4"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--enable-elf-shlibs",
@@ -34,7 +34,7 @@ pkgdesc = "Ext2/3/4 file system utilities"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://e2fsprogs.sourceforge.net"
 source = f"$(KERNEL_SITE)/kernel/people/tytso/e2fsprogs/v{pkgver}/e2fsprogs-{pkgver}.tar.xz"
-sha256 = "08242e64ca0e8194d9c1caad49762b19209a06318199b63ce74ae4ef2d74e63c"
+sha256 = "fd5bf388cbdbe006a3d3b318d983b2948382440acc85a87f1e7d108653e8db0b"
 options = ["etcfiles"]
 
 


### PR DESCRIPTION
## Description

Lots of fuse2fs stuff, but also config/behavioural changes FYI:

```
Add mke2fs.conf configuration settings to control whether the RAID
stripe or stride sizes from the storage device information depending on
whether the storage device is a rotational or non-rotational device.  By
default, don't set the RAID stripe size for non-rotational devices.

E2scrub no longer runs fstrim by default, since util-linux ships with a
fstrim.timer systemd file which will run fstrim on all mounted file
systems.  This can be re-enabled in /etc/e2scrub.conf if for some reason
it is desireable to run the fstrim out of e2scrub.
```

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
