### PR TITLE
main/crun: update to 1.28

### DIFF
--- a/main/crun/template.py
+++ b/main/crun/template.py
@@ -1,30 +1,29 @@
 pkgname = "crun"
-pkgver = "1.23.1"
+pkgver = "1.28"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = ["--disable-systemd"]
-# broken presently
-configure_gen = []
-# full testsuite fails in netns
-make_check_target = "tests/tests_libcrun_errors.log"
 hostmakedepends = [
+    "autoconf",
+    "automake",
     "go-md2man",
     "pkgconf",
     "python",
+    "slibtool",
 ]
 makedepends = [
     "argp-standalone",
+    "blake3-devel",
+    "json-c-devel",
     "libcap-devel",
     "libseccomp-devel",
-    # -static for test build from all target
-    "libunwind-devel-static",
-    "yajl-devel",
 ]
 pkgdesc = "Fast and lightweight OCI runtime"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://github.com/containers/crun"
 source = f"{url}/releases/download/{pkgver}/crun-{pkgver}.tar.zst"
-sha256 = "6cea8d41e4be425ba2fa55587e16e44ddbe2fa333b367024e68235b922e26056"
+sha256 = "62b82f7db89df3652970d9ad76f635a177d09bcb543c8d1dae13a749cd3e6e35"
+hardening = ["vis", "cfi"]
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Notes:

- Fixes CVE-2026-47766, which is apparently:
  - CVE-2026-41579 - runc: Malicious image with /dev symlink can 
    trigger limited host filesystem integrity violations
- Uses system blake3 lib
- Switched from YAJL to json-c for JSON parsing
- autoreconf seems to work fine now
- 15/15 tests pass ok
- vis + cfi enabled and tested fine (so far)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
