### PR TITLE
main/podman: update to 5.8.5

### DIFF
--- a/main/podman/template.py
+++ b/main/podman/template.py
@@ -1,5 +1,5 @@
 pkgname = "podman"
-pkgver = "5.8.2"
+pkgver = "5.8.5"
 pkgrel = 0
 build_style = "go"
 # for install.bin compat
@@ -50,7 +50,7 @@ pkgdesc = "Container and image management tool"
 license = "Apache-2.0"
 url = "https://podman.io"
 source = f"https://github.com/containers/podman/archive/v{pkgver}.tar.gz"
-sha256 = "b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84"
+sha256 = "60f830e6664e3693b18214ee1f20b1cd8d3be9050ab503c2474bf070fb2954b3"
 # nah
 options = ["!check"]
 


### PR DESCRIPTION
## Description

Fixes:

- CVE-2026-44517
- CVE-2026-57231
- CVE-2026-42508

Podman 6.0.1 is out, but 6.0.0 breaks a load of stuff. Will need to come back to that.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
