### PR TITLE
main/podman: update to 6.0.2 (and friends)

### DIFF
--- a/main/aardvark-dns/template.py
+++ b/main/aardvark-dns/template.py
@@ -1,5 +1,5 @@
 pkgname = "aardvark-dns"
-pkgver = "1.16.0"
+pkgver = "2.0.0"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable"]
@@ -8,7 +8,7 @@ pkgdesc = "Authoritative DNS server for A/AAAA container records"
 license = "Apache-2.0"
 url = "https://github.com/containers/aardvark-dns"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "6c84a3371087d6af95407b0d3de26cdc1e720ae8cd983a9bdaec8883e2216959"
+sha256 = "d3f5d6b3be3c2d80e8257fb9467e34ff104f299474427979454034dca6dc88cc"
 
 
 def install(self):

--- a/main/buildah/patches/basename.patch
+++ b/main/buildah/patches/basename.patch
@@ -1,6 +1,8 @@
---- a/vendor/github.com/containers/storage/pkg/unshare/unshare.c
-+++ b/vendor/github.com/containers/storage/pkg/unshare/unshare.c
-@@ -19,6 +19,8 @@
+diff --git a/vendor/go.podman.io/storage/pkg/unshare/unshare.c b/vendor/go.podman.io/storage/pkg/unshare/unshare.c
+index a2800654..fbabb447 100644
+--- a/vendor/go.podman.io/storage/pkg/unshare/unshare.c
++++ b/vendor/go.podman.io/storage/pkg/unshare/unshare.c
+@@ -20,6 +20,8 @@
  #include <sys/mount.h>
  #include <linux/limits.h>
  

--- a/main/buildah/template.py
+++ b/main/buildah/template.py
@@ -1,6 +1,6 @@
 pkgname = "buildah"
-pkgver = "1.41.5"
-pkgrel = 6
+pkgver = "1.44.1"
+pkgrel = 0
 build_style = "go"
 make_build_args = ["./cmd/..."]
 hostmakedepends = [
@@ -28,9 +28,7 @@ go_build_tags = [
 pkgdesc = "OCI image building tool"
 license = "Apache-2.0"
 url = "https://buildah.io"
-source = (
-    f"https://github.com/containers/buildah/archive/refs/tags/v{pkgver}.tar.gz"
-)
-sha256 = "4bd94a16c612f493ce57557e21a58cb7e6427311e6e758484c18cd7e44276c43"
+source = f"https://github.com/podman-container-tools/buildah/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "ac022c60c84f0dd447f1982ae9e28e89d73892d0da24276fa6662cd1d045885e"
 # needs subid config in the chroot
 options = ["!check"]

--- a/main/cni-plugins/template.py
+++ b/main/cni-plugins/template.py
@@ -1,13 +1,13 @@
 pkgname = "cni-plugins"
-pkgver = "1.7.1"
-pkgrel = 9
+pkgver = "1.9.1"
+pkgrel = 0
 hostmakedepends = ["bash", "go"]
 makedepends = ["linux-headers"]
 pkgdesc = "Standard CNI plugins for containers"
 license = "Apache-2.0"
 url = "https://www.cni.dev"
 source = f"https://github.com/containernetworking/plugins/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "95b639f8ccbb714da98e331ef8813f790d447fce5417f2f8a575f3c62bfb1474"
+sha256 = "34bd82d47e981940751619c9cc44c095bb90bfcaf8d71865cbb822c37690a764"
 # can't run tests inside namespaces
 options = ["!check"]
 

--- a/main/conmon/template.py
+++ b/main/conmon/template.py
@@ -1,5 +1,5 @@
 pkgname = "conmon"
-pkgver = "2.1.13"
+pkgver = "2.2.1"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -16,7 +16,7 @@ pkgdesc = "OCI container monitor"
 license = "Apache-2.0"
 url = "https://github.com/containers/conmon"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "350992cb2fe4a69c0caddcade67be20462b21b4078dae00750e8da1774926d60"
+sha256 = "814fb5979a3a4b8576b1f901e606b482bebb41cb7e57926e6d5765ee786b96d3"
 
 
 def post_build(self):
@@ -24,10 +24,4 @@ def post_build(self):
 
 
 def post_install(self):
-    # the default containers-common config paths that podman and friends use
-    # check /usr/libexec/podman hardcoded, but also /usr/bin is in the path.
-    # so just link it, i guess... maybe this should be fixed by adding /usr/lib/
-    # podman somehow to that path, as for all the other non-conmon stuff it does
-    self.install_dir("usr/bin")
-    self.install_link("usr/bin/conmon", "../lib/podman/conmon")
     self.install_man("docs/conmon.8")

--- a/main/containers-common/patches/settings.patch
+++ b/main/containers-common/patches/settings.patch
@@ -1,5 +1,30 @@
---- a/image/registries.conf
-+++ b/image/registries.conf
+diff --color=auto -urN a/common/pkg/config/containers.conf b/common/pkg/config/containers.conf
+--- a/common/pkg/config/containers.conf	2026-07-07 17:48:51.000000000 +0100
++++ b/common/pkg/config/containers.conf	2026-07-11 10:59:37.939368310 +0100
+@@ -498,7 +498,7 @@
+ # Cgroup management implementation used for the runtime.
+ # Valid options "systemd" or "cgroupfs"
+ #
+-#cgroup_manager = "systemd"
++cgroup_manager = "cgroupfs"
+ 
+ # Environment variables to pass into conmon
+ #
+@@ -565,7 +565,7 @@
+ # Selects which logging mechanism to use for container engine events.
+ # Valid values are `journald`, `file` and `none`.
+ #
+-#events_logger = "journald"
++events_logger = "file"
+ 
+ # Creates a more verbose container-create event which includes a JSON payload
+ # with detailed information about the container.
+File a/image/pkg/tlsclientconfig/testdata/unreadable-ca/unreadable.crt is not a regular file or directory and was skipped
+File a/image/pkg/tlsclientconfig/testdata/unreadable-cert/client-cert-1.cert is not a regular file or directory and was skipped
+File a/image/pkg/tlsclientconfig/testdata/unreadable-key/client-cert-1.key is not a regular file or directory and was skipped
+diff --color=auto -urN a/image/registries.conf b/image/registries.conf
+--- a/image/registries.conf	2026-07-07 17:48:51.000000000 +0100
++++ b/image/registries.conf	2026-07-11 10:56:30.571261953 +0100
 @@ -18,7 +18,7 @@
  # of these registries, it should be added at the end of the list.
  #
@@ -9,22 +34,3 @@
  #
  # [[registry]]
  # # The "prefix" field is used to choose the relevant [[registry]] TOML table;
---- a/storage/docs/Makefile
-+++ b/storage/docs/Makefile
-@@ -1,4 +1,4 @@
--GOMD2MAN = ../tests/tools/build/go-md2man
-+GOMD2MAN = go-md2man
- PREFIX ?= ${DESTDIR}/usr
- MANINSTALLDIR=${PREFIX}/share/man
- MANPAGES_MD = $(wildcard docs/*.5.md)
---- a/common/pkg/config/containers.conf
-+++ b/common/pkg/config/containers.conf
-@@ -417,7 +417,7 @@ default_sysctls = [
- # Cgroup management implementation used for the runtime.
- # Valid options "systemd" or "cgroupfs"
- #
--#cgroup_manager = "systemd"
-+cgroup_manager = "cgroupfs"
- 
- # Environment variables to pass into conmon
- #

--- a/main/containers-common/template.py
+++ b/main/containers-common/template.py
@@ -1,33 +1,23 @@
 pkgname = "containers-common"
-pkgver = "0.64.1"
+pkgver = "0.68.1"
 pkgrel = 0
 make_build_args = ["-C", "docs"]
 make_install_args = [*make_build_args]
 hostmakedepends = ["go-md2man"]
 pkgdesc = "Shared docs and configs for Containers"
 license = "Apache-2.0"
-url = "https://github.com/containers/common"
-_base_url = url.removesuffix("/common")
-_common_ver = pkgver
-_storage_ver = "1.59.1"
-_image_ver = "5.36.1"
+url = "https://github.com/containers/container-libs"
 _shortnames_ver = "2025.03.19"
 source = [
-    f"{_base_url}/common/archive/v{_common_ver}.tar.gz",
-    f"{_base_url}/storage/archive/v{_storage_ver}.tar.gz",
-    f"{_base_url}/image/archive/v{_image_ver}.tar.gz",
-    f"{_base_url}/shortnames/archive/v{_shortnames_ver}.tar.gz",
+    f"{url}/archive/refs/tags/common/v{pkgver}.tar.gz",
+    f"{url.removesuffix('container-libs')}/shortnames/archive/refs/tags/v{_shortnames_ver}.tar.gz",
 ]
 source_paths = [
-    "common",
-    "storage",
-    "image",
+    ".",
     "shortnames",
 ]
 sha256 = [
-    "414def665a172a4d79366dc594e5313d43d672ba19009aa2a3dd78272e277506",
-    "2d4b0e5f66c83c776c6dab81fd52bee2aac72832ef3af4e6a1e081aaf1f87f30",
-    "8ea547fe0f2dcfaa458f9e2d584eaacd504572bdb33ce0e98e70fffbc851c519",
+    "6cfc76c4db34c30e560ab1bf5f297964fc755e8448a71f4b1ed8a68026431788",
     "1a2db4dca75b04d54623087972888459363392b9c4f64b6d0ac2f4b78cba3e45",
 ]
 # no tests

--- a/main/fuse-overlayfs/template.py
+++ b/main/fuse-overlayfs/template.py
@@ -1,5 +1,5 @@
 pkgname = "fuse-overlayfs"
-pkgver = "1.16"
+pkgver = "1.17"
 pkgrel = 0
 build_style = "gnu_configure"
 hostmakedepends = [
@@ -14,5 +14,5 @@ pkgdesc = "FUSE implementation for overlayfs"
 license = "GPL-2.0-or-later"
 url = "https://github.com/containers/fuse-overlayfs"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "45968517603389ead067222d234bc8d8ed33e4b4f8ba16216bdd3e6aedcccea9"
+sha256 = "cefffecfbb001b2784f19af344f27eae07b31a4faa38d345b738af96b2bec59e"
 hardening = ["vis", "cfi"]

--- a/main/netavark/template.py
+++ b/main/netavark/template.py
@@ -1,5 +1,5 @@
 pkgname = "netavark"
-pkgver = "1.15.2"
+pkgver = "2.0.0"
 pkgrel = 0
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "go-md2man", "protobuf-protoc"]
@@ -8,7 +8,7 @@ pkgdesc = "Container network stack"
 license = "Apache-2.0"
 url = "https://github.com/containers/netavark"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "84325e03aa0a2818aef9fb57b62cda8e9472584744d91ce5e5b191098f9e6d6a"
+sha256 = "031aeeacc930382e8635d40a885798eff1da164dfcf9024b698f822e5995d9c8"
 
 
 def post_build(self):

--- a/main/podman/template.py
+++ b/main/podman/template.py
@@ -1,6 +1,6 @@
 pkgname = "podman"
-pkgver = "5.8.2"
-pkgrel = 1
+pkgver = "6.0.2"
+pkgrel = 0
 build_style = "go"
 # for install.bin compat
 make_dir = "bin"
@@ -34,8 +34,8 @@ depends = [
     "conmon",
     "containers-common",
     "fuse-overlayfs",
-    "iptables",
     "netavark",
+    "nftables",
     "oci-runtime",
     "passt",
 ]
@@ -50,7 +50,7 @@ pkgdesc = "Container and image management tool"
 license = "Apache-2.0"
 url = "https://podman.io"
 source = f"https://github.com/containers/podman/archive/v{pkgver}.tar.gz"
-sha256 = "b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84"
+sha256 = "0895a541aeb7aa8e99133ed2b328c1bb40fd397b7c3b01e083396c90e8628756"
 # nah
 options = ["!check"]
 
@@ -79,3 +79,6 @@ def install(self):
         name="podman-docker",
         mode=0o755,
     )
+
+    self.uninstall("usr/share/man/man?/podman-quadlet*", glob=True)
+    self.uninstall("usr/share/man/man?/quadlet.*", glob=True)

--- a/main/skopeo/patches/basename.patch
+++ b/main/skopeo/patches/basename.patch
@@ -1,6 +1,8 @@
---- a/vendor/github.com/containers/storage/pkg/unshare/unshare.c
-+++ b/vendor/github.com/containers/storage/pkg/unshare/unshare.c
-@@ -19,6 +19,8 @@
+diff --git a/vendor/go.podman.io/storage/pkg/unshare/unshare.c b/vendor/go.podman.io/storage/pkg/unshare/unshare.c
+index a2800654..fbabb447 100644
+--- a/vendor/go.podman.io/storage/pkg/unshare/unshare.c
++++ b/vendor/go.podman.io/storage/pkg/unshare/unshare.c
+@@ -20,6 +20,8 @@
  #include <sys/mount.h>
  #include <linux/limits.h>
  

--- a/main/skopeo/template.py
+++ b/main/skopeo/template.py
@@ -1,6 +1,6 @@
 pkgname = "skopeo"
-pkgver = "1.20.0"
-pkgrel = 5
+pkgver = "1.23.0"
+pkgrel = 0
 build_style = "go"
 # for compatibility with Makefile targets
 make_dir = "bin"
@@ -21,9 +21,9 @@ depends = ["containers-common"]
 go_build_tags = ["libsqlite3"]
 pkgdesc = "OCI image and repo manipulation tool"
 license = "Apache-2.0"
-url = "https://github.com/containers/skopeo"
+url = "https://github.com/podman-container-tools/skopeo"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "0c19fe51b2cd8d1bd5e38c03b97421e318fc08153bdf5ef2f816a29889eacdef"
+sha256 = "de96bfc2bb523c852af675ffdadd934484812ce190aa8620e1d5fd6c51442e25"
 
 
 def post_build(self):


### PR DESCRIPTION
## Description

Large amount of breaking changes, moved repos, config changes.

Minimum versions required now:

> Due to breaking changes in this release, Podman v6.0.0 must be used with Buildah v1.44.0, Skopeo v1.23, Netavark and Aardvark v2.0.0, and configuration files from the container-libs repository's common/v0.68.0 release.

Some other relevant packaging notes:

- Support for running on iptables has been removed. Please use nftables instead.
- containers-common has moved to a new mono-repo

I'll definitely want your expert eyes on this @q66. :)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
