### PR TITLE
[RFC] main/sddm: switch to wayland by default

### DIFF
--- a/main/sddm/files/sddm.config
+++ b/main/sddm/files/sddm.config
@@ -11,8 +11,8 @@ User=
 
 [General]
 # Which display server should be used.
-# Valid values are: x11, x11-user, wayland. Wayland support is experimental
-DisplayServer=x11
+# Valid values are: x11, x11-user, wayland (considered experimental)
+DisplayServer=wayland
 
 # Comma-separated list of environment variables to be set
 GreeterEnvironment=
@@ -93,7 +93,7 @@ ReuseSession=true
 
 [Wayland]
 # Path of the Wayland compositor to execute when starting the greeter
-CompositorCommand=weston --shell=kiosk
+CompositorCommand=kwin_wayland --drm --no-lockscreen --no-global-shortcuts --locale1 --inputmethod plasma-keyboard
 
 # Enable Qt's automatic high-DPI scaling
 EnableHiDPI=true

--- a/main/sddm/patches/sddm-unused-tty.patch
+++ b/main/sddm/patches/sddm-unused-tty.patch
@@ -1,0 +1,53 @@
+diff --git a/src/daemon/Display.cpp b/src/daemon/Display.cpp
+index 4014e0d..971598e 100644
+--- a/src/daemon/Display.cpp
++++ b/src/daemon/Display.cpp
+@@ -36,6 +36,7 @@
+ #include <QTimer>
+ #include <QLocalSocket>
+ 
++#include <cstdlib>
+ #include <pwd.h>
+ #include <unistd.h>
+ #include <sys/time.h>
+@@ -77,7 +78,39 @@ namespace SDDM {
+     }
+ 
+     int fetchAvailableVt() {
+-        if (!isTtyInUse(QStringLiteral("tty" STRINGIFY(SDDM_INITIAL_VT)))) {
++        /* chimera active ttys */
++        QFile ttys{QString::fromUtf8("/run/agetty-active")};
++        if (ttys.open(QIODevice::ReadOnly)) {
++            char buf[4096], *bufp = buf, *ttystr = nullptr;
++            memset(buf, 0, sizeof(buf));
++            auto sz = ttys.read(buf, sizeof(buf) - 1);
++            if (sz > 0) {
++                unsigned long minvt = 1;
++                while (*bufp) {
++                    if (strncmp(bufp, "tty", 3)) {
++                        break;
++                    }
++                    char *err = nullptr;
++                    auto gettyn = strtoul(bufp + 3, &err, 10);
++                    if (!err || (*err && *err != '\n')) {
++                        break;
++                    }
++                    if (gettyn >= minvt) {
++                        ttystr = bufp;
++                        minvt = gettyn + 1;
++                    }
++                    if (!*err) {
++                        break;
++                    }
++                    *err = '\0';
++                    bufp = err + 1;
++                }
++                if (minvt < 64 && ttystr && !isTtyInUse(QString::fromUtf8(ttystr))) {
++                    return int(minvt);
++                }
++            }
++        }
++        if (!isTtyInUse(QStringLiteral("tty%1").arg(SDDM_INITIAL_VT))) {
+             return SDDM_INITIAL_VT;
+         }
+         const auto vt = VirtualTerminal::currentVt();

--- a/main/sddm/template.py
+++ b/main/sddm/template.py
@@ -1,6 +1,6 @@
 pkgname = "sddm"
 pkgver = "0.21.0"
-pkgrel = 5
+pkgrel = 6
 build_style = "cmake"
 configure_args = [
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
@@ -12,6 +12,10 @@ configure_args = [
     "-DUID_MAX=60513",
     "-DRUNTIME_DIR=/run/sddm",
     "-DUSE_ELOGIND=ON",
+    # we have runtime detection patched in, however
+    # in case that does not exist, fall back to 7 first
+    # (e.g. with our agetty service disabled, which you should not do...)
+    "-DSDDM_INITIAL_VT=7",
 ]
 hostmakedepends = [
     "cmake",
@@ -33,11 +37,12 @@ makedepends = [
 depends = [
     "dinit-dbus",
     "elogind",
+    "kwin",
     "openrc-settingsd",
+    "plasma-keyboard",
     "plasma-workspace",
     "turnstile",
     "xrdb",
-    "xserver-xorg-input-libinput",
 ]
 pkgdesc = "QML based display manager"
 license = "GPL-2.0-or-later AND CC-BY-3.0"


### PR DESCRIPTION
The greeter is kinda wonky when it comes to session selection. However, it is wonky regardless even in x11 mode, just slightly less. Use kwin for wayland compositor because we already bring in KDE dependencies anyway through plasma-workspace, and with kwin we get a nice virtual keyboard and stuff, without significant new deps

testing appreciated

cc @JamiKettunen 