### PR TITLE
main/man-pages: update to 6.18

### DIFF
--- a/main/man-pages/template.py
+++ b/main/man-pages/template.py
@@ -1,12 +1,12 @@
 pkgname = "man-pages"
-pkgver = "6.16"
+pkgver = "6.18"
 pkgrel = 0
 hostmakedepends = ["bash", "gsed"]
 pkgdesc = "Linux Documentation Project manual pages"
 license = "GPL-2.0-or-later"
 url = "https://man7.org/linux/man-pages/index.html"
 source = f"$(KERNEL_SITE)/docs/man-pages/man-pages-{pkgver}.tar.xz"
-sha256 = "8e247abd75cd80809cfe08696c81b8c70690583b045749484b242fb43631d7a3"
+sha256 = "c934fadc8b59748c68227a34f6581d2ddf8282b73cdcd52546c8cd88b74b24d1"
 options = ["!autosplit"]
 
 
@@ -55,9 +55,20 @@ def install(self):
         self.rm("ulckpwdf.3")
 
     # Useless, pull in bash and other stuff we don't want
-    for cmd in ["diffman-git", "mansect", "pdfman", "sortman"]:
+    for cmd in [
+        "diffman-git",
+        "grepc",
+        "grepc_c",
+        "mansect",
+        "mansectf",
+        "pdfman",
+        "sortman",
+    ]:
         self.uninstall(f"usr/bin/{cmd}")
         self.uninstall(f"usr/share/man/man1/{cmd}.1")
+
+    # as above, but doesn't have a man page to delete
+    self.uninstall("usr/bin/grepc_mk")
 
 
 @subpackage("man-pages-devel")


### PR DESCRIPTION
## Description

The prior 6.17 release added some new commands:

> This release adds several new programs.  We recommend that distributions
> package all of our src/bin/ scripts in a separate binary package, called
> something like manpages-utils (this happens to be the name I'd suggest
> specifically for Debian, for consistency with manpages and
> manpages-dev).

- grepc - find declarations, definitions, and uses in source code
 - grepc_c - print PCRE patterns for searching C code
- grepc_mk
  -  no man page
- mansectf - format specific sections of manual pages

Given we uninstall other binaries I did that here too since they don't seem to be needed.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
