### PR TITLE
dracut-install: fix checksum and url after upstream repo rename

### DIFF
--- a/main/dracut-install/template.py
+++ b/main/dracut-install/template.py
@@ -11,9 +11,13 @@ makedepends = ["chimerautils-devel", "kmod-devel"]
 checkdepends = ["asciidoc"]
 pkgdesc = "Dracut-install command from dracut"
 license = "GPL-2.0-or-later"
-url = "https://github.com/dracut-ng/dracut-ng"
+url = "https://github.com/dracut-ng/dracut"
+# upstream renamed the GitHub repo dracut-ng/dracut-ng -> dracut-ng/dracut;
+# same tag/commit, but GitHub's auto-generated archive now uses the new repo
+# name for its internal top-level dir (dracut-107/ instead of
+# dracut-ng-107/), which changes the tarball's bytes and thus its checksum.
 source = f"{url}/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "b39d0d1cd35ff43aba8771c5367d8c6c59bb432c0cac62f49601f21c0d634895"
+sha256 = "fab19fb41d86de681c022d1a8798804595750be934d98a785ff0257dcdfc9a78"
 hardening = ["vis", "cfi"]
 # assumes rw filesystem
 options = ["!check"]


### PR DESCRIPTION
Upstream renamed the GitHub repo dracut-ng/dracut-ng -> dracut-ng/dracut (same tag/commit). GitHub's auto-generated archive now uses the new repo name for its internal top-level directory (dracut-107/ instead of dracut-ng-107/), which changes the tarball bytes and thus the checksum, causing dracut-install to fail with a SHA256 mismatch on fetch.

Also updated `url` to point at the new location directly rather than relying on GitHub's rename redirect, which isn't permanent (it breaks if the old name is ever claimed by a different repo).

Verified the new tarball's content is unchanged from the old one (dracut-install.c and the full module tree present as expected). This is purely a checksum/URL update, not a content change.

## Description

Describe what your pull request does here. For new packages, this is the
purpose of the package, for other changes this is what your change does,
for trivial package updates you may remove this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
