### PR TITLE
cbuild: don't trust a 0-byte Packages.adb/APKINDEX.tar.gz as an incremental index base

### DIFF
--- a/src/cbuild/apk/cli.py
+++ b/src/cbuild/apk/cli.py
@@ -408,9 +408,17 @@ def build_index(repopath, epoch, allow_untrusted=False):
 
     aargs = ["--quiet", "--output", "Packages.adb", "--hash", "sha256-160"]
 
-    if (repopath / "Packages.adb").is_file():
+    # an existing index is only usable as an incremental base if it's
+    # non-empty; a 0-byte file (e.g. left behind by a crash mid-write) is
+    # not a valid index, and passing it via --index makes apk error out
+    # with "unexpected end of file" instead of just rebuilding fresh, as
+    # it would if the file were absent entirely
+    adb_path = repopath / "Packages.adb"
+    gz_path = repopath / "APKINDEX.tar.gz"
+
+    if adb_path.is_file() and adb_path.stat().st_size > 0:
         aargs += ["--index", "Packages.adb"]
-    elif (repopath / "APKINDEX.tar.gz").is_file():
+    elif gz_path.is_file() and gz_path.stat().st_size > 0:
         aargs += ["--index", "APKINDEX.tar.gz"]
 
     keypath = None


### PR DESCRIPTION
build_index() only checked is_file() before passing an existing index to apk via --index, but a 0-byte file (left behind by a crash mid-write, e.g. a kernel panic during a long build) is not a valid index. Passing it makes apk fail with "unexpected end of file" instead of just rebuilding the index fresh, as it would if the file were absent entirely. This failure mode is silent about its cause and hits every subsequent build that touches the same repo until someone notices and manually deletes the corrupt file(s). Hit this after a kernel panic corrupted both Packages.adb and its APKINDEX.tar.gz hardlink mid-write, which then failed 20 unrelated package builds back to back (one of them a ~16hr build that had otherwise completed successfully) before being traced back to this.

## Description

Describe what your pull request does here. For new packages, this is the
purpose of the package, for other changes this is what your change does,
for trivial package updates you may remove this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
