### PR TITLE
cronie: add missing dinit-chimera makedepend

### DIFF
--- a/main/cronie/template.py
+++ b/main/cronie/template.py
@@ -9,7 +9,7 @@ configure_args = [
     "--without-selinux",
 ]
 hostmakedepends = ["automake", "libtool"]
-makedepends = ["linux-pam-devel", "musl-obstack-devel"]
+makedepends = ["dinit-chimera", "linux-pam-devel", "musl-obstack-devel"]
 depends = ["cmd:run-parts!debianutils"]
 pkgdesc = "Cron daemon"
 license = "ISC AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-or-later"


### PR DESCRIPTION
cronie's dinit service file (crond) declares depends-on = local.target, but dinit-chimera (the package providing svc:local.target) was never listed in makedepends, so packaging failed with "svc: local.target (unknown provider)". Every other dinit-integrated package (acpid, avahi-autoipd, etc.) already lists it.

## Description

Describe what your pull request does here. For new packages, this is the
purpose of the package, for other changes this is what your change does,
for trivial package updates you may remove this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
