### PR TITLE
lvm2-dm: fix libexecdir override, actually landing in /usr/lib

### DIFF
--- a/main/lvm2/template.py
+++ b/main/lvm2/template.py
@@ -1,9 +1,13 @@
 pkgname = "lvm2"
 pkgver = "2.03.33"
-pkgrel = 1
+pkgrel = 2
 build_style = "gnu_configure"
 configure_args = [
-    "--libexecdir=/usr/libexec",  # TODO switch libexec
+    # lvm2's configure has its own separate --with-libexecdir AC_ARG_WITH
+    # that unconditionally overrides plain --libexecdir if not given
+    # explicitly (falls back to ${prefix}/libexec otherwise), so the
+    # standard autoconf flag alone silently has no effect here.
+    "--with-libexecdir=/usr/lib",
     "--enable-editline",
     "--enable-pkgconfig",
     "--enable-fsadm",


### PR DESCRIPTION
lvm2's own `configure` script defines a separate `--with-libexecdir` AC_ARG_WITH that unconditionally overrides the standard `--libexecdir` autoconf flag if not passed explicitly (falls back to `${prefix}/libexec` otherwise). This meant `lvresize_fs_helper` (and friends) landed in `/usr/libexec` instead of `/usr/lib`, which fails cports lint on Chimera (no `/usr/libexec` split). Passing `--with-libexecdir=/usr/lib` explicitly fixes it. Verified with a clean isolated `cbuild pkg -f -t` rebuild.