### PR TITLE
pipewire: explicitly disable libsystemd feature

### DIFF
--- a/main/pipewire/template.py
+++ b/main/pipewire/template.py
@@ -1,12 +1,17 @@
 pkgname = "pipewire"
 pkgver = "1.6.7"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "--auto-features=enabled",
     "-Ddocs=enabled",
     "-Dman=enabled",
     "-Dlogind-provider=libelogind",
+    # --auto-features=enabled promotes this separate feature flag (default
+    # "auto") to required too; without it meson hard-fails looking for
+    # libsystemd.pc, which Chimera doesn't ship (elogind provides logind
+    # integration instead, set above).
+    "-Dlibsystemd=disabled",
     "-Dsdl2=disabled",  # examples
     "-Dlibffado=disabled",
     "-Droc=disabled",  # TODO


### PR DESCRIPTION
`--auto-features=enabled` promotes every meson `type: 'feature', value: 'auto'` option to required, including `libsystemd` (separate from the already-correctly-configured `logind-provider=libelogind`). Chimera doesn't ship `libsystemd.pc`, so this makes the meson configure step hard-fail. Passing `-Dlibsystemd=disabled` explicitly fixes it since elogind already provides the logind integration. Verified with a clean isolated `cbuild pkg -f -t` rebuild.