### PR TITLE
perl-crypt-urandom: fetch from permanent metacpan path

### DIFF
--- a/main/perl-crypt-urandom/template.py
+++ b/main/perl-crypt-urandom/template.py
@@ -1,6 +1,6 @@
 pkgname = "perl-crypt-urandom"
 pkgver = "0.54"
-pkgrel = 0
+pkgrel = 1
 build_style = "perl_module"
 hostmakedepends = ["perl"]
 makedepends = ["perl"]
@@ -8,5 +8,9 @@ depends = ["perl"]
 pkgdesc = "Perl module for non-blocking randomness"
 license = "Artistic-1.0-Perl OR GPL-1.0-or-later"
 url = "https://metacpan.org/dist/Crypt-URandom"
-source = f"$(CPAN_SITE)/Crypt/Crypt-URandom-{pkgver}.tar.gz"
+# $(CPAN_SITE) (www.cpan.org/modules/by-module) only mirrors the latest
+# release per module and 403s on older pinned versions once superseded
+# upstream (this one has since moved on to 0.55); the permanent
+# author-keyed path never gets pruned.
+source = f"https://cpan.metacpan.org/authors/id/D/DD/DDICK/Crypt-URandom-{pkgver}.tar.gz"
 sha256 = "4a73cd394933328da484aaeb8645d735b35465df60109e559e0a28b066053a57"


### PR DESCRIPTION
Same issue as perl-authen-sasl: `$(CPAN_SITE)` only mirrors the latest release per module and 403s on this pinned older version now that upstream has shipped 0.55. Switching to the permanent author-keyed metacpan path fixes the fetch permanently. Verified with a clean isolated build.