### PR TITLE
user/libvips: update to 8.14.4

### DIFF
--- a/user/libvips/template.py
+++ b/user/libvips/template.py
@@ -11,8 +11,8 @@ hostmakedepends = [
     "pkgconf",
 ]
 makedepends = [
+    "cgif-devel",
     "fftw-devel",
-    "giflib-devel",
     "glib-devel",
     "gobject-introspection",
     "highway-devel",

--- a/user/libvips/template.py
+++ b/user/libvips/template.py
@@ -1,5 +1,5 @@
 pkgname = "libvips"
-pkgver = "8.17.2"
+pkgver = "8.18.4"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Db_ndebug=true"]
@@ -34,7 +34,7 @@ pkgdesc = "Fast image processing library"
 license = "LGPL-2.1-or-later"
 url = "https://github.com/libvips/libvips"
 source = f"https://github.com/libvips/libvips/releases/download/v{pkgver}/vips-{pkgver}.tar.xz"
-sha256 = "57ea0ec4f30ea04748c9e8eec5415e7c9ac7cafe6822e4788fc110376a1d224a"
+sha256 = "2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037"
 # broken
 options = ["!cross"]
 

--- a/user/libvips/template.py
+++ b/user/libvips/template.py
@@ -22,6 +22,7 @@ makedepends = [
     "libjpeg-turbo-devel",
     "libjxl-devel",
     "libpng-devel",
+    "libraw-devel",
     "librsvg-devel",
     "libtiff-devel",
     "libwebp-devel",


### PR DESCRIPTION
## Description

In addition to the version bump, this adds libraw to makedepends (support for handling camera RAW images [was added with 8.18.0](https://www.libvips.org/2025/12/04/What's-new-in-8.18.html)) and, as per #5226, replaces giflib with cgif (though this is currently not enough for working gifsave; libimagequant is still needed for this, but as per the fedi post I'm holding off on submitting another new package for now).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
