### PR TITLE
user/earlybird: new package

### DIFF
--- a/user/earlybird/template.py
+++ b/user/earlybird/template.py
@@ -1,0 +1,17 @@
+pkgname = "earlybird"
+pkgver = "4.6.1"
+pkgrel = 0
+build_style = "go"
+hostmakedepends = ["go"]
+depends = ["git"]
+pkgdesc = "Sensitive data scanner for source code repositories"
+license = "Apache-2.0"
+url = "https://github.com/americanexpress/earlybird"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "04bfc2de0d6701e20ddba59216bc14af52d5978fade597097cc34c2830361a19"
+# check: depends on this package being built from its own cloned git repo, and as this is a tarball, the test is nonfunctional
+options = ["!check"]
+
+
+def post_install(self):
+    self.install_license("LICENSE.txt")


### PR DESCRIPTION
## Description

This is a tool created by American Express' open source department for scanning source code repositories for vulnerabilities and bad security practices (CWEs), like exposed secrets, API keys, outdated cryptography, etc cetera. It is a very straightforward, basic Go tool to package, aside from the built-in test having to be skipped due to relying on the assumption that its own repo used for building is being cloned from git. (It uses itself to test. Since we're using versioned tarballs, the test fails.)

I tested this package on a x86_64 VPS running Chimera Linux, and it works exactly as it should. I have had no issues using it.

Best of luck with the huge amount in the package queue. Take your time packaging this.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
