### PR TITLE
main/unbound: update to 1.25.2

### DIFF
--- a/main/unbound/template.py
+++ b/main/unbound/template.py
@@ -1,5 +1,5 @@
 pkgname = "unbound"
-pkgver = "1.25.1"
+pkgver = "1.25.2"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -42,7 +42,7 @@ pkgdesc = "Validating, recursive, and caching DNS resolver"
 license = "BSD-3-Clause"
 url = "https://nlnetlabs.nl/projects/unbound/about"
 source = f"https://nlnetlabs.nl/downloads/unbound/unbound-{pkgver}.tar.gz"
-sha256 = "0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f"
+sha256 = "0d92275c703d5f5f8baba3dab22117dd8c29b495588a5c229768ed6581566600"
 skip_dependencies = ["usr/lib/dinit.d/*"]
 options = ["etcfiles"]
 


### PR DESCRIPTION
## Description

Oof, that's a lot of CVEs:

- CVE-2026-14586 - Assertion in libngtcp2 when under pressure in high
  concurrency DNS-over-QUIC environments. Thanks to Kunta Chu, Kaihua
  Wang, and Jianjun Chen from Tsinghua University, for the report.
- CVE-2026-32665 - Remote DNS-over-QUIC denial of service due to
  `quic-size` budget bypass. Thanks to N0zoM1z0
  (https://github.com/N0zoM1z0) for the report. In addition, thanks to
  Kunta Chu, Kaihua Wang, and Jianjun Chen from Tsinghua University, for
  also reporting this issue. In addition, thanks to Qifan Zhang, Palo
  Alto Networks, for also reporting this issue. In addition, thanks to
  Xuanchao Xie, for also reporting this issue.
- CVE-2026-40691 - Packet of death for DNSCrypt over TCP. Thanks to
  Qifan Zhang, Palo Alto Networks, for the report. In addition, thanks
  to Trung Nguyen (@everping) of CyStack, for also reporting this issue.
- CVE-2026-41637 - Degradation of resolution service from improperly
  accounted client-terminated DNS-over-QUIC queries. Thanks to Qifan
  Zhang, Palo Alto Networks, for the report.
- CVE-2026-42955 - Extra fix for CVE-2026-40622 to also clamp the TTL of
  A/AAAA records disallowing a one-time 'ghost domain' delegation
  renewal via glue records. Thanks to Qifan Zhang, Palo Alto Networks,
  for the report.
- CVE-2026-44621 - Libunbound applications configured with
  'unwanted-reply-threshold' could eventually be abruptly terminated.
  Thanks to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-44687 - Off-by-one error in 'harden-below-nxdomain' logic can
  shadow a stub/forward zone by a legitimate parent's NXDOMAIN. Thanks
  to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-44690 - Cross-zone wildcard cache poisoning via RRSIG.labels
  manipulation. Thanks to Qifan Zhang, Palo Alto Networks, for the
  report.
- CVE-2026-46582 - A wildcard replay, as another piece of data, triggers
  poisoning in the serve expired reply path. Thanks to Qifan Zhang, Palo
  Alto Networks, for the report.
- CVE-2026-50045 - 'max-global-quota' reset by DNSSEC validation
  restarts. Thanks to Kunjie Shang, University of Science and Technology
  of China, for the report.
- CVE-2026-50046 - Possible heap use-after-free in an error path when a
  DoT forwarded query is jostled out. Thanks to Qifan Zhang, Palo Alto
  Networks, for the report.
- CVE-2026-50243 - 'response-ip'/'rpz' can rewrite BOGUS answers instead
  of returning SERVFAIL. Thanks to Qifan Zhang, Palo Alto Networks, for
  the report.
- CVE-2026-50248 - BOGUS configured primary hostname accepted for XFR in
  auth/rpz zones. Thanks to Qifan Zhang, Palo Alto Networks, for the
  report.
- CVE-2026-50251 - Attacker supplied `0.0.0.0`/`::` glue triggers
  defensive full-cache flush. Thanks to Qifan Zhang, Palo Alto Networks,
  for the report.
- CVE-2026-50252 - Possible cache poisoning attack by mapping source
  port population per thread. Thanks to Inbal Schussheim and Amit Klein,
  Hebrew University, for the report.
- CVE-2026-52863 - Memory corruption could lead to crash and denial of
  service. Thanks to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-54478 - DNS Cookie bypass when combined with proxy-protocol
  use. Thanks to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-55708 - Privacy/configuration issue when adding local data in
  views through 'unbound-control'. Thanks to Qifan Zhang, Palo Alto
  Networks, for the report.
- CVE-2026-55717 - 'serve-expired-client-timeout' and 'response-ip'
  CNAME redirect could lead to a crash. Thanks to Qifan Zhang, Palo Alto
  Networks, for the report. In addition, thanks to Xin Wang, Jiapeng Li,
  and Jiajia Liu, Northwestern Polytechnical University, for also
  reporting this issue.
- CVE-2026-55973 - 'dns-error-reporting: yes' leads to stack buffer
  overflow. Thanks to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-55990 - Packet of death for a DNSCrypt misconfigured Unbound.
  Thanks to Qifan Zhang, Palo Alto Networks, for the report.
- CVE-2026-55991 - Remote DNS-over-QUIC (DoQ) flow-control assertion
  failure in libngtcp2. Thanks to Qifan Zhang, Palo Alto Networks, for
  the report. In addition, thanks to Xuanchao Xie, for also reporting
  this issue.
- CVE-2026-56416 - Possible heap buffer overflow when validator
  canonicalizes RDATA that contains domain name. Thanks to Qifan Zhang,
  Palo Alto Networks, for the report.
- CVE-2026-56444 - Degradation of resolution service when
  'discard-timeout' and 'serve-expired-client-timeout' are combined in
  unusual configuration. Thanks to Qifan Zhang, Palo Alto Networks, for
  the report. In addition, thanks to Xin Wang, Jiapeng Li, and Jiajia
  Liu, Northwestern Polytechnical University, for also reporting this
  issue. In addition, thanks to Haruki Oyama (Waseda University), for
  also reporting this issue.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
