### PR TITLE
main/openssh: update to 10.4_p1

### DIFF
--- a/main/openssh/template.py
+++ b/main/openssh/template.py
@@ -1,6 +1,6 @@
 pkgname = "openssh"
-pkgver = "10.3_p1"
-pkgrel = 1
+pkgver = "10.4_p1"
+pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
     "--datadir=/usr/share/openssh",
@@ -43,7 +43,7 @@ pkgdesc = "OpenSSH free Secure Shell (SSH) client and server implementation"
 license = "SSH-OpenSSH"
 url = "https://www.openssh.com"
 source = f"https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-{pkgver.replace('_', '')}.tar.gz"
-sha256 = "56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4"
+sha256 = "ef6026dd2aea8d56059638d5d3262902c892ceba9f88395835e0d06d3fb63238"
 file_modes = {"usr/lib/ssh-keysign": ("root", "root", 0o4755)}
 # CFI: does not work; maybe make testsuite work first
 hardening = ["vis", "!cfi"]


### PR DESCRIPTION
## Description

I think we're good?

 * sshd(8): on Linux systems with the seccomp sandbox enabled,
   failures to enable SECCOMP or NO_NEW_PRIVS are now fatal.
   Previously sshd(8) would log the error but continue operation,
   to support systems that lacked these features. Now systems that
   lack these should instead disable the sandbox at configure time.

https://www.openssh.org/releasenotes.html

Tested ssh, ssh-agent, and sshd either way. Looks fine.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
