### PR TITLE
main/shaderc: update to 2026.3

### DIFF
--- a/main/blender/template.py
+++ b/main/blender/template.py
@@ -1,6 +1,6 @@
 pkgname = "blender"
 pkgver = "5.1.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DCMAKE_BUILD_TYPE=Release",

--- a/main/ffmpeg/template.py
+++ b/main/ffmpeg/template.py
@@ -1,6 +1,6 @@
 pkgname = "ffmpeg"
 pkgver = "8.1.2"
-pkgrel = 1
+pkgrel = 2
 build_style = "configure"
 configure_args = [
     "--prefix=/usr",

--- a/main/libplacebo/template.py
+++ b/main/libplacebo/template.py
@@ -1,6 +1,6 @@
 pkgname = "libplacebo"
 pkgver = "7.360.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "-Dshaderc=enabled",

--- a/main/shaderc/template.py
+++ b/main/shaderc/template.py
@@ -1,5 +1,5 @@
 pkgname = "shaderc"
-pkgver = "2026.2"
+pkgver = "2026.3"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -12,7 +12,7 @@ pkgdesc = "Collection of tools and libraries for shader compilation"
 license = "Apache-2.0"
 url = "https://github.com/google/shaderc"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42"
+sha256 = "ee493ccf1b3038b4ef2fe024664c5eb2dc4bcc1f6b05b33e3909de0e19c81024"
 tool_flags = {
     "CXXFLAGS": [f"-I{self.profile().sysroot / 'usr/include/glslang'}"]
 }

--- a/user/supertuxkart/template.py
+++ b/user/supertuxkart/template.py
@@ -1,6 +1,6 @@
 pkgname = "supertuxkart"
 pkgver = "1.5"
-pkgrel = 1
+pkgrel = 2
 build_style = "cmake"
 hostmakedepends = ["cmake", "ninja", "pkgconf"]
 makedepends = [


### PR DESCRIPTION
## Description

- **Deprecate HLSL compilation** (planned removal)
- New build option `SHADERC_ENABLE_HLSL` to build without HLSL support

Think we're good?

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
