### PR TITLE
main/libgit2: update to 1.9.6

### DIFF
--- a/main/libgit2/template.py
+++ b/main/libgit2/template.py
@@ -1,6 +1,6 @@
 pkgname = "libgit2"
-pkgver = "1.9.4"
-pkgrel = 1
+pkgver = "1.9.6"
+pkgrel = 0
 build_style = "cmake"
 configure_args = [
     "-DUSE_SSH=ON",
@@ -27,7 +27,7 @@ pkgdesc = "Linkable library for using git"
 license = "GPL-2.0-only WITH GCC-exception-2.0"
 url = "https://libgit2.org"
 source = f"https://github.com/libgit2/libgit2/archive/v{pkgver}.tar.gz"
-sha256 = "824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b"
+sha256 = "a88a42a4ea9bdab7aa8686eead3bf7d9c6dd74529caca16ab22eaa92433d31d9"
 
 
 def post_extract(self):


### PR DESCRIPTION
## Description

- Fix for blame error handling on hunk creation failures
- Fix for potential PCRE memory access: 1-byte heap-buffer-overflow
  WRITE in bundled PCRE 8.45 reachable via revspec
- Fix for CVE-2026-53586: give auth callback current host
- Fix for CVE-2026-53587: libgit2 version 1.9.4 and below is vulnerable
  to a heap out-of-bounds read in set_data in
  src/libgit2/transports/smart_pkt.c.
- Fix for CVE-2026-53585: Unbounded Memory Allocation via Delta Object
  Result-Size Header
- Fix for CVE-2026-53584: submodule: check paths for escaping
- Fix for CVE-2026-53583: inverted IP SubjectAltName comparison in
  OpenSSL backend.

Other bug fixes.

https://github.com/libgit2/libgit2/releases/tag/v1.9.5
https://github.com/libgit2/libgit2/releases/tag/v1.9.6

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
