### PR TITLE
main/wireshark: hide ads by default

### DIFF
--- a/main/wireshark/patches/no-ads.patch
+++ b/main/wireshark/patches/no-ads.patch
@@ -1,0 +1,14 @@
+remove sponsored tips by default
+
+diff -ruN a/ui/recent.c b/ui/recent.c
+--- a/ui/recent.c	2026-07-15 19:43:00.000000000 +0200
++++ b/ui/recent.c	2026-07-24 11:32:04.792432412 +0200
+@@ -1723,7 +1723,7 @@
+     recent.gui_welcome_page_sidebar_learn_visible = true;
+     recent.gui_welcome_page_sidebar_tips_visible = true;
+     recent.gui_welcome_page_sidebar_tips_events = true;
+-    recent.gui_welcome_page_sidebar_tips_sponsorship = true;
++    recent.gui_welcome_page_sidebar_tips_sponsorship = false;
+     recent.gui_welcome_page_sidebar_tips_tips = true;
+     recent.gui_welcome_page_sidebar_tips_auto_advance = true;
+     recent.gui_welcome_page_sidebar_tips_interval = 8;

--- a/main/wireshark/template.py
+++ b/main/wireshark/template.py
@@ -1,13 +1,12 @@
 pkgname = "wireshark"
 pkgver = "4.7.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DENABLE_GNUTLS=ON",
     "-DENABLE_LUA=ON",
     "-DENABLE_DEBUG=OFF",
     "-DENABLE_WERROR=OFF",
-    "-DUSE_qt6=ON",
 ]
 make_build_args = ["--target", "all", "test-programs"]
 hostmakedepends = [


### PR DESCRIPTION
fixes #5898, but note that it will **not** override the option if it was already saved as true by the previous default

also remove a now unused build flag

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine