### PR TITLE
main/ethtool: update to 7.1

### DIFF
--- a/main/ethtool/template.py
+++ b/main/ethtool/template.py
@@ -1,5 +1,5 @@
 pkgname = "ethtool"
-pkgver = "7.0"
+pkgver = "7.1"
 pkgrel = 0
 build_style = "gnu_configure"
 hostmakedepends = ["pkgconf", "automake", "libtool"]
@@ -8,6 +8,6 @@ pkgdesc = "Utility for controlling network drivers and hardware"
 license = "GPL-2.0-only"
 url = "http://www.kernel.org/pub/software/network/ethtool"
 source = f"{url}/ethtool-{pkgver}.tar.xz"
-sha256 = "660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162"
+sha256 = "4d78c26edc0255bc92f4b995b5fd66108d75ff966ed4694f6025a6d370bc2496"
 # FIXME int
 hardening = ["vis", "cfi", "!int"]


### PR DESCRIPTION
## Description

Version 7.1 - Jul 7, 2026

- Feature: track TX pause storm events (-I -a)
- Feature: update doc for ETHTOOL_PFC_PREVENTION_TOUT tunable
- Feature: RX CQE coalescing params (-c, -C)
- Feature: allow hex dump of all pages (-m)
- Feature: qsfp: support newer SFF-8636 compliance codes (-m)
- Feature: sfpid: support newer SFF-8636 compliance codes (-m)
- Fix: document --disable-netlink in help output (-h)
- Fix: add missing newlines in FEC output (--show-fec)
- Fix: sfpid: fix 10G Base-ER module detection (-m)
- Misc: clarify 10000baseCR link mode in man page

https://fossies.org/linux/ethtool/NEWS

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
