### PR TITLE
main/ldacbt: update to 2.0.2.6

### DIFF
--- a/main/ldacbt/template.py
+++ b/main/ldacbt/template.py
@@ -1,5 +1,5 @@
 pkgname = "ldacbt"
-pkgver = "2.0.2.3"
+pkgver = "2.0.2.6"
 pkgrel = 0
 build_style = "cmake"
 configure_args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
@@ -8,7 +8,7 @@ pkgdesc = "AOSP libldac dispatcher"
 license = "Apache-2.0"
 url = "https://github.com/EHfive/ldacBT"
 source = f"{url}/releases/download/v{pkgver}/ldacBT-{pkgver}.tar.gz"
-sha256 = "4bd8eece78bb5c1361fab95743e7100506e2408a25c4a592a0f8d349746dc5b4"
+sha256 = "fee05740e86ee66f4540486d92683ee8e8071119907b57ca762c7e5d943ecef0"
 # no test suite
 options = ["!check"]
 


### PR DESCRIPTION
## Description

- v2.0.2.4: Dropped patch version from soname (e.g.
  `libldacBT_enc.so.2.0.2.3` → `libldacBT_enc.so.2`). Stopped versioning
  built .so with script version.
- v2.0.2.5: Pinned version to 2.0.2.3 in pkgconfig files for
  compatibility.
- v2.0.2.6: Re-shipped libldac included tarball in release (bundled in
  GitHub Actions). No code changes.

https://github.com/EHfive/ldacBT/tags

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
