### PR TITLE
main/libdeflate: update to 1.25

### DIFF
--- a/main/libdeflate/template.py
+++ b/main/libdeflate/template.py
@@ -1,5 +1,5 @@
 pkgname = "libdeflate"
-pkgver = "1.24"
+pkgver = "1.25"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -19,7 +19,7 @@ pkgdesc = "Library for DEFLATE/zlib/gzip compression and decompression"
 license = "MIT"
 url = "https://github.com/ebiggers/libdeflate"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "ad8d3723d0065c4723ab738be9723f2ff1cb0f1571e8bfcf0301ff9661f475e8"
+sha256 = "d11473c1ad4c57d874695e8026865e38b47116bbcb872bfc622ec8f37a86017d"
 hardening = ["vis", "!cfi"]
 
 


### PR DESCRIPTION
## Description

CMake now relocatabale & gcc-16 build fix.

https://github.com/ebiggers/libdeflate/blob/v1.25/NEWS.md

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
