### PR TITLE
main/libseccomp: update to 2.6.1

### DIFF
--- a/main/libseccomp/template.py
+++ b/main/libseccomp/template.py
@@ -1,6 +1,6 @@
 # update python-libseccomp alongside this
 pkgname = "libseccomp"
-pkgver = "2.6.0"
+pkgver = "2.6.1"
 pkgrel = 0
 build_style = "gnu_configure"
 hostmakedepends = [
@@ -16,7 +16,7 @@ pkgdesc = "High level interface to seccomp"
 license = "LGPL-2.1-or-later"
 url = "https://github.com/seccomp/libseccomp"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "0889a8da98e37f86019c90789fd4ff7eda6e1ceb9ef07d4c51c67aeb50a77860"
+sha256 = "f9a13e4c633d319a9240189760ca348caa0837c0ebe2a09b17061da8ceaf60f0"
 # prevent a bunch of pain
 exec_wrappers = [("/usr/bin/gsed", "sed")]
 


### PR DESCRIPTION
## Description

- Update the syscall table for Linux v7.1.0-rc4
- GHSA-4q85-33p6-j5g6: Fix incorrect 64-bit comparison merge that can
  weaken libseccomp filters.
- GHSA-46fr-jh49-xvhx: Fix issue where oversized libseccomp filters can
  trigger a double free.
- GHSA-2hqh-5c36-grrm: Fix issue where oversized libseccomp filters can
  trigger a heap corruption.

And other bugfixes.

https://github.com/seccomp/libseccomp/releases/tag/v2.6.1

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
