### PR TITLE
user/hexyl: new package

### DIFF
--- a/user/hexyl/template.py
+++ b/user/hexyl/template.py
@@ -1,0 +1,16 @@
+pkgname = "hexyl"
+pkgver = "0.17.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["rust-std"]
+pkgdesc = "Command-line hex viewer"
+license = "MIT OR Apache-2.0"
+url = "https://github.com/sharkdp/hexyl"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "72fa17397ad187eec6b295d02c7caabbb209a6e0d5706187b8a599bd5df8615e"
+
+
+def post_install(self):
+    self.install_license("LICENSE-MIT")
+    self.install_file("doc/hexyl.1.md", "usr/share/doc/hexyl")


### PR DESCRIPTION
## Description

Hexyl is a command line hex viewer by the same person behind Numbat and similar tools. It passed all packaging tests, and I've had no issues using it, either.

It's helpful for people who frequently debug hex code.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
