### PR TITLE
main/appstream: update to 1.1.5

### DIFF
--- a/main/appstream/template.py
+++ b/main/appstream/template.py
@@ -1,5 +1,5 @@
 pkgname = "appstream"
-pkgver = "1.1.4"
+pkgver = "1.1.5"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -56,7 +56,7 @@ url = "https://www.freedesktop.org/wiki/Distributions/AppStream"
 source = (
     f"https://github.com/ximion/appstream/archive/refs/tags/v{pkgver}.tar.gz"
 )
-sha256 = "0cba35762201ab9e367d5b8da4d0a6c3bd456103ac78b852585995318d6f109a"
+sha256 = "2160a8d9205448214a9e3c9fe3bc205fa630542109c8bf869b26951989b9bb38"
 # gir
 options = ["!cross"]
 


### PR DESCRIPTION
This includes the fix for an accidental ABI break (removing a deprecated function) that breaks the Flatpak backend in Discover.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
