### PR TITLE
main/htop: fix scheduler support

### DIFF
--- a/main/htop/patches/scheduler.patch
+++ b/main/htop/patches/scheduler.patch
@@ -1,0 +1,45 @@
+diff --git a/Scheduling.c b/Scheduling.c
+index 2b4cee87..7594af80 100644
+--- a/Scheduling.c
++++ b/Scheduling.c
+@@ -13,6 +13,8 @@ in the source distribution for its full text.
+ 
+ #include <assert.h>
+ #include <stddef.h>
++#include <sys/syscall.h>
++#include <unistd.h>
+ 
+ #include "FunctionBar.h"
+ #include "ListItem.h"
+@@ -22,6 +24,14 @@ in the source distribution for its full text.
+ #include "XUtils.h"
+ 
+ 
++static int _sched_setscheduler(pid_t pid, int policy, const struct sched_param *param) {
++   return syscall(SYS_sched_setscheduler, pid, policy, param);
++}
++
++static int _sched_getscheduler(pid_t pid) {
++   return syscall(SYS_sched_getscheduler, pid);
++}
++
+ static const SchedulingPolicy policies[] = {
+    [SCHED_OTHER] = { "Other",      SCHED_OTHER, false },
+ #ifdef SCHED_BATCH
+@@ -114,7 +124,7 @@ static bool Scheduling_setPolicy(Process* p, Arg arg) {
+       policy |= SCHED_RESET_ON_FORK;
+    #endif
+ 
+-   int r = sched_setscheduler(Process_getPid(p), policy, &param);
++   int r = _sched_setscheduler(Process_getPid(p), policy, &param);
+ 
+    /* POSIX says on success the previous scheduling policy should be returned,
+     * but Linux always returns 0. */
+@@ -160,6 +170,6 @@ const char* Scheduling_formatPolicy(int policy) {
+  * Gather scheduling policy (thread-specific data)
+  */
+ void Scheduling_readProcessPolicy(Process* proc) {
+-   proc->scheduling_policy = sched_getscheduler(Process_getPid(proc));
++   proc->scheduling_policy = _sched_getscheduler(Process_getPid(proc));
+ }
+ #endif  /* SCHEDULER_SUPPORT */

--- a/main/htop/template.py
+++ b/main/htop/template.py
@@ -1,6 +1,6 @@
 pkgname = "htop"
 pkgver = "3.5.2"
-pkgrel = 0
+pkgrel = 1
 build_style = "gnu_configure"
 configure_args = [
     "--enable-capabilities",


### PR DESCRIPTION
When the scheduler policy column was enabled, it would always show as "N/A", similarly setting a new policy for some process would not work. The reason is that because the sched_getscheduler and sched_setscheduler work on threads on Linux but should work on processes by POSIX, the musl wrappers return ENOSYS instead. Like rtkit, htop actually wants to refer to the threads, so adapt the patch from there and call the syscalls directly.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
