### PR TITLE
user/nushell: update to 0.114.1

### DIFF
--- a/user/nushell/template.py
+++ b/user/nushell/template.py
@@ -1,10 +1,10 @@
 pkgname = "nushell"
-pkgver = "0.112.2"
+pkgver = "0.114.1"
 pkgrel = 0
 build_style = "cargo"
 make_build_args = [
     "--no-default-features",
-    "--features=plugin,trash-support,sqlite,native-tls,network",
+    "--features=plugin,trash-support,lsp,local-socket,system-clipboard,sqlite,native-tls,network",
     "--workspace",
 ]
 make_check_args = [
@@ -26,7 +26,7 @@ pkgdesc = "Shell with a focus on structured data"
 license = "MIT"
 url = "https://www.nushell.sh"
 source = f"https://github.com/nushell/nushell/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "32ebcfe41b6390145e90eb86273e221f22eeacd53ecac5274405f148fb4258c2"
+sha256 = "48ef2fb6bb3ec2b1dcff87a792aeebdfab10b29f3119a62291075b17e4ad25d5"
 _plugins = [
     "polars",
     "formats",


### PR DESCRIPTION
## Description

Nushell has updated a few times.

A couple of things that might be interesting:

~~1. `http-parser` is needed now. I could probably find where it's used if needed.~~ <- **EDIT** don't know how I thought this was the case
1. `nu-plugin` has a hard requirement of the `local-socket` feature, it will not build if it's not enabled.
2. Other features (LSP server, system clipboard) I explicitly listed as features built in this package, more so to make it clear to anyone that might wonder/ask in the future.

For anyone using Nushell, there's some deprecations you should probably be aware of:

https://www.nushell.sh/blog/2026-05-23-nushell_v0_113_0.html#deprecations
https://www.nushell.sh/blog/2026-05-23-nushell_v0_113_0.html#other-changes
https://www.nushell.sh/blog/2026-07-04-nushell_v0_114_0.html#deprecations
https://www.nushell.sh/blog/2026-07-04-nushell_v0_114_0.html#other-changes

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
- [X] I will take responsibility for my template and keep it up to date
