### PR TITLE
user/apparmor: new package

### DIFF
--- a/user/apparmor-extra-profiles
+++ b/user/apparmor-extra-profiles
@@ -1,0 +1,1 @@
+apparmor

--- a/user/apparmor/files/apparmor
+++ b/user/apparmor/files/apparmor
@@ -1,0 +1,5 @@
+type = scripted
+command = /usr/lib/apparmor/apparmor.systemd reload
+stop-command = /usr/lib/apparmor/apparmor.systemd stop
+depends-on: early-fs-local.target
+before: local.target

--- a/user/apparmor/patches/clang.patch
+++ b/user/apparmor/patches/clang.patch
@@ -1,0 +1,26 @@
+diff --git a/common/list_af_names.sh b/common/list_af_names.sh
+index a6f794c..3878346 100755
+--- a/common/list_af_names.sh
++++ b/common/list_af_names.sh
+@@ -11,7 +11,7 @@
+ # rewrite as "AF_".
+ 
+ echo "#include <sys/socket.h>" | \
+-  cpp -dM | \
++  clang-cpp -dM | \
+   LC_ALL=C sed -n \
+     -e '/PF_UNIX/d' \
+     -e 's/PF_LOCAL/PF_UNIX/' \
+diff --git a/common/list_capabilities.sh b/common/list_capabilities.sh
+index 4e37cda..3e7546b 100755
+--- a/common/list_capabilities.sh
++++ b/common/list_capabilities.sh
+@@ -7,7 +7,7 @@
+ # =====================
+ 
+ echo "#include <linux/capability.h>" | \
+-  cpp -dM | \
++  clang-cpp -dM | \
+   LC_ALL=C sed -n \
+     -e '/CAP_EMPTY_SET/d' \
+     -e 's/^\#define[ \t]\+CAP_\([A-Z0-9_]\+\)[ \t]\+\([0-9xa-f]\+\)\(.*\)$/CAP_\1/p' | \

--- a/user/apparmor/patches/ignore-apk-backups.patch
+++ b/user/apparmor/patches/ignore-apk-backups.patch
@@ -1,0 +1,40 @@
+diff --git a/parser/apparmor_parser.pod b/parser/apparmor_parser.pod
+index c786f31..c69f1e0 100644
+--- a/parser/apparmor_parser.pod
++++ b/parser/apparmor_parser.pod
+@@ -47,7 +47,7 @@ name containing a set of profiles. If a directory is specified then the
+ B<apparmor_parser> will try to do a profile load for each file in the
+ directory that is not a dot file, or explicitly black listed (*.dpkg-new,
+ *.dpkg-old, *.dpkg-dist, *.dpkg-bak, *.dpkg-remove, *.pacsave, *.pacnew,
+-*.rpmnew, *.rpmsave, *.orig, *.rej, *~).
++*.rpmnew, *.rpmsave, *.apk-new, *.orig, *.rej, *~).
+ The B<apparmor_parser> will fall back to taking input from standard input if
+ a profile or directory is not supplied.
+ 
+diff --git a/utils/apparmor/common.py b/utils/apparmor/common.py
+index 73d1c6f..5d88252 100644
+--- a/utils/apparmor/common.py
++++ b/utils/apparmor/common.py
+@@ -180,7 +180,7 @@ def is_skippable_file(path):
+ 
+     skippable_suffix = (
+         '.dpkg-new', '.dpkg-old', '.dpkg-dist', '.dpkg-bak', '.dpkg-remove',
+-        '.pacsave', '.pacnew', '.rpmnew', '.rpmsave', '.orig', '.rej', '~')
++        '.pacsave', '.pacnew', '.rpmnew', '.rpmsave', '.apk-new', '.orig', '.rej', '~')
+     if basename.endswith(skippable_suffix):
+         return True
+ 
+diff --git a/utils/test/test-aa.py b/utils/test/test-aa.py
+index c51d186..d9ce9d6 100644
+--- a/utils/test/test-aa.py
++++ b/utils/test/test-aa.py
+@@ -505,6 +505,9 @@ class AaTest_is_skippable_file(AATest):
+     def test_skippable_16(self):
+         self.assertTrue(is_skippable_file('README'))
+ 
++    def test_skippable_17(self):
++        self.assertTrue(is_skippable_file('bin.ping.apk-new'))
++
+ 
+ class AaTest_parse_profile_data(AATest):
+     def test_parse_empty_profile_01(self):

--- a/user/apparmor/patches/syslog-ng.patch
+++ b/user/apparmor/patches/syslog-ng.patch
@@ -1,0 +1,18 @@
+diff --git a/profiles/apparmor.d/sbin.syslog-ng b/profiles/apparmor.d/sbin.syslog-ng
+index 7662038..2dc44a5 100644
+--- a/profiles/apparmor.d/sbin.syslog-ng
++++ b/profiles/apparmor.d/sbin.syslog-ng
+@@ -53,10 +53,10 @@ profile syslog-ng /{usr/,}{bin,sbin}/syslog-ng {
+   /var/lib/syslog-ng/syslog-ng-?????.qf rw,
+   # chrooted applications
+   @{CHROOT_BASE}/var/lib/*/dev/log w,
+-  @{CHROOT_BASE}/var/lib/syslog-ng/syslog-ng.persist* rw,
++  @{CHROOT_BASE}/var/syslog-ng.persist* rw,
+   @{CHROOT_BASE}/var/log/** w,
+-  @{CHROOT_BASE}@{run}/syslog-ng.pid krw,
+-  @{CHROOT_BASE}@{run}/syslog-ng.ctl rw,
++  @{CHROOT_BASE}/var/syslog-ng.pid krw,
++  @{CHROOT_BASE}/var/syslog-ng.ctl rw,
+   /{var,var/run,run}/log/journal/ r,
+   /{var,var/run,run}/log/journal/*/ r,
+   /{var,var/run,run}/log/journal/*/*.journal r,

--- a/user/apparmor/patches/usrmerge.patch
+++ b/user/apparmor/patches/usrmerge.patch
@@ -1,0 +1,35 @@
+diff --git a/init/apparmor.systemd b/init/apparmor.systemd
+index ada6d38..74fea9b 100644
+--- a/init/apparmor.systemd
++++ b/init/apparmor.systemd
+@@ -15,7 +15,7 @@
+ #    along with this program; if not, contact Novell, Inc.
+ # ----------------------------------------------------------------------
+ 
+-APPARMOR_FUNCTIONS=/lib/apparmor/rc.apparmor.functions
++APPARMOR_FUNCTIONS=/usr/lib/apparmor/rc.apparmor.functions
+ 
+ # This function is used in rc.apparmor.functions
+ # shellcheck disable=SC2317,SC2329
+diff --git a/init/rc.apparmor.functions b/init/rc.apparmor.functions
+index 96cb23d..549e1ef 100644
+--- a/init/rc.apparmor.functions
++++ b/init/rc.apparmor.functions
+@@ -31,7 +31,7 @@
+ 
+ # Some nice defines that we use
+ 
+-PARSER=/sbin/apparmor_parser
++PARSER=/usr/bin/apparmor_parser
+ PARSER_OPTS=
+ # Suppress warnings when booting in quiet mode
+ if [ "${QUIET:-no}" = yes ] || [ "${quiet:-n}" = y ]; then
+@@ -50,7 +50,7 @@ ADDITIONAL_PROFILE_DIR=
+ if [ -n "$ADDITIONAL_PROFILE_DIR" ] && [ -d "$ADDITIONAL_PROFILE_DIR" ]; then
+ 	PROFILE_DIRS="$PROFILE_DIRS $ADDITIONAL_PROFILE_DIR"
+ fi
+-AA_STATUS=/usr/sbin/aa-status
++AA_STATUS=/usr/bin/aa-status
+ SECURITYFS=/sys/kernel/security
+ SFS_MOUNTPOINT="${SECURITYFS}/apparmor"
+ 

--- a/user/apparmor/template.py
+++ b/user/apparmor/template.py
@@ -1,0 +1,83 @@
+# match to libapparmor
+pkgname = "apparmor"
+pkgver = "5.0.2"
+pkgrel = 0
+build_style = "makefile"
+make_env = {"USE_SYSTEM": "1"}
+hostmakedepends = [
+    "automake",
+    "bash",
+    "bison",
+    "findutils",
+    "flex",
+    "gettext",
+    "gsed",
+    "libapparmor-devel",
+    "linux-headers",
+    "pkgconf",
+    "python",
+    "python-setuptools",
+]
+makedepends = [
+    "dinit-chimera",
+    "libapparmor-devel",
+    "linux-headers",
+    "linux-pam-devel",
+    "zstd-devel",
+]
+depends = ["python-apparmor"]
+pkgdesc = "Mandatory access control for programs"
+license = "GPL-2.0-or-later"
+url = "https://gitlab.com/apparmor/apparmor"
+source = f"{url}/-/archive/v{pkgver}/apparmor-v{pkgver}.tar.gz"
+sha256 = "bef45f228c0bde2f80d9630084e56bd8020b3fc4dfa7ee48a6aca585bb5ea0ed"
+# cfi breaks apparmor_parser
+hardening = ["vis", "!cfi"]
+# the build system is a mess to untangle
+options = ["!check", "etcfiles"]
+# gsed: used to generate headers
+# gfind: used to install apparmor profiles
+exec_wrappers = [("/usr/bin/gsed", "sed"), ("/usr/bin/gfind", "find")]
+
+
+def build(self):
+    self.make.build(wrksrc="binutils")
+    self.make.build(wrksrc="parser")
+    self.make.build(wrksrc="profiles")
+    self.make.build(wrksrc="utils")
+
+    self.make.build(wrksrc="changehat/pam_apparmor")
+
+
+def install(self):
+    for proj in (
+        "binutils",
+        "parser",
+        "profiles",
+        "utils",
+        "changehat/pam_apparmor",
+    ):
+        self.make.install(
+            args=[
+                f"SBINDIR=/{self.chroot_destdir}/usr/bin",
+                f"USR_SBINDIR=/{self.chroot_destdir}/usr/bin",
+                f"BINDIR=/{self.chroot_destdir}/usr/bin",
+                f"VIM_INSTALL_PATH=/{self.chroot_destdir}/usr/share/vim/vimfiles/syntax",
+                f"SECDIR=/{self.chroot_destdir}/usr/lib/security",
+            ],
+            wrksrc=proj,
+        )
+
+    self.install_service(self.files_path / "apparmor")
+    self.install_file("init/apparmor.systemd", "usr/lib/apparmor", 0o755)
+    self.install_file("init/rc.apparmor.functions", "usr/lib/apparmor", 0o755)
+
+    # requires python tkinter
+    self.uninstall("usr/bin/aa-notify")
+    self.uninstall("etc/apparmor/notify.conf")
+
+
+@subpackage("apparmor-extra-profiles")
+def _(self):
+    self.subdesc = "Extra profiles"
+    return ["usr/share/apparmor/extra-profiles"]

--- a/user/libapparmor-devel
+++ b/user/libapparmor-devel
@@ -1,0 +1,1 @@
+libapparmor

--- a/user/libapparmor/patches/ignore-apk-backups.patch
+++ b/user/libapparmor/patches/ignore-apk-backups.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/libapparmor/src/private.c b/libraries/libapparmor/src/private.c
+index 39b5789..5d56797 100644
+--- a/libraries/libapparmor/src/private.c
++++ b/libraries/libapparmor/src/private.c
+@@ -112,6 +112,8 @@ static struct ignored_suffix_t ignored_suffixes[] = {
+            ignored */
+ 	{ ".rpmnew", 7, 0 },
+ 	{ ".rpmsave", 8, 0 },
++	/* apk-tools packaging files */
++	{ ".apk-new", 8, 0 },
+ 	/* patch file backups/conflicts */
+ 	{ ".orig", 5, 0 },
+ 	{ ".rej", 4, 0 },

--- a/user/libapparmor/patches/musl.patch
+++ b/user/libapparmor/patches/musl.patch
@@ -1,0 +1,13 @@
+diff --git a/libraries/libapparmor/src/Makefile.am b/libraries/libapparmor/src/Makefile.am
+index 47b4979..295c7d0 100644
+--- a/libraries/libapparmor/src/Makefile.am
++++ b/libraries/libapparmor/src/Makefile.am
+@@ -50,7 +50,7 @@ scanner.h: scanner.l
+ scanner.c: scanner.l
+ 
+ af_protos.h:
+-	 echo '#include <netinet/in.h>' | $(CC) $(CPPFLAGS) -E -dD - | LC_ALL=C  sed  -n -e "/IPPROTO_MAX/d"  -e "s/^\#define[ \\t]\\+IPPROTO_\\([A-Z0-9_]\\+\\)\\(.*\\)$$/AA_GEN_PROTO_ENT(\\UIPPROTO_\\1, \"\\L\\1\")/p" > $@
++	 echo '#include <netinet/in.h>' | $(CC) $(CPPFLAGS) -E -dD - | LC_ALL=C  sed  -n -e "/IPPROTO_MAX/d"  -e "s/^\#define[ \\t]\\+IPPROTO_\\([A-Z0-9_]\\+\\)\\(.*\\)$$/AA_GEN_PROTO_ENT(\\IPPROTO_\\1, \"\\L\\1\")/p" > $@
+ 
+ lib_LTLIBRARIES = libapparmor.la
+ noinst_HEADERS = grammar.h parser.h scanner.h af_protos.h private.h PMurHash.h

--- a/user/libapparmor/template.py
+++ b/user/libapparmor/template.py
@@ -1,0 +1,44 @@
+# match to apparmor
+pkgname = "libapparmor"
+pkgver = "5.0.2"
+pkgrel = 0
+build_wrksrc = "libraries/libapparmor"
+build_style = "gnu_configure"
+configure_args = ["--with-python"]
+hostmakedepends = [
+    "autoconf",
+    "autoconf-archive",
+    "automake",
+    "bison",
+    "flex",
+    "gettext",
+    "gsed",
+    "libtool",
+    "pkgconf",
+    "python-devel",
+    "python-setuptools",
+    "swig",
+]
+makedepends = ["python-devel"]
+pkgdesc = "Library for AppArmor"
+license = "GPL-2.0-or-later"
+url = "https://gitlab.com/apparmor/apparmor"
+source = f"{url}/-/archive/v{pkgver}/apparmor-v{pkgver}.tar.gz"
+sha256 = "bef45f228c0bde2f80d9630084e56bd8020b3fc4dfa7ee48a6aca585bb5ea0ed"
+# vis: breaks symbols
+hardening = ["!vis"]
+# dejagnu
+options = ["!check"]
+# gsed: used to generate headers
+exec_wrappers = [("/usr/bin/gsed", "sed")]
+
+
+@subpackage("libapparmor-devel")
+def _(self):
+    return self.default_devel()
+
+
+@subpackage("python-apparmor")
+def _(self):
+    self.subdesc = "Python bindings"
+    return ["usr/lib/python*"]

--- a/user/python-apparmor
+++ b/user/python-apparmor
@@ -1,0 +1,1 @@
+libapparmor


### PR DESCRIPTION
## Description

Adds apparmor and libapparmor. Apparmor and libapparmor are in seperate templates, as i found it to be pretty jank to deal with different build styles in the same template.
There are still some considerations to be made, such as the dinit service, which when restarted, briefly disables all profiles. However, in my testing it works just fine, although this is only on x86_64 as that is the only hardware I have available.

I know reviewer bandwidth is low currently, but I saw no good reason to just sit on this template in private, so I'll just pick this up when there is more review capacity.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
- [x] I will take responsibility for my template and keep it up to date
