### PR TITLE
main/php8.3: update to 8.3.33

### DIFF
--- a/main/php8.3/template.py
+++ b/main/php8.3/template.py
@@ -1,5 +1,5 @@
 pkgname = "php8.3"
-pkgver = "8.3.32"
+pkgver = "8.3.33"
 _majver = pkgver[0 : pkgver.rfind(".")]
 pkgrel = 0
 _apiver = "20230831"
@@ -133,7 +133,7 @@ pkgdesc = "HTML-embedded scripting language"
 license = "PHP-3.01"
 url = "https://www.php.net"
 source = f"{url}/distributions/php-{pkgver}.tar.gz"
-sha256 = "8e1f03eea0b07bc29e1f94d3cfcf0532b0421ec63c1792346b58c3ad8e40fc9b"
+sha256 = "f43566da482abeb1614a512dabeda74967847ce8e176a977390d7a115e7812fd"
 options = ["etcfiles"]
 
 if self.profile().arch in ["loongarch64"]:


### PR DESCRIPTION
## Description

- Date: Fixed leak on double DatePeriod::__construct() call.
- GD: Upgrade libgd. (CVE-2026-9672)
- PGSQL: Fixed [GHSA-7qpv-r5mr-78m4](https://github.com/php/php-src/security/advisories/GHSA-7qpv-r5mr-78m4) (SQL injection via E'...' backslash breakout). (CVE-2026-17543)
- Phar: Fixed [GHSA-vc5h-9ppw-p5f3](https://github.com/php/php-src/security/advisories/GHSA-vc5h-9ppw-p5f3) (Crash via recursive symlinks). (CVE-2026-7260)

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
