### PR TITLE
main/passt: update to 2026_07_28.f8df3f1

### DIFF
--- a/main/passt/patches/include-close_range-shim.patch
+++ b/main/passt/patches/include-close_range-shim.patch
@@ -1,0 +1,12 @@
+diff --git a/isolation.c b/isolation.c
+index 94cbe7f..6446627 100644
+--- a/isolation.c
++++ b/isolation.c
+@@ -93,6 +93,7 @@
+ #include "passt.h"
+ #include "log.h"
+ #include "isolation.h"
++#include "linux_dep.h"
+ #include "conf.h"
+ 
+ #define CAP_VERSION	_LINUX_CAPABILITY_VERSION_3

--- a/main/passt/template.py
+++ b/main/passt/template.py
@@ -1,5 +1,5 @@
 pkgname = "passt"
-_pkgver = "2026_06_11.a9c61ff"
+_pkgver = "2026_07_28.f8df3f1"
 # yeardate only
 pkgver = _pkgver.split(".")[0].replace("_", ".")
 pkgrel = 0
@@ -12,7 +12,7 @@ pkgdesc = "User-mode network translation layer between Layer 2 and 4"
 license = "BSD-3-Clause AND GPL-2.0-or-later"
 url = "https://passt.top/passt/about"
 source = f"https://passt.top/passt/snapshot/passt-{_pkgver}.tar.zst"
-sha256 = "9df3815aaf17c4cbc9862115e8bc15664e2794b54a3a8d584bba6b9021748a02"
+sha256 = "13cd432b1d15fc26d5d7e4a3642d26f1a44943aec72185882de2e9609d46bb4c"
 # tries to pass no-strict-aliasing via __attribute(optimise) for some stuff but that is ignored
 tool_flags = {"CFLAGS": ["-fno-strict-aliasing", "-std=c23"]}
 hardening = ["vis", "cfi"]


### PR DESCRIPTION
## Description

- dropped: /usr/bin/qrap (obsolete)
- upstream forgot to include linux_dep.h in isolation.c? patch it.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
