### PR TITLE
main/talloc: update to 2.5.0

### DIFF
--- a/main/talloc/template.py
+++ b/main/talloc/template.py
@@ -1,5 +1,5 @@
 pkgname = "talloc"
-pkgver = "2.4.4"
+pkgver = "2.5.0"
 pkgrel = 0
 build_style = "waf"
 configure_script = "buildtools/bin/waf"
@@ -24,7 +24,7 @@ pkgdesc = "Hierarchical pool based memory allocator with destructors"
 license = "LGPL-3.0-or-later"
 url = "https://talloc.samba.org"
 source = f"https://download.samba.org/pub/talloc/talloc-{pkgver}.tar.gz"
-sha256 = "55e47994018c13743485544e7206780ffbb3c8495e704a99636503e6e77abf59"
+sha256 = "912afa237510ae542a7733998eb18a12bcda35ab6729c8e2ddb43e8d0ebab007"
 # we don't want their makefile
 env = {"PYTHONHASHSEED": "1", "WAF_MAKE": "1"}
 hardening = ["vis", "!cfi"]


### PR DESCRIPTION
## Description

musl has memset_explicit(). ✅ Only 3 commits 2.4.4 -> 2.5.0:

- d227642a talloc: Add talloc_asprintf_addsep()
- ed2aaa44 lib:talloc:testsuite remove unread global test_abort_stop
- 3e81b73a Replace memset_s() with memset_explicit()

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
