### PR TITLE
main/libsrtp: update to 2.8.0

### DIFF
--- a/main/libsrtp/template.py
+++ b/main/libsrtp/template.py
@@ -1,5 +1,5 @@
 pkgname = "libsrtp"
-pkgver = "2.7.0"
+pkgver = "2.8.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dcrypto-library=openssl"]
@@ -9,7 +9,7 @@ pkgdesc = "Library for Secure Real-Time Transport Protocol"
 license = "BSD-3-Clause"
 url = "https://github.com/cisco/libsrtp"
 source = f"{url}/archive/v{pkgver}.tar.gz"
-sha256 = "54facb1727a557c2a76b91194dcb2d0a453aaf8e2d0cbbf1e3c2848c323e28ad"
+sha256 = "d123dcff5c56d4f1a9006f2b311ea99a85016cbf3bb24b1007885d422237db85"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Fixes AES-192 KDF (#770), proper null-crypto + null-auth support.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
