### PR TITLE
main/python-cairo: update to 1.29.0

### DIFF
--- a/main/python-cairo/template.py
+++ b/main/python-cairo/template.py
@@ -1,6 +1,6 @@
 pkgname = "python-cairo"
-pkgver = "1.28.0"
-pkgrel = 1
+pkgver = "1.29.0"
+pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
     "meson",
@@ -13,7 +13,7 @@ pkgdesc = "Python bindings for the Cairo graphics library"
 license = "LGPL-2.1-or-later OR MPL-1.1"
 url = "https://pycairo.readthedocs.io"
 source = f"https://github.com/pygobject/pycairo/releases/download/v{pkgver}/pycairo-{pkgver}.tar.gz"
-sha256 = "26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc"
+sha256 = "f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142"
 
 
 @subpackage("python-cairo-devel")


### PR DESCRIPTION
## Description

Drops Python 3.9 and PyPy 3.10 (floor is now 3.10+), multi-phase init,
experimental free-threaded Python support, empty-image handling fixes.

Adds --no-x11 build option to disable X11 surface support (not
enabled).

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
