### PR TITLE
main/wf-shell: update to 0.11.0, move gtk4-layer-shell to main, wayfire and wf-config updated to 0.11.0 and temporary patch deployed for wf-shell to compile against clang

### DIFF
--- a/main/gtk4-layer-shell-devel
+++ b/main/gtk4-layer-shell-devel
@@ -1,0 +1,1 @@
+gtk4-layer-shell

--- a/main/gtk4-layer-shell/template.py
+++ b/main/gtk4-layer-shell/template.py
@@ -1,5 +1,5 @@
 pkgname = "gtk4-layer-shell"
-pkgver = "1.2.0"
+pkgver = "1.3.0"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -14,7 +14,7 @@ pkgdesc = "Library to create panels and other desktop components for Wayland"
 license = "MIT"
 url = "https://github.com/wmww/gtk4-layer-shell"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "4e04711fec80afbcd0a1e6e39c07ae263d2c3400181791b7826f3e5317b33567"
+sha256 = "1ebb01ab14e98afd1727f68f64981c37bd23305b1f131f5667c02b94cf593192"
 # vis breaks symbols
 hardening = ["!vis"]
 # a few tests fail

--- a/main/wayfire/template.py
+++ b/main/wayfire/template.py
@@ -1,5 +1,5 @@
 pkgname = "wayfire"
-pkgver = "0.10.0"
+pkgver = "0.11.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -8,6 +8,7 @@ configure_args = [
     "-Dxwayland=enabled",
 ]
 hostmakedepends = [
+    "gettext",
     "meson",
     "pkgconf",
     "wayland-progs",
@@ -23,14 +24,14 @@ makedepends = [
     "udev-devel",
     "wayland-protocols",
     "wf-config-devel",
-    "wlroots0.19-devel",
+    "wlroots0.20-devel",
     "yyjson-devel",
 ]
 pkgdesc = "Modular and extensible wayland compositor"
 license = "MIT"
 url = "https://wayfire.org"
 source = f"https://github.com/WayfireWM/wayfire/releases/download/v{pkgver}/wayfire-{pkgver}.tar.xz"
-sha256 = "83f98d67479f41f3a4dcf30b414495bb8df2353daa7601159f4012a120827a16"
+sha256 = "29dc95468c4f954341c9ecbad889b661eb849bdb96fb47e19c9d6edc8d49640b"
 # vis breaks symbols
 hardening = ["!vis"]
 # FIXME: crashes in signal-provider.hpp::provider_t::emit from libblur

--- a/main/wf-config/template.py
+++ b/main/wf-config/template.py
@@ -1,5 +1,5 @@
 pkgname = "wf-config"
-pkgver = "0.10.0"
+pkgver = "0.11.0"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -16,7 +16,7 @@ pkgdesc = "Library for managing configuration files written for Wayfire"
 license = "MIT"
 url = "https://wayfire.org"
 source = f"https://github.com/WayfireWM/wf-config/releases/download/v{pkgver}/wf-config-{pkgver}.tar.xz"
-sha256 = "9676f08248aaf83b91ecce5c953326c4341084b6efa00d3757a936617a51e487"
+sha256 = "b7721326ade8d42b25ecd2d572e5deb853b1327672608472854c6473bc8d2514"
 # vis breaks syumbols
 hardening = ["!vis"]
 # missing doctest

--- a/main/wf-shell/patches/0001-locker-fix-Clang-build-failure-in-switch-on-WfOption.patch
+++ b/main/wf-shell/patches/0001-locker-fix-Clang-build-failure-in-switch-on-WfOption.patch
@@ -1,0 +1,28 @@
+From 75c034f9bbc035c6b0fb77ee3b653be4370ff33d Mon Sep 17 00:00:00 2001
+From: Gurkul Sahoo <gurkulsahoo47@gmail.com>
+Date: Fri, 7 Aug 2026 18:31:28 +0530
+Subject: [PATCH] locker: fix Clang build failure in switch on WfOption<int>
+
+Clang rejects the implicit decltype(auto) conversion operator from
+base_option_wrapper_t as a valid contextual conversion for switch,
+while GCC accepts it. Use the explicit .value() accessor instead.
+---
+ src/locker/timedrevealer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/locker/timedrevealer.cpp b/src/locker/timedrevealer.cpp
+index dd4f30b..4f4263e 100644
+--- a/src/locker/timedrevealer.cpp
++++ b/src/locker/timedrevealer.cpp
+@@ -18,7 +18,7 @@ WayfireLockerTimedRevealer::WayfireLockerTimedRevealer(std::string always_option
+     auto hide_callback = [this] ()
+     {
+         Gtk::RevealerTransitionType type = Gtk::RevealerTransitionType::NONE;
+-        switch (hide_animation)
++        switch (hide_animation.value())
+         {
+           case 1:
+             type = Gtk::RevealerTransitionType::CROSSFADE;
+-- 
+2.55.0
+

--- a/main/wf-shell/template.py
+++ b/main/wf-shell/template.py
@@ -48,7 +48,6 @@ sha256 = [
     "1999dcab22ccf159b56e670476c0f6eab309ac2f69d16ad3c117824f17201313",
     "0163f8e7250d46a18905b04e966f3a4c849a3afb810ca1e862cb685f8a92bc2e",
 ]
-
 options = ["etcfiles"]
 
 

--- a/main/wf-shell/template.py
+++ b/main/wf-shell/template.py
@@ -27,7 +27,7 @@ makedepends = [
 pkgdesc = "Desktop shell for Wayfire"
 license = "MIT"
 url = "https://wayfire.org"
-_wfjson = "a85b53d8a45565b876465bdf7482776eb01cc54a"
+_wfjson = "70039e13cdeaebd8ec498ed30bf5ab91c2e313ec"
 _wlogout = "1cffc6fd0be5d8127f394b25eb3c82e71fbaabe1"
 _gvc = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6"
 source = [
@@ -44,7 +44,7 @@ source_paths = [
 ]
 sha256 = [
     "328b1a01c5fc63ebc6fa79152bafdcd2e1525c8bb3caf5b49361ff2792dd57f4",
-    "91cec007677cbf83e84aae0abd0cc4436dbef142fd9bede01b6df289b4df3e06",
+    "749d9f649f82570d860c0742c11ff83ff1b108ca7a8ec02c5c3e5f439084fafa",
     "1999dcab22ccf159b56e670476c0f6eab309ac2f69d16ad3c117824f17201313",
     "0163f8e7250d46a18905b04e966f3a4c849a3afb810ca1e862cb685f8a92bc2e",
 ]
@@ -54,8 +54,4 @@ options = ["etcfiles"]
 
 def post_install(self):
     self.install_license("LICENSE")
-    (self.destdir / "usr/lib/pam.d").mkdir(parents=True, exist_ok=True)
-    (self.destdir / "etc/pam.d/wf-locker").rename(
-        self.destdir / "usr/lib/pam.d/wf-locker"
-    )
-    (self.destdir / "etc/pam.d").rmdir()
+    self.rename("etc/pam.d", "usr/lib/pam.d", relative=False)

--- a/main/wf-shell/template.py
+++ b/main/wf-shell/template.py
@@ -1,5 +1,5 @@
 pkgname = "wf-shell"
-pkgver = "0.10.0"
+pkgver = "0.11.0"
 pkgrel = 0
 build_style = "meson"
 hostmakedepends = [
@@ -11,19 +11,51 @@ hostmakedepends = [
 ]
 makedepends = [
     "alsa-lib-devel",
-    "gtk-layer-shell-devel",
-    "gtkmm3.0-devel",
+    "ddcutil-devel",
+    "gtk4-layer-shell-devel",
+    "gtkmm-devel",
     "libdbusmenu-devel",
     "libpulse-devel",
+    "linux-pam-devel",
+    "openssl3-devel",
+    "pipewire-devel",
     "wayfire-devel",
     "wayland-protocols",
+    "wireplumber-devel",
+    "yyjson-devel",
 ]
 pkgdesc = "Desktop shell for Wayfire"
 license = "MIT"
 url = "https://wayfire.org"
-source = f"https://github.com/WayfireWM/wf-shell/releases/download/v{pkgver}/wf-shell-{pkgver}.tar.xz"
-sha256 = "49a7fc861849051a3be5de353e3d7442a37170c990a3ffd8d83b67a369edca93"
+_wfjson = "a85b53d8a45565b876465bdf7482776eb01cc54a"
+_wlogout = "1cffc6fd0be5d8127f394b25eb3c82e71fbaabe1"
+_gvc = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6"
+source = [
+    f"https://github.com/WayfireWM/wf-shell/archive/refs/tags/v{pkgver}.tar.gz",
+    f"https://github.com/WayfireWM/wf-json/archive/{_wfjson}.tar.gz",
+    f"https://github.com/soreau/wayland-logout/archive/{_wlogout}.tar.gz",
+    f"https://github.com/GNOME/libgnome-volume-control/archive/{_gvc}.tar.gz",
+]
+source_paths = [
+    ".",
+    "subprojects/wf-json",
+    "subprojects/wayland-logout",
+    "subprojects/gvc",
+]
+sha256 = [
+    "328b1a01c5fc63ebc6fa79152bafdcd2e1525c8bb3caf5b49361ff2792dd57f4",
+    "91cec007677cbf83e84aae0abd0cc4436dbef142fd9bede01b6df289b4df3e06",
+    "1999dcab22ccf159b56e670476c0f6eab309ac2f69d16ad3c117824f17201313",
+    "0163f8e7250d46a18905b04e966f3a4c849a3afb810ca1e862cb685f8a92bc2e",
+]
+
+options = ["etcfiles"]
 
 
 def post_install(self):
     self.install_license("LICENSE")
+    (self.destdir / "usr/lib/pam.d").mkdir(parents=True, exist_ok=True)
+    (self.destdir / "etc/pam.d/wf-locker").rename(
+        self.destdir / "usr/lib/pam.d/wf-locker"
+    )
+    (self.destdir / "etc/pam.d").rmdir()


### PR DESCRIPTION
## Description

Update wf-shell to 0.11.0.

This required moving gtk4-layer-shell from user to main and
updating it to 1.3.0, to satisfy wf-shell's build dependencies.

I have updated wayfire and wf-config to 0.11.0 also on recommendation of maintainers.

I have deployed a patch for wf-shell as it would not compile against clang.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [ ] I will take responsibility for my template and keep it up to date
