### PR TITLE
user/bluetui: new package

### DIFF
--- a/user/bluetui/template.py
+++ b/user/bluetui/template.py
@@ -1,0 +1,16 @@
+pkgname = "bluetui"
+pkgver = "0.8.1"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = ["cargo-auditable"]
+makedepends = ["rust-std"]
+depends = ["bluez"]
+pkgdesc = "TUI for managing bluetooth devices"
+license = "GPL-3.0-only"
+url = "https://github.com/pythops/bluetui"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "9b82b3c268a20bf04e55095cacc3341d46013ccfa7d268c4f225d4a88f9c7138"
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This PR packages [bluetui](https://github.com/pythops/bluetui/). It's a handy TUI for managing bluetooth devices. Because it's from the same author of [user/impala](https://github.com/pythops/impala), it shares similar default keybindings and UI. So I believe it's good alternatives comparing to existing bluetooth TUI like [user/bluetuith](https://github.com/bluetuith-org/bluetuith). 

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

> Acknowledged. I would like to add that because it's from the same author of [user/impala](https://github.com/chimera-linux/cports/blob/master/user/impala/template.py) and share basically the same building procedure, I reused most parts of impala's template.py (except for `depends`, which this package depends on `bluez` instead of `iwd`). So I feel this template could be classified as easy to review and meet basic quality requirements. That being said, feel free to close this PR or just leave this package until it's ready to be reviewed at a later point, if you think otherwise.

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
