### PR TITLE
user/framework-system: ignore stray non-version tags

### DIFF
--- a/user/framework-system/update.py
+++ b/user/framework-system/update.py
@@ -1,0 +1,1 @@
+pattern = r"refs/tags/v([0-9.]+)"


### PR DESCRIPTION
new github update-check is matching some stuff wrong; in this case `refs/tags/41f3c37` is taken as “version 41”