### PR TITLE
user/libratbag: only restart on failure

### DIFF
--- a/user/libratbag/files/ratbagd
+++ b/user/libratbag/files/ratbagd
@@ -1,4 +1,5 @@
 type = process
 command = /usr/bin/ratbagd
+restart = on-failure
 depends-on: dbus
 depends-on: local.target

--- a/user/libratbag/template.py
+++ b/user/libratbag/template.py
@@ -1,6 +1,6 @@
 pkgname = "libratbag"
 pkgver = "0.18"
-pkgrel = 0
+pkgrel = 1
 build_style = "meson"
 configure_args = [
     "-Dsystemd=false",


### PR DESCRIPTION
this matches the behavior or the upstream systemd unit (`Restart=on-abort`). otherwise it keeps pointlessly restarting when it exits on idle

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
