### PR TITLE
add noctalia and sdbus-cpp

### DIFF
--- a/user/noctalia/patches/fix-ambiguous-cast.patch
+++ b/user/noctalia/patches/fix-ambiguous-cast.patch
@@ -1,0 +1,13 @@
+diff --git a/src/system/icon_resolver.cpp b/src/system/icon_resolver.cpp
+index 035d9af..5e7c7e0 100644
+--- a/src/system/icon_resolver.cpp
++++ b/src/system/icon_resolver.cpp
+@@ -148,7 +148,7 @@ namespace {
+       signature += ':';
+       std::error_code ec;
+       const auto modified = fs::last_write_time(path, ec);
+-      signature += ec ? "missing" : std::to_string(modified.time_since_epoch().count());
++      signature += ec ? "missing" : std::to_string(static_cast<long long>(modified.time_since_epoch().count()));
+       signature += '\n';
+     };
+     for (const auto& root : plan.baseDirs) {

--- a/user/noctalia/patches/fix-stb-includes.patch
+++ b/user/noctalia/patches/fix-stb-includes.patch
@@ -1,0 +1,106 @@
+diff --git a/PACKAGING.md b/PACKAGING.md
+index 511e1d3..c8a1d81 100644
+--- a/PACKAGING.md
++++ b/PACKAGING.md
+@@ -130,7 +130,7 @@ has copy-paste install lines for common distros.
+ 
+ Notes packagers hit often:
+ 
+-- **stb** must provide `stb/stb_image_resize2.h` (and `stb/stb_image_write.h`).
++- **stb** must provide `stb_image_resize2.h` (and `stb_image_write.h`).
+   Older packages that only ship `stb_image_resize` are not enough. Meson fails
+   the configure check if `stb_image_resize2` is missing.
+ - Meson requires **WirePlumber 0.5** (`wireplumber-0.5` pkg-config). 0.4 is not
+diff --git a/meson.build b/meson.build
+index 2f1b241..21939b5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -188,11 +188,11 @@ mcu_dep = declare_dependency(
+ )
+ 
+ # ── System: stb_image_resize2 and stb_image_write (header-only) ─────────────────────────────────
+-if not cc.has_header('stb/stb_image_resize2.h')
+-  error('stb/stb_image_resize2.h not found')
++if not cc.has_header('stb_image_resize2.h')
++  error('stb_image_resize2.h not found')
+ endif
+-if not cc.has_header('stb/stb_image_write.h')
+-  error('stb/stb_image_write.h not found')
++if not cc.has_header('stb_image_write.h')
++  error('stb_image_write.h not found')
+ endif
+ 
+ # ── System: libwebp (WebP decode and thumbnail encode) ───────────────────────
+diff --git a/noctalia.scm b/noctalia.scm
+index fb46afd..714b8e0 100644
+--- a/noctalia.scm
++++ b/noctalia.scm
+@@ -88,7 +88,7 @@
+                       (which cmd)))
+                    ;; Adjust import paths for STB headers packaged in Guix.
+                    (substitute* (find-files "." "\\.cpp$|^meson\\.build$")
+-                     (("\\bstb/stb_") "stb_")))))))
++                     (("\\bstb_") "stb_")))))))
+     (native-inputs
+      (list pkg-config))
+     (inputs
+diff --git a/src/capture/screenshot_service.cpp b/src/capture/screenshot_service.cpp
+index f7559bb..e446aba 100644
+--- a/src/capture/screenshot_service.cpp
++++ b/src/capture/screenshot_service.cpp
+@@ -34,7 +34,7 @@
+ #include <filesystem>
+ #include <format>
+ #include <fstream>
+-#include <stb/stb_image_resize2.h>
++#include <stb_image_resize2.h>
+ #include <sys/wait.h>
+ #include <thread>
+ #include <unistd.h>
+diff --git a/src/render/core/image_encoder.cpp b/src/render/core/image_encoder.cpp
+index d7b61ae..bdce31a 100644
+--- a/src/render/core/image_encoder.cpp
++++ b/src/render/core/image_encoder.cpp
+@@ -1,7 +1,7 @@
+ #include "render/core/image_encoder.h"
+ 
+ #define STB_IMAGE_WRITE_IMPLEMENTATION
+-#include "stb/stb_image_write.h"
++#include "stb_image_write.h"
+ 
+ #include <cstring>
+ 
+diff --git a/src/render/core/image_file_loader.cpp b/src/render/core/image_file_loader.cpp
+index d5764ba..01ef252 100644
+--- a/src/render/core/image_file_loader.cpp
++++ b/src/render/core/image_file_loader.cpp
+@@ -10,7 +10,7 @@
+ #include <cstdint>
+ #include <cstring>
+ #include <expected>
+-#include <stb/stb_image_resize2.h>
++#include <stb_image_resize2.h>
+ #include <string_view>
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+diff --git a/src/render/core/stb_image_resize_impl.cpp b/src/render/core/stb_image_resize_impl.cpp
+index 20dc1b3..2ba1cce 100644
+--- a/src/render/core/stb_image_resize_impl.cpp
++++ b/src/render/core/stb_image_resize_impl.cpp
+@@ -1,2 +1,2 @@
+ #define STB_IMAGE_RESIZE_IMPLEMENTATION
+-#include <stb/stb_image_resize2.h>
++#include <stb_image_resize2.h>
+diff --git a/src/render/core/thumbnail_service.cpp b/src/render/core/thumbnail_service.cpp
+index 3debb10..9b9f8bb 100644
+--- a/src/render/core/thumbnail_service.cpp
++++ b/src/render/core/thumbnail_service.cpp
+@@ -13,7 +13,7 @@
+ #include <filesystem>
+ #include <fstream>
+ #include <optional>
+-#include <stb/stb_image_resize2.h>
++#include <stb_image_resize2.h>
+ #include <sys/eventfd.h>
+ #include <system_error>
+ #include <unistd.h>

--- a/user/noctalia/patches/make-sed-portable.patch
+++ b/user/noctalia/patches/make-sed-portable.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 21939b5..8b2415e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -397,7 +397,7 @@ _wlr_ls_h = custom_target('wlr-layer-shell-unstable-v1-client-header',
+   output:  'wlr-layer-shell-unstable-v1-client-protocol.h',
+   command: [
+     'sh', '-c',
+-    '"$1" client-header "$2" "$3" && sed -i s/namespace/name_space/g "$3"',
++    '"$1" client-header "$2" "$3" && sed s/namespace/name_space/g "$3" > "$3.tmp" && mv "$3.tmp" "$3"',
+     '_', wayland_scanner.full_path(), '@INPUT@', '@OUTPUT@',
+   ],
+ )

--- a/user/noctalia/template.py
+++ b/user/noctalia/template.py
@@ -1,0 +1,48 @@
+pkgname = "noctalia"
+pkgver = "5.0.0_beta8"
+pkgrel = 0
+build_style = "meson"
+hostmakedepends = ["meson", "pkgconf"]
+makedepends = [
+    "cairo-devel",
+    "curl-devel",
+    "elogind-devel",
+    "fontconfig-devel",
+    "freetype-devel",
+    "harfbuzz-devel",
+    "jemalloc-devel",
+    "libepoxy-devel",
+    "libical-devel",
+    "libjxl-devel",
+    "libqalculate-devel",
+    "librsvg-devel",
+    "libsecret-devel",
+    "libsndfile-devel",
+    "libsodium-devel",
+    "libwebp-devel",
+    "libxkbcommon-devel",
+    "libxml2-devel",
+    "linux-pam-devel",
+    "md4c-devel",
+    "mesa-devel",
+    "nlohmann-json",
+    "pango-devel",
+    "pipewire-devel",
+    "polkit-devel",
+    "sdbus-cpp-devel",
+    "stb",
+    "tomlplusplus-devel",
+    "wayland-devel",
+    "wayland-protocols",
+    "wireplumber-devel",
+]
+pkgdesc = "Desktop shell for Wayland"
+license = "MIT"
+url = "https://noctalia.dev"
+_upver = pkgver.replace("_beta", "-beta.")
+source = f"https://github.com/noctalia-dev/noctalia/archive/v{_upver}.tar.gz"
+sha256 = "a60e4ab8723f428e11b9a2bac97811aaa6a494648730abc61025c35cb728539e"
+
+
+def post_install(self):
+    self.install_license("LICENSE")

--- a/user/sdbus-cpp-devel
+++ b/user/sdbus-cpp-devel
@@ -1,0 +1,1 @@
+sdbus-cpp

--- a/user/sdbus-cpp/template.py
+++ b/user/sdbus-cpp/template.py
@@ -1,0 +1,17 @@
+pkgname = "sdbus-cpp"
+pkgver = "2.3.1"
+pkgrel = 0
+build_style = "cmake"
+configure_args = ["-DSDBUSCPP_BUILD_CODEGEN=ON"]
+hostmakedepends = ["cmake", "ninja", "pkgconf"]
+makedepends = ["elogind-devel", "libexpat-devel"]
+pkgdesc = "High-level C++ D-Bus library"
+license = "LGPL-2.1-or-later"
+url = "https://github.com/Kistler-Group/sdbus-cpp"
+source = f"{url}/archive/v{pkgver}.tar.gz"
+sha256 = "3a289eded586c26d06c1387de72c7bf7c809527a70d51ba6401fe61059b19626"
+
+
+@subpackage("sdbus-cpp-devel")
+def _(self):
+    return self.default_devel()


### PR DESCRIPTION
## Description

`user/noctalia`: Noctalia desktop shell. Its purpose is to provide a easily configurable, unified Linux desktop experience without using separate bars, notification centers, settings menu, etc. Required 3 simple patches to remove GNU/libstdc++-isms and be more portable.
`user/sdbus-cpp`: Dependency for Noctalia. It is a modern dbus library which is also being used by other wayland desktop components.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
