### PR TITLE
main/easyeffects: update 8.2.8, add missing dependency

### DIFF
--- a/main/easyeffects/template.py
+++ b/main/easyeffects/template.py
@@ -1,5 +1,5 @@
 pkgname = "easyeffects"
-pkgver = "8.2.7"
+pkgver = "8.2.8"
 pkgrel = 0
 build_style = "cmake"
 hostmakedepends = [
@@ -44,6 +44,7 @@ makedepends = [
     "zita-convolver-devel",
 ]
 depends = [
+    "kirigami-addons",
     # most plugins are from here and it can crash without them (and at least prints
     # 9 million warnings), so just always pull it
     "lsp-plugins-lv2",
@@ -53,7 +54,7 @@ pkgdesc = "PipeWire audio plugins"
 license = "GPL-3.0-or-later"
 url = "https://github.com/wwmm/easyeffects"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "b6374830282c34b90ace1a2c684d3675e5e00f8f73dffc4778105232f5482e13"
+sha256 = "0e241ad32a0147d180f9dd35181c8eea11e7d32309dda9b4b70b6b472189e45e"
 tool_flags = {"CXXFLAGS": ["-fexperimental-library"]}
 
 


### PR DESCRIPTION
## Description

Updates easyeffects to 8.2.8 and adds missing kirigami-addons dependency

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
