### PR TITLE
main/thermald: update to 2.5.12

### DIFF
--- a/main/thermald/files/sysusers.conf
+++ b/main/thermald/files/sysusers.conf
@@ -1,3 +1,0 @@
-# Create thermald group
-
-g _thermald -

--- a/main/thermald/files/thermald
+++ b/main/thermald/files/thermald
@@ -1,3 +1,4 @@
 type = process
 command = /usr/bin/thermald --adaptive --dbus-enable --no-daemon
-depends-on = dbus
+depends-on: dbus
+depends-on: local.target

--- a/main/thermald/template.py
+++ b/main/thermald/template.py
@@ -1,10 +1,9 @@
 pkgname = "thermald"
-pkgver = "2.5.11"
+pkgver = "2.5.12"
 pkgrel = 0
 archs = ["x86_64"]
 # don't use autogen.sh, it generates files that force reconf in build phase
 build_style = "gnu_configure"
-configure_args = ["--with-dbus-power-group=_thermald"]
 make_dir = "."
 hostmakedepends = [
     "autoconf-archive",
@@ -27,7 +26,7 @@ pkgdesc = "Thermal daemon for x86_64-based Intel CPUs"
 license = "GPL-2.0-or-later"
 url = "https://github.com/intel/thermal_daemon"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "0f4d7371d2cadf12f868e4b56d0e70af07a1c3b7d883dbe541a3707e449ea1ad"
+sha256 = "f0698f8295b1c4f57673462e7c3a970d0fc328d56d80c0b9ab35644f5dbb72a9"
 hardening = ["vis", "!cfi"]
 options = ["etcfiles"]
 
@@ -46,4 +45,3 @@ def post_install(self):
     )
     self.install_license("COPYING")
     self.install_service(self.files_path / "thermald")
-    self.install_sysusers(self.files_path / "sysusers.conf")


### PR DESCRIPTION
the power group feature was removed in https://github.com/intel/thermal_daemon/commit/6c8126f2d5aae8aedf6a3c33b7f92923fbe6bacc

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
