### PR TITLE
main/sdl3: update to 3.4.14

### DIFF
--- a/main/sdl3/template.py
+++ b/main/sdl3/template.py
@@ -1,5 +1,5 @@
 pkgname = "sdl3"
-pkgver = "3.4.12"
+pkgver = "3.4.14"
 pkgrel = 0
 build_style = "cmake"
 configure_args = [
@@ -50,7 +50,7 @@ pkgdesc = "Simple DirectMedia Layer version 3"
 license = "Zlib"
 url = "https://libsdl.org"
 source = f"https://github.com/libsdl-org/SDL/releases/download/release-{pkgver}/SDL3-{pkgver}.zip"
-sha256 = "3d4de8967a49c0451e775a0c1e9022092c19fdef41ba38a83fcf031c5a6496e2"
+sha256 = "b07ef7b5431cea0cb2ea9613e2d8410f9ef37f5627f82f1733086cb00aa2b4b4"
 
 
 def post_install(self):


### PR DESCRIPTION
## Description

Minor update to SDL3:

https://github.com/libsdl-org/SDL/releases/tag/release-3.4.14

> - GPU buffers and textures can have multiple read usages
> - Fixed X11 crash if the IME service was shutdown in the background
> - Fixed hang when hiding an X11 window on some window managers
> - Fixed being unable to get clipboard text on older versions of macOS
> - Fixed the 8BitDo Pro 3 controller showing up twice on macOS
> - Fixed Xbox controllers not being detected if SDL is built with GameInput support
> - Fixed pen creating phantom mouse events in relative mode on Android

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)
- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine
