### PR TITLE
user/wlr-which-key: new package

### DIFF
--- a/user/wlr-which-key/template.py
+++ b/user/wlr-which-key/template.py
@@ -1,0 +1,19 @@
+pkgname = "wlr-which-key"
+pkgver = "1.3.0"
+pkgrel = 0
+build_style = "cargo"
+hostmakedepends = [
+    "cargo-auditable",
+    "pkgconf",
+]
+makedepends = [
+    "glib-devel",
+    "libxkbcommon-devel",
+    "pango-devel",
+    "rust-std",
+]
+pkgdesc = "Keymap manager for wlroots-based compositors"
+license = "GPL-3.0-or-later"
+url = "https://github.com/MaxVerevkin/wlr-which-key"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "50fc06f60e67dc678ffe7bb167d662910d98085e185d2030c09ebd5793bf2794"


### PR DESCRIPTION
## Description

`wlr-which-key` is a configurable tool to show keymaps onto the screen for wlroots-based compositors. It is very fast and minimal.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
