### PR TITLE
main/flatpak: update to 1.18.1

### DIFF
--- a/main/flatpak/template.py
+++ b/main/flatpak/template.py
@@ -1,12 +1,11 @@
 pkgname = "flatpak"
-pkgver = "1.16.6"
-pkgrel = 1
+pkgver = "1.18.1"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Ddconf=enabled",
     "-Ddbus_config_dir=/usr/share/dbus-1/system.d",
     "-Dgdm_env_file=true",
-    "-Dhttp_backend=curl",
     "-Dlibzstd=enabled",
     "-Dselinux_module=disabled",
     "-Dsystem_bubblewrap=/usr/bin/bwrap",
@@ -67,7 +66,7 @@ pkgdesc = "Linux application sandboxing and distribution framework"
 license = "LGPL-2.1-or-later"
 url = "https://flatpak.org"
 source = f"https://github.com/flatpak/flatpak/releases/download/{pkgver}/flatpak-{pkgver}.tar.xz"
-sha256 = "1e63e7f3fe44b602f34d92a6fe46fd8a3bc6be9460c03c2681e57976c658eec3"
+sha256 = "bc683fc916ed21c0524bb064f358c2ac18586b8ec88c76f2f7f289877521631c"
 # test runner expects a different env (possible FIXME?)
 options = ["etcfiles", "!check", "!cross"]
 


### PR DESCRIPTION
## Description

0.16.x is now retired. Lots of big security fixes. curl is now
the only HTTP backend, so drop the flag.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
