### PR TITLE
user/gitoxide: update to 0.58.0

### DIFF
--- a/user/gitoxide/template.py
+++ b/user/gitoxide/template.py
@@ -1,10 +1,10 @@
 pkgname = "gitoxide"
-pkgver = "0.51.0"
+pkgver = "0.58.0"
 pkgrel = 0
 build_style = "cargo"
 make_build_args = [
     "--no-default-features",
-    "--features=max-control,gitoxide-core-blocking-client,http-client-curl",
+    "--features=max-control,gitoxide-core-blocking-client,http-client-curl,sha1",
 ]
 make_install_args = [*make_build_args]
 make_check_args = [*make_install_args]
@@ -18,7 +18,7 @@ pkgdesc = "Rust implementation of Git"
 license = "Apache-2.0 OR MIT"
 url = "https://github.com/Byron/gitoxide"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "22da356497d22eabb598233cfba61db3674e234792df1def55212ea7d2793e5d"
+sha256 = "af8210e01903e0995aa5899d8c8cd3f4f2b115ec38a924fa7bf3c7d8ba949077"
 
 
 def post_install(self):


### PR DESCRIPTION
"sha1" feature added to `make_build_args` as required by https://github.com/GitoxideLabs/gitoxide/blob/v0.58.0/gix-hash/src/lib.rs#L32

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine