### PR TITLE
main/*: remove redundant sysusers.conf files

### DIFF
--- a/main/dbus/sysusers.conf
+++ b/main/dbus/sysusers.conf
@@ -1,1 +1,0 @@
-u dbus - "dbus user" /tmp /usr/bin/nologin

--- a/main/qemu/sysusers.conf
+++ b/main/qemu/sysusers.conf
@@ -1,1 +1,0 @@
-u _qemu - "qemu user" /tmp /usr/bin/nologin

--- a/main/wireshark/sysusers.conf
+++ b/main/wireshark/sysusers.conf
@@ -1,1 +1,0 @@
-g _wireshark -


### PR DESCRIPTION
## Description

With these commits I believe the need for build-time user/group creation was removed for the respective packages:

- dbus: dc42f96722ec784ee1dd9185152d91b45b2f9218
- qemu: bf4b80acdf0d5c8175fef2846a76c232d3b71852
- wireshark: 58f6b8ebd723d20b91a5e7e073adb796b45789c2

Incidentally, I'm not sure assigning non-root users and groups in `file_modes` works any more. `make` is invoked via [chroot.enter with fakeroot=True](https://github.com/chimera-linux/cports/blob/c104aea3013e4a902db303f5ff9d7dec390c6f07/src/cbuild/core/build.py#L866) and that in turn sets [`FAKEROOTDONTTRYCHOWN=1`](https://github.com/chimera-linux/cports/blob/c104aea3013e4a902db303f5ff9d7dec390c6f07/src/cbuild/core/chroot.py#L852). So, from what I can tell [the `chown` lines put into the Makefile](https://github.com/chimera-linux/cports/blob/c104aea3013e4a902db303f5ff9d7dec390c6f07/src/cbuild/apk/generate.py#L362-L366) do nothing.

This isn't an issue in practice since there are no cases left where the user and group is non-`root`. However, the docs do still mention the functionality.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
