### PR TITLE
main/fwupd: update to 2.1.7 (& minor deps)

### DIFF
--- a/main/fwupd/template.py
+++ b/main/fwupd/template.py
@@ -1,5 +1,5 @@
 pkgname = "fwupd"
-pkgver = "2.1.6"
+pkgver = "2.1.7"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -49,7 +49,7 @@ pkgdesc = "Firmware updater"
 license = "LGPL-2.1-or-later"
 url = "https://github.com/fwupd/fwupd"
 source = f"{url}/archive/{pkgver}.tar.gz"
-sha256 = "03f45f637a7178839f9f4894f86f4cb0ff4e2fc8d04a9a4da5af3157404ac369"
+sha256 = "338ea5b139f9a37447ff2215d0a8d2cf23851fb5a39fba7b1b0ded52a40240cc"
 options = ["etcfiles", "!cross"]
 
 if self.profile().arch == "x86_64":

--- a/main/libmbim/template.py
+++ b/main/libmbim/template.py
@@ -1,6 +1,6 @@
 pkgname = "libmbim"
-pkgver = "1.32.0"
-pkgrel = 1
+pkgver = "1.34.0"
+pkgrel = 0
 build_style = "meson"
 configure_args = [
     "-Dintrospection=true",
@@ -19,7 +19,7 @@ pkgdesc = "MBIM modem protocol helper library"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://www.freedesktop.org/wiki/Software/libmbim"
 source = f"https://gitlab.freedesktop.org/mobile-broadband/libmbim/-/archive/{pkgver}/libmbim-{pkgver}.tar.gz"
-sha256 = "7eca9f5af2eecfdb5e3a2a865a7f29d0ac9532ab187a9c6adce4d85f897eb385"
+sha256 = "55bb88df358f8a36b6e01e63877500d7c6420f5907d2d3101812b4912eabe08f"
 
 
 @subpackage("libmbim-devel")

--- a/main/libqmi/template.py
+++ b/main/libqmi/template.py
@@ -1,5 +1,5 @@
 pkgname = "libqmi"
-pkgver = "1.36.0"
+pkgver = "1.38.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = [
@@ -22,7 +22,7 @@ pkgdesc = "QMI modem protocol helper library"
 license = "GPL-2.0-or-later AND LGPL-2.1-or-later"
 url = "https://www.freedesktop.org/wiki/Software/libqmi"
 source = f"https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/archive/{pkgver}/libqmi-{pkgver}.tar.gz"
-sha256 = "e254fafdd916a78a27126e6d72ae436662487f59c7de84d4d40286059af89093"
+sha256 = "8ee3b3a9002f2b45c825deade85710db006e01674f5f9359d351c192cc926015"
 
 
 @subpackage("libqmi-devel")

--- a/main/libqrtr-glib/template.py
+++ b/main/libqrtr-glib/template.py
@@ -1,5 +1,5 @@
 pkgname = "libqrtr-glib"
-pkgver = "1.2.2"
+pkgver = "1.4.0"
 pkgrel = 0
 build_style = "meson"
 configure_args = ["-Dgtk_doc=false"]
@@ -9,7 +9,7 @@ pkgdesc = "Qualcomm IPC Router protocol helper library"
 license = "LGPL-2.1-or-later"
 url = "https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib"
 source = f"{url}/-/archive/{pkgver}/libqrtr-glib-{pkgver}.tar.gz"
-sha256 = "c5cdf5ea91cbd2cf2758b2896064c7b1dfe7156063267df905f957ac69b6b763"
+sha256 = "9e5f988c6005af347f6d0ac95c872e473c9c10c3ec3714ee0b73d896db7d5766"
 
 
 @subpackage("libqrtr-glib-devel")


### PR DESCRIPTION
## Description

- **main/libmbim: update to 1.34.0**
- **main/libqrtr-glib: update to 1.4.0**
- **main/libqmi: update to 1.38.0**
- **main/fwupd: update to 2.1.7**

libqmi & libmbim bring -D*_groupname=` build options to lock down their
/dev nodes to certain group names. No other distro seems to do this
however, and we're not currently doing it, so leave as-is.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
