### PR TITLE
user/ocaml: update to 5.5.0

### DIFF
--- a/user/ocaml/template.py
+++ b/user/ocaml/template.py
@@ -1,5 +1,5 @@
 pkgname = "ocaml"
-pkgver = "5.4.0"
+pkgver = "5.5.0"
 pkgrel = 0
 archs = ["aarch64", "ppc64", "ppc64le", "x86_64"]
 build_style = "gnu_configure"
@@ -12,8 +12,8 @@ depends = [self.with_pkgver("ocaml-runtime"), *makedepends]
 pkgdesc = "Implementation of the OCaml language"
 license = "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 url = "https://ocaml.org"
-source = f"https://github.com/ocaml/ocaml/archive/refs/tags/{pkgver}.tar.gz"
-sha256 = "4ab55ac30d247e20f35df20a9f7596e5eb5f92fbbd0f8e3e54838bbc3edf931e"
+source = f"https://caml.inria.fr/pub/distrib/ocaml-5.5/ocaml-{pkgver}.tar.xz"
+sha256 = "fcc6ae665d1ec51d52510eaac7834a86a9806bf5a258bb7cca78733fccf015ba"
 tools = {"ASPP": "cc -c", "AS": "cc -c"}
 hardening = ["!int"]
 # may be disabled

--- a/user/ocaml/update.py
+++ b/user/ocaml/update.py
@@ -1,0 +1,1 @@
+pattern = r"ocaml-([\d.]+)\.tar"


### PR DESCRIPTION
## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

## Additional notes

- Updated 'source' to the developer's URL, as the GitHub release tarballs no longer contain `manual/` or `testsuite/tests/` and would raise this error:
```
0:02:51.948 => ocaml-5.5.0-r0: running check...
make -C testsuite all
make[1]: Entering directory '/builddir/ocaml-5.5.0/testsuite'
There are no tests in the tests directory!
This happens when the sources of OCaml are extracted from a tarball
generated by git-archive (which includes those generated by GitHub)
Note that the release tarballs published at https://caml.inria.fr/pub/distrib/ include all the manual and testsuite sources
The required files are in commit f5238509da6029a44ba0eb648f5dff7d9c89f519, for example:
  git clone https://github.com/ocaml/ocaml --revision f5238509da6029a44ba0eb648f5dff7d9c89f519 --depth 1 git-sources
  mv git-sources/tests .
make[2]: *** [Makefile:345: tests] Error 1
make[1]: *** [Makefile:165: all] Error 2
make[1]: Leaving directory '/builddir/ocaml-5.5.0/testsuite'
make: *** [Makefile:952: tests] Error 2
0:02:52.009 => A failure has occurred!
```