### PR TITLE
main/libgcrypt: update to 1.12.3

### DIFF
--- a/main/libgcrypt/patches/regen.patch
+++ b/main/libgcrypt/patches/regen.patch
@@ -1,6 +1,7 @@
---- a/autogen.sh
-+++ b/autogen.sh
-@@ -265,8 +265,8 @@
+diff -urN a/autogen.sh b/autogen.sh
+--- a/autogen.sh	2025-09-24 08:28:47.000000000 +0100
++++ b/autogen.sh	2026-08-26 16:54:36.135911910 +0100
+@@ -285,8 +285,8 @@
        rvd=$((0x$(echo ${rev} | dd bs=1 count=4 2>/dev/null)))
      else
        ingit=no
@@ -8,6 +9,6 @@
 -      tmp="-unknown"
 +      beta=no
 +      tmp=""
+       cid="0000000"
        rev="0000000"
        rvd="0"
-     fi

--- a/main/libgcrypt/template.py
+++ b/main/libgcrypt/template.py
@@ -1,5 +1,5 @@
 pkgname = "libgcrypt"
-pkgver = "1.11.2"
+pkgver = "1.12.3"
 pkgrel = 0
 build_style = "gnu_configure"
 configure_args = [
@@ -18,7 +18,7 @@ pkgdesc = "GNU cryptographic library"
 license = "LGPL-2.1-or-later"
 url = "https://www.gnupg.org"
 source = f"{url}/ftp/gcrypt/libgcrypt/libgcrypt-{pkgver}.tar.bz2"
-sha256 = "6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac"
+sha256 = "98d1b0b3202d2b03fa754a35aa3cbbfcf526a3260d8d2ee213748001b1043006"
 options = ["linkundefver"]
 
 


### PR DESCRIPTION
## Description

- Brings Dilithium (ML-DSA) support
- VAES/AVX512 AES, Intel SM3/SM4/SHA512 extensions, RISC-V vector
  crypto, Camellia/Argon2/sntrup761 speedups.

Lots of security fixes.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
