### PR TITLE
main/libjpeg-turbo: update to 3.2.0

### DIFF
--- a/main/libjpeg-turbo/patches/CVE-2026-75466.patch
+++ b/main/libjpeg-turbo/patches/CVE-2026-75466.patch
@@ -1,0 +1,75 @@
+From c33ab9bf82482d643b4a19af5a8dcdc63b2719cb Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Sat, 15 Aug 2026 13:49:19 -0400
+Subject: [PATCH] Fix FPE w/tj3LoadImage*/index clr PNG/TJPF_UNKNOWN
+
+Due to an oversight in 285744829a1ed5b12dfff61a6a39da0eea0b8405, the PNG
+reader did not handle cinfo->in_color_space == JCS_UNKNOWN (which only
+occurs if *pixelFormat = TJPF_UNKNOWN is passed to tj3LoadImage*()) for
+non-grayscale indexed-color PNG images.  If the image's palette
+contained non-grayscale colors, then cinfo->in_color_space remained
+JCS_UNKNOWN, which caused cinfo->input_components to be 0, which caused
+samplesperrow = 0 to be passed to the memory manager's alloc_sarray
+method when attempting to allocate the intermediate buffer for pixel
+format translation.  In the alloc_sarray() method, an integer
+division-by-zero error occurred when computing ltemp.  On x86 platforms,
+this caused SIGFPE to be thrown.  On AArch64 platforms, ltemp was
+computed to be 0, which caused rowsperchunk to be 0, which caused an
+infinite loop because currow was never incremented.
+
+This commit modifies the PNG reader accordingly and also hardens the
+memory manager against such erroneous arguments.
+
+Fixes #911
+---
+ src/jmemmgr.c | 6 +++---
+ src/rdpng.c   | 2 ++
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/jmemmgr.c b/src/jmemmgr.c
+index 494d04a1..97552edc 100644
+--- a/src/jmemmgr.c
++++ b/src/jmemmgr.c
+@@ -4,7 +4,7 @@
+  * This file was part of the Independent JPEG Group's software:
+  * Copyright (C) 1991-1997, Thomas G. Lane.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2016, 2021-2022, 2024, D. R. Commander.
++ * Copyright (C) 2016, 2021-2022, 2024, 2026, D. R. Commander.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+  *
+@@ -459,7 +459,7 @@ alloc_sarray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
+   if ((ALIGN_SIZE % sample_size) != 0)
+     out_of_memory(cinfo, 5);    /* safety check */
+ 
+-  if (samplesperrow > MAX_ALLOC_CHUNK) {
++  if (samplesperrow == 0 || samplesperrow > MAX_ALLOC_CHUNK) {
+     /* This prevents overflow/wrap-around in round_up_pow2() if sizeofobject
+        is close to SIZE_MAX. */
+     out_of_memory(cinfo, 9);
+@@ -560,7 +560,7 @@ alloc_barray(j_common_ptr cinfo, int pool_id, JDIMENSION blocksperrow,
+   long ltemp;
+ 
+   /* Make sure each row is properly aligned */
+-  if ((sizeof(JBLOCK) % ALIGN_SIZE) != 0)
++  if (blocksperrow == 0 || (sizeof(JBLOCK) % ALIGN_SIZE) != 0)
+     out_of_memory(cinfo, 6);    /* safety check */
+ 
+   /* Calculate max # of rows allowed in one allocation chunk */
+diff --git a/src/rdpng.c b/src/rdpng.c
+index 08a0e632..4f89ead7 100644
+--- a/src/rdpng.c
++++ b/src/rdpng.c
+@@ -590,6 +590,8 @@ start_input_png(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
+     if ((cinfo->in_color_space == JCS_UNKNOWN ||
+          cinfo->in_color_space == JCS_RGB) && gray)
+       cinfo->in_color_space = JCS_GRAYSCALE;
++    else if (cinfo->in_color_space == JCS_UNKNOWN)
++      cinfo->in_color_space = JCS_EXT_RGB;
+     if (cinfo->in_color_space == JCS_GRAYSCALE && !gray)
+       ERREXIT(cinfo, JERR_BAD_IN_COLORSPACE);
+ 
+-- 
+2.55.0
+

--- a/main/libjpeg-turbo/template.py
+++ b/main/libjpeg-turbo/template.py
@@ -1,6 +1,6 @@
 pkgname = "libjpeg-turbo"
-pkgver = "3.1.4.1"
-pkgrel = 0
+pkgver = "3.2.0"
+pkgrel = 1
 build_style = "cmake"
 configure_args = [
     "-DWITH_JPEG8=1",
@@ -12,7 +12,7 @@ pkgdesc = "Derivative of libjpeg which uses SIMD instructions"
 license = "IJG AND BSD-3-Clause AND Zlib"
 url = "https://libjpeg-turbo.org"
 source = f"https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/{pkgver}/libjpeg-turbo-{pkgver}.tar.gz"
-sha256 = "ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022"
+sha256 = "6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e"
 
 # tests segfault with altivec simd
 # also some floattest12 tests fail


### PR DESCRIPTION
## Description

- Update to upstream 3.2.0
- Backport fix for CVE-2026-75466

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
