### PR TITLE
user/lidm: New package

### DIFF
--- a/user/lidm/files/lidm
+++ b/user/lidm/files/lidm
@@ -1,0 +1,8 @@
+type            = process
+command         = /sbin/agetty tty7 linux-c -n -l /usr/local/bin/lidm -o 7
+restart         = true
+depends-on      = login.target
+termsignal      = HUP
+smooth-recovery = true
+inittab-id      = 7
+inittab-line    = tty7

--- a/user/lidm/template.py
+++ b/user/lidm/template.py
@@ -1,0 +1,21 @@
+pkgname = "lidm"
+pkgver = "2.0.2"
+pkgrel = 0
+build_style = "makefile"
+makedepends = [
+    "dinit-chimera",
+    "linux-headers",
+    "linux-pam-devel",
+]
+pkgdesc = "Customizable TUI display manager"
+license = "GPL-3.0-only"
+url = "https://github.com/javalsai/lidm"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "08bb013df15987b5a685c5925a41b2c9a8531e4af3c9a097c0dbb1fa8a6d8a79"
+# no test suite, files in /etc
+options = ["!check", "etcfiles"]
+
+
+def post_install(self):
+    self.install_license("LICENSE")
+    self.install_service(self.files_path / "lidm")


### PR DESCRIPTION
## Description

new package: [LiDM](https://github.com/javalsai/lidm)

LiDM is a really light unix login manager made in C, and highly customizable _sadly in /etc, figuring out /usr/share/examples/ might take some time_. Whats more important for why i want this in the repos is that the only login managers are sddm and gdm, with no option for a lighter TUI login manager, and compared to other TUI login managers (ly, lemurs, etc.) LiDM has a short dependency list, is written in a pretty standard language, and from my testing just works.

I understand if this gets turned down from the repos

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

- [x] I will take responsibility for my template and keep it up to date
