### PR TITLE
user/fonts-atkinson-hyperlegible-{next,mono}: new package

### DIFF
--- a/user/fonts-atkinson-hyperlegible-mono-otf
+++ b/user/fonts-atkinson-hyperlegible-mono-otf
@@ -1,0 +1,1 @@
+fonts-atkinson-hyperlegible-mono

--- a/user/fonts-atkinson-hyperlegible-mono-ttf
+++ b/user/fonts-atkinson-hyperlegible-mono-ttf
@@ -1,0 +1,1 @@
+fonts-atkinson-hyperlegible-mono

--- a/user/fonts-atkinson-hyperlegible-mono/template.py
+++ b/user/fonts-atkinson-hyperlegible-mono/template.py
@@ -1,0 +1,40 @@
+pkgname = "fonts-atkinson-hyperlegible-mono"
+pkgver = "20241120"
+pkgrel = 0
+pkgdesc = "New (2024) monospace sibling family to Atkinson Hyperlegible Next"
+license = "OFL-1.1"
+url = "https://www.brailleinstitute.org/freefont"
+source = "https://github.com/googlefonts/atkinson-hyperlegible-next-mono/archive/154d50362016cc3e873eb21d242cd0772384c8f9.tar.gz"
+sha256 = "d8b50ca876781ef6c2f0e1dd1a7ed6896a7f7769242e76be901b98c6d7edfafb"
+options = ["empty"]
+
+
+def install(self):
+    self.install_file(
+        "fonts/ttf/*.ttf",
+        "usr/share/fonts/atkinson-hyperlegible-mono",
+        glob=True,
+    )
+    self.install_file(
+        "fonts/otf/*.otf",
+        "usr/share/fonts/atkinson-hyperlegible-mono",
+        glob=True,
+    )
+    self.install_license("OFL.txt")
+
+
+@subpackage("fonts-atkinson-hyperlegible-mono-otf")
+def _(self):
+    self.subdesc = "OpenType"
+    self.depends = [self.parent, "!atkinson-hyperlegible-mono-ttf"]
+    self.install_if = [self.parent]
+
+    return ["usr/share/fonts/atkinson-hyperlegible-mono/*.otf"]
+
+
+@subpackage("fonts-atkinson-hyperlegible-mono-ttf")
+def _(self):
+    self.subdesc = "TrueType"
+    self.depends = [self.parent, "!fonts-atkinson-hyperlegible-mono-otf"]
+
+    return ["usr/share/fonts/atkinson-hyperlegible-mono/*.ttf"]

--- a/user/fonts-atkinson-hyperlegible-next-otf
+++ b/user/fonts-atkinson-hyperlegible-next-otf
@@ -1,0 +1,1 @@
+fonts-atkinson-hyperlegible-next

--- a/user/fonts-atkinson-hyperlegible-next-ttf
+++ b/user/fonts-atkinson-hyperlegible-next-ttf
@@ -1,0 +1,1 @@
+fonts-atkinson-hyperlegible-next

--- a/user/fonts-atkinson-hyperlegible-next/template.py
+++ b/user/fonts-atkinson-hyperlegible-next/template.py
@@ -1,0 +1,40 @@
+pkgname = "fonts-atkinson-hyperlegible-next"
+pkgver = "20210430"
+pkgrel = 0
+pkgdesc = "New (2024) second version of the Atkinson Hyperlegible fonts"
+license = "OFL-1.1"
+url = "https://www.brailleinstitute.org/freefont"
+source = "https://github.com/googlefonts/atkinson-hyperlegible-next/archive/7925f50f649b3813257faf2f4c0b381011f434f1.tar.gz"
+sha256 = "4b455dcf5ce2d6261df7caf6f4d035c893b446f14269106a07bc03c204368626"
+options = ["empty"]
+
+
+def install(self):
+    self.install_file(
+        "fonts/ttf/*.ttf",
+        "usr/share/fonts/atkinson-hyperlegible-next",
+        glob=True,
+    )
+    self.install_file(
+        "fonts/otf/*.otf",
+        "usr/share/fonts/atkinson-hyperlegible-next",
+        glob=True,
+    )
+    self.install_license("OFL.txt")
+
+
+@subpackage("fonts-atkinson-hyperlegible-next-otf")
+def _(self):
+    self.subdesc = "OpenType"
+    self.depends = [self.parent, "!atkinson-hyperlegible-next-ttf"]
+    self.install_if = [self.parent]
+
+    return ["usr/share/fonts/atkinson-hyperlegible-next/*.otf"]
+
+
+@subpackage("fonts-atkinson-hyperlegible-next-ttf")
+def _(self):
+    self.subdesc = "TrueType"
+    self.depends = [self.parent, "!fonts-atkinson-hyperlegible-next-otf"]
+
+    return ["usr/share/fonts/atkinson-hyperlegible-next/*.ttf"]


### PR DESCRIPTION
## Description

Add [`Atkinson Hyperlegible Next`](https://www.brailleinstitute.org/freefont) and `Atkinson Hyperlegible Mono`, a typeface focusing on letterform distinction for legibility for low vision readers, as well as its monospace verison.



## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [x] I will take responsibility for my template and keep it up to date
