### PR TITLE
user/emmylua-analyzer-rust: leverage cargo install

### DIFF
--- a/user/emmylua-analyzer-rust/template.py
+++ b/user/emmylua-analyzer-rust/template.py
@@ -1,6 +1,6 @@
 pkgname = "emmylua-analyzer-rust"
 pkgver = "0.25.1"
-pkgrel = 0
+pkgrel = 1
 build_style = "cargo"
 hostmakedepends = ["cargo-auditable", "openssl3-devel", "pkgconf"]
 makedepends = ["rust-std"]
@@ -22,11 +22,12 @@ if self.profile().arch in ["loongarch64", "ppc64le"]:
 
 
 def install(self):
-    self.install_bin(f"target/{self.profile().triplet}/release/emmylua_ls")
-    self.install_bin(f"target/{self.profile().triplet}/release/luafmt")
-    self.install_bin(f"target/{self.profile().triplet}/release/emmylua_check")
-    self.install_bin(f"target/{self.profile().triplet}/release/emmylua_doc_cli")
-    self.install_bin(
-        f"target/{self.profile().triplet}/release/schema_to_emmylua"
-    )
+    self.cargo.install(wrksrc="crates/emmylua_ls")
+    self.cargo.install(wrksrc="crates/emmylua_formatter")
+    self.cargo.install(wrksrc="crates/emmylua_check")
+    self.cargo.install(wrksrc="crates/emmylua_doc_cli")
+    self.cargo.install(wrksrc="crates/schema_to_emmylua")
+
+
+def post_install(self):
     self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This updates the `emmylua-analyzer-rust` template to use `self.cargo.install` with different `wrksrc`es instead of directly installing binaries from the `target` directory, which I feel is a cleaner and more correct approach.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [x] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [x] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [x] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [x] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [x] I have built and tested my changes on my machine
