### PR TITLE
user/dnsproxy: update to 0.84.2

### DIFF
--- a/user/dnsproxy/template.py
+++ b/user/dnsproxy/template.py
@@ -1,5 +1,5 @@
 pkgname = "dnsproxy"
-pkgver = "0.83.0"
+pkgver = "0.84.2"
 pkgrel = 1
 build_style = "go"
 hostmakedepends = ["go"]
@@ -8,7 +8,7 @@ pkgdesc = "DNS proxy server"
 license = "Apache-2.0"
 url = "https://github.com/AdguardTeam/dnsproxy"
 source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
-sha256 = "53a586f02ca9c5e3e39ccf70c8e8dade7302b3b17800ade171357dc08fc4e89c"
+sha256 = "a7a6fe89dd1ec34e94fecf78a980696ae1b5f95424e2b9cf62602bf8fee89a2d"
 # uses network
 options = ["etcfiles", "!check"]
 


### PR DESCRIPTION
## Description

From the dnsproxy release:
Changed:
  - The version of Go updated to 1.26.8. Fixed:
  - DoQ 0-RTT opcode handling.
  
## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
