### PR TITLE
user/nnd: new package

### DIFF
--- a/user/nnd/template.py
+++ b/user/nnd/template.py
@@ -1,0 +1,16 @@
+pkgname = "nnd"
+pkgver = "0.80"
+pkgrel = 0
+archs = ["x86_64"]
+build_style = "cargo"
+hostmakedepends = ["cargo"]
+makedepends = []
+pkgdesc = "TUI-Debugger for linux"
+license = "Apache-2.0"
+url = "https://github.com/al13n321/nnd"
+source = f"{url}/archive/refs/tags/v{pkgver}.tar.gz"
+sha256 = "034e06697f06a7507f22e0433d55a8e687c9028bb229efc2c32f3f36c5925eae"
+
+
+def post_install(self):
+    self.install_license("LICENSE")


### PR DESCRIPTION
## Description

This adds the [nnd](https://github.com/al13n321/nnd) debugger.
nnd is a debugger for Linux. Partially inspired by RemedyBG. It is fast, runs as a TUI and is not based on lldb or gdb, but mostly developed from scatch.

## Checklist

Before this pull request is reviewed, certain conditions must be met.

The following must be true for all changes:

- [X] I have read [CONTRIBUTING.md](https://github.com/chimera-linux/cports/blob/master/CONTRIBUTING.md)
- [X] I acknowledge that overtly not following the above or the below will result in my pull request getting closed
- [X] I acknowledge https://gts.chimera-linux.org/@chimera/statuses/01KWARHE1BXBMXB8WPXK0BBM1B (temporary)

The following must be true for template/package changes:

- [X] I have read [Packaging.md](https://github.com/chimera-linux/cports/blob/master/Packaging.md#quality_requirements)
- [X] I have built and tested my changes on my machine

The following must be true for new package submissions:

- [X] I will take responsibility for my template and keep it up to date
